### PR TITLE
fix: prevent race condition in submodule update workflow

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -11,6 +11,10 @@ on:
       - backend-update
       - admin-frontend-update
 
+concurrency:
+  group: update-submodules
+  cancel-in-progress: false
+
 jobs:
 #──────────────────────── A. подтягиваем конкретный сабмодуль (repo-dispatch) ────────────────────────
   update-submodule:
@@ -44,7 +48,11 @@ jobs:
             echo "No changes"
           else
             git commit -m "chore: update ${{ steps.vars.outputs.target }} submodule to latest commit [skip ci]"
-            git push
+            for i in 1 2 3; do
+              git push && break
+              echo "Push failed (attempt $i), pulling and retrying..."
+              git pull --rebase
+            done
           fi
 
 #──────────────────────── B1. деплой (repository_dispatch → dev-стек) ───────────────────────────────


### PR DESCRIPTION
## Summary
- Add `concurrency` group to serialize simultaneous submodule update workflows instead of running them in parallel
- Add retry loop (up to 3 attempts) with `git pull --rebase` before `git push` as a safety net

## Problem
When multiple submodules dispatch updates at the same time (e.g. admin + backend + platform + landing), each triggers a separate workflow run. They all checkout master, update their submodule, and try to push. The first one succeeds, but the rest fail with:
```
! [rejected] master -> master (fetch first)
error: failed to push some refs
```

This has been happening consistently — 5 out of 15 recent runs failed for this reason.

## Test plan
- [ ] Trigger two submodule updates simultaneously and verify both succeed
- [ ] Verify deploy job still runs after successful push

🤖 Generated with [Claude Code](https://claude.com/claude-code)