### PR TITLE
fix: responsive polish — кнопки, фильтры, календарь

### DIFF
--- a/platform-frontend/src/components/common/Breadcrumbs.vue
+++ b/platform-frontend/src/components/common/Breadcrumbs.vue
@@ -35,7 +35,7 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
   <nav
     v-if="breadcrumbs.length > 0"
     aria-label="Навигация"
-    class="flex items-center gap-1.5 text-xs text-muted-foreground px-3 pt-3"
+    class="flex items-center gap-1.5 text-xs text-muted-foreground px-4 pt-3"
   >
     <button
       class="flex items-center hover:text-foreground transition-colors"

--- a/platform-frontend/src/components/events/CalendarView.vue
+++ b/platform-frontend/src/components/events/CalendarView.vue
@@ -219,7 +219,7 @@ function goToToday() {
       <button
         v-for="(day, index) in calendarDays"
         :key="index"
-        class="relative bg-card p-2 min-h-[3.5rem] text-center transition-colors hover:bg-muted/50"
+        class="relative bg-card p-1.5 sm:p-2 min-h-[2.5rem] sm:min-h-[3.5rem] text-center transition-colors hover:bg-muted/50"
         :class="{
           'opacity-40': !day.isCurrentMonth,
           'ring-2 ring-primary ring-inset': selectedDate === day.dateKey,

--- a/platform-frontend/src/components/events/EventCard.vue
+++ b/platform-frontend/src/components/events/EventCard.vue
@@ -282,7 +282,7 @@ const { openInGoogleCalendar } = useGoogleCalendar()
         ]"
       >
         <div class="overflow-hidden">
-          <div class="mt-1 space-y-1 text-muted-foreground text-sm">
+          <div class="mt-1 space-y-1 text-muted-foreground text-sm break-words">
             <span>{{ event.members.map(member => `${member.firstName} ${member.lastName}`).join(', ') }}</span>
           </div>
         </div>

--- a/platform-frontend/src/pages/Kudos.vue
+++ b/platform-frontend/src/pages/Kudos.vue
@@ -128,11 +128,11 @@ onMounted(() => {
         Стена благодарностей
       </Typography>
       <button
-        class="flex items-center gap-2 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+        class="flex items-center gap-2 px-3 sm:px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors shrink-0"
         @click="openDialog"
       >
         <Send class="h-4 w-4" />
-        Поблагодарить
+        <span class="hidden sm:inline">Поблагодарить</span>
       </button>
     </div>
 

--- a/platform-frontend/src/pages/Marketplace.vue
+++ b/platform-frontend/src/pages/Marketplace.vue
@@ -277,11 +277,11 @@ onMounted(() => {
         Барахолка
       </Typography>
       <button
-        class="flex items-center gap-2 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+        class="flex items-center gap-2 px-3 sm:px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors shrink-0"
         @click="showCreateDialog = true"
       >
         <Plus class="h-4 w-4" />
-        Новое объявление
+        <span class="hidden sm:inline">Новое объявление</span>
       </button>
     </div>
 

--- a/platform-frontend/src/pages/Mentors.vue
+++ b/platform-frontend/src/pages/Mentors.vue
@@ -107,10 +107,10 @@ onMounted(loadMentors)
         <Input
           v-model="searchQuery"
           placeholder="Поиск по имени..."
-          class="max-w-xs"
+          class="w-full sm:max-w-xs"
         />
-        <Select v-model="selectedTag" class="max-w-xs">
-          <SelectTrigger class="max-w-xs">
+        <Select v-model="selectedTag" class="w-full sm:max-w-xs">
+          <SelectTrigger class="w-full sm:max-w-xs">
             <SelectValue placeholder="Все теги" />
           </SelectTrigger>
           <SelectContent>

--- a/platform-frontend/src/pages/Raffles.vue
+++ b/platform-frontend/src/pages/Raffles.vue
@@ -150,8 +150,8 @@ onMounted(() => {
             class="rounded-2xl border bg-card border-border p-5"
           >
             <div class="flex items-start justify-between mb-3">
-              <div>
-                <h3 class="font-semibold">
+              <div class="min-w-0">
+                <h3 class="font-semibold break-words">
                   {{ raffle.title }}
                 </h3>
                 <p
@@ -164,7 +164,7 @@ onMounted(() => {
               <Gift class="h-5 w-5 text-primary shrink-0" />
             </div>
 
-            <div class="flex items-center gap-4 text-sm mb-3">
+            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm mb-3">
               <div>
                 <span class="text-muted-foreground">Приз:</span>
                 <span class="font-medium ml-1">{{ raffle.prize }}</span>

--- a/platform-frontend/src/pages/TaskExchange.vue
+++ b/platform-frontend/src/pages/TaskExchange.vue
@@ -374,11 +374,11 @@ watch(showEditDialog, (open) => {
         Биржа заданий
       </Typography>
       <button
-        class="flex items-center gap-2 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+        class="flex items-center gap-2 px-3 sm:px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors shrink-0"
         @click="showCreateDialog = true"
       >
         <Plus class="h-4 w-4" />
-        Предложить задание
+        <span class="hidden sm:inline">Предложить задание</span>
       </button>
     </div>
 


### PR DESCRIPTION
## Summary
- Кнопки в хедерах скрывают текст на мобилке (только иконка)
- Фильтры менторов full-width на мобилке
- Календарь: компактные ячейки на мобилке
- Raffles: flex-wrap + break-words для длинного контента
- EventCard: break-words на списке участников
- Breadcrumbs: выровнены с page content (px-4)

## Test plan
- [ ] Мобилка: кнопки не обрезаются, иконки видны
- [ ] Календарь: компактный на мобилке, нормальный на десктопе
- [ ] Lint/build/tests проходят