### PR TITLE
test: тесты для локальных UI компонентов

### DIFF
--- a/admin-frontend/src/__tests__/components/UiComponents.test.ts
+++ b/admin-frontend/src/__tests__/components/UiComponents.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Typography from '@/components/ui/typography/Typography.vue'
+import Tag from '@/components/ui/tag/Tag.vue'
+
+describe('Typography', () => {
+  it('renders as <span> with body-m classes by default', () => {
+    const wrapper = mount(Typography, {
+      slots: { default: 'Hello' },
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.classes()).toContain('text-base')
+  })
+
+  it('renders correct tag with `as` prop', () => {
+    const wrapper = mount(Typography, {
+      props: { as: 'h1' },
+      slots: { default: 'Title' },
+    })
+    expect(wrapper.element.tagName).toBe('H1')
+  })
+
+  it('applies variant classes for h2', () => {
+    const wrapper = mount(Typography, {
+      props: { variant: 'h2' },
+      slots: { default: 'Heading' },
+    })
+    expect(wrapper.classes()).toContain('text-2xl')
+    expect(wrapper.classes()).toContain('font-bold')
+    expect(wrapper.classes()).toContain('uppercase')
+  })
+
+  it('applies variant classes for h3', () => {
+    const wrapper = mount(Typography, {
+      props: { variant: 'h3' },
+      slots: { default: 'Heading' },
+    })
+    expect(wrapper.classes()).toContain('text-lg')
+    expect(wrapper.classes()).toContain('font-semibold')
+  })
+
+  it('applies variant classes for h4', () => {
+    const wrapper = mount(Typography, {
+      props: { variant: 'h4' },
+      slots: { default: 'Heading' },
+    })
+    expect(wrapper.classes()).toContain('text-base')
+    expect(wrapper.classes()).toContain('font-semibold')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mount(Typography, {
+      slots: { default: 'Slot content here' },
+    })
+    expect(wrapper.text()).toBe('Slot content here')
+  })
+
+  it('passes through class prop', () => {
+    const wrapper = mount(Typography, {
+      props: { class: 'custom-class' },
+      slots: { default: 'Text' },
+    })
+    expect(wrapper.classes()).toContain('custom-class')
+    // Should also retain variant classes
+    expect(wrapper.classes()).toContain('text-base')
+  })
+})
+
+describe('Tag', () => {
+  it('renders with default variant styling', () => {
+    const wrapper = mount(Tag, {
+      slots: { default: 'Tag text' },
+    })
+    expect(wrapper.classes()).toContain('border-border')
+    expect(wrapper.classes()).toContain('text-foreground')
+    expect(wrapper.classes()).not.toContain('border-accent/30')
+  })
+
+  it('renders with active variant styling', () => {
+    const wrapper = mount(Tag, {
+      props: { variant: 'active' },
+      slots: { default: 'Active tag' },
+    })
+    expect(wrapper.classes()).toContain('border-accent/30')
+    expect(wrapper.classes()).toContain('text-accent')
+    expect(wrapper.classes()).not.toContain('border-border')
+  })
+
+  it('renders disabled state with opacity-50', () => {
+    const wrapper = mount(Tag, {
+      props: { disabled: true },
+      slots: { default: 'Disabled' },
+    })
+    expect(wrapper.classes()).toContain('opacity-50')
+    expect(wrapper.classes()).toContain('pointer-events-none')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mount(Tag, {
+      slots: { default: 'My tag' },
+    })
+    expect(wrapper.text()).toBe('My tag')
+  })
+
+  it('renders as custom element with `as` prop', () => {
+    const wrapper = mount(Tag, {
+      props: { as: 'button' },
+      slots: { default: 'Button tag' },
+    })
+    expect(wrapper.element.tagName).toBe('BUTTON')
+  })
+})

--- a/landing-frontend/src/__tests__/UiComponents.test.ts
+++ b/landing-frontend/src/__tests__/UiComponents.test.ts
@@ -1,0 +1,201 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import UiAccordion from '@/components/ui/UiAccordion.vue'
+import UiButton from '@/components/ui/UiButton.vue'
+import UiTag from '@/components/ui/UiTag.vue'
+import UiTypography from '@/components/ui/UiTypography.vue'
+
+describe('uiTypography', () => {
+  it('renders as <p> by default', () => {
+    const wrapper = mount(UiTypography, { slots: { default: 'Hello' } })
+    expect(wrapper.element.tagName).toBe('P')
+  })
+
+  it('renders correct tag with `as` prop', () => {
+    const wrapper = mount(UiTypography, {
+      props: { as: 'span' },
+      slots: { default: 'Text' },
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('applies variant class h1', () => {
+    const wrapper = mount(UiTypography, {
+      props: { variant: 'h1' },
+      slots: { default: 'Heading' },
+    })
+    expect(wrapper.classes()).toContain('h1')
+  })
+
+  it('applies variant class h2', () => {
+    const wrapper = mount(UiTypography, {
+      props: { variant: 'h2' },
+      slots: { default: 'Heading' },
+    })
+    expect(wrapper.classes()).toContain('h2')
+  })
+
+  it('applies variant class body-m', () => {
+    const wrapper = mount(UiTypography, {
+      props: { variant: 'body-m' },
+      slots: { default: 'Body' },
+    })
+    expect(wrapper.classes()).toContain('body-m')
+  })
+
+  it('defaults to body-l variant class', () => {
+    const wrapper = mount(UiTypography, { slots: { default: 'Text' } })
+    expect(wrapper.classes()).toContain('body-l')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mount(UiTypography, {
+      slots: { default: '<em>rich</em> text' },
+    })
+    expect(wrapper.text()).toContain('rich text')
+    expect(wrapper.find('em').exists()).toBe(true)
+  })
+})
+
+describe('uiButton', () => {
+  it('renders as <button> by default with filled variant', () => {
+    const wrapper = mount(UiButton, { slots: { default: 'Click' } })
+    expect(wrapper.element.tagName).toBe('BUTTON')
+    expect(wrapper.classes()).toContain('filled')
+  })
+
+  it('renders disabled state', () => {
+    const wrapper = mount(UiButton, {
+      props: { disabled: true },
+      slots: { default: 'Disabled' },
+    })
+    expect(wrapper.classes()).toContain('disabled')
+    expect(wrapper.attributes('disabled')).toBeDefined()
+  })
+
+  it('renders stroke variant', () => {
+    const wrapper = mount(UiButton, {
+      props: { variant: 'stroke' },
+      slots: { default: 'Stroke' },
+    })
+    expect(wrapper.classes()).toContain('stroke')
+    expect(wrapper.classes()).not.toContain('filled')
+  })
+
+  it('renders dark-filled variant', () => {
+    const wrapper = mount(UiButton, {
+      props: { variant: 'dark-filled' },
+      slots: { default: 'Dark' },
+    })
+    expect(wrapper.classes()).toContain('dark-filled')
+  })
+
+  it('renders as anchor when as="a"', () => {
+    const wrapper = mount(UiButton, {
+      props: { as: 'a' },
+      slots: { default: 'Link' },
+    })
+    expect(wrapper.element.tagName).toBe('A')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mount(UiButton, {
+      slots: { default: 'Submit' },
+    })
+    expect(wrapper.text()).toBe('Submit')
+  })
+})
+
+describe('uiTag', () => {
+  it('renders with default variant', () => {
+    const wrapper = mount(UiTag, { slots: { default: 'Vue' } })
+    expect(wrapper.classes()).toContain('default')
+    expect(wrapper.element.tagName).toBe('BUTTON')
+  })
+
+  it('renders with active variant', () => {
+    const wrapper = mount(UiTag, {
+      props: { variant: 'active' },
+      slots: { default: 'Active' },
+    })
+    expect(wrapper.classes()).toContain('active')
+    expect(wrapper.classes()).not.toContain('default')
+  })
+
+  it('renders disabled state', () => {
+    const wrapper = mount(UiTag, {
+      props: { disabled: true },
+      slots: { default: 'Disabled' },
+    })
+    expect(wrapper.classes()).toContain('disabled')
+    expect(wrapper.attributes('disabled')).toBeDefined()
+    expect(wrapper.attributes('aria-disabled')).toBe('true')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mount(UiTag, {
+      slots: { default: 'TypeScript' },
+    })
+    expect(wrapper.text()).toBe('TypeScript')
+  })
+})
+
+describe('uiAccordion', () => {
+  it('renders with title', () => {
+    const wrapper = mount(UiAccordion, {
+      props: { title: 'FAQ Question' },
+    })
+    expect(wrapper.text()).toContain('FAQ Question')
+  })
+
+  it('starts closed (content wrapper collapsed)', () => {
+    const wrapper = mount(UiAccordion, {
+      props: { title: 'Question' },
+      slots: { default: 'Answer' },
+    })
+    const contentWrapper = wrapper.find('.accordion-wrapper')
+    expect(contentWrapper.classes()).not.toContain('accordion-wrapper--open')
+    expect(wrapper.classes()).not.toContain('open')
+  })
+
+  it('toggles open on click', async () => {
+    const wrapper = mount(UiAccordion, {
+      props: { title: 'Question' },
+      slots: { default: 'Answer text' },
+    })
+
+    await wrapper.find('.accordion').trigger('click')
+
+    expect(wrapper.find('.accordion-wrapper').classes()).toContain('accordion-wrapper--open')
+    expect(wrapper.classes()).toContain('open')
+
+    // Click again to close
+    await wrapper.find('.accordion').trigger('click')
+
+    expect(wrapper.find('.accordion-wrapper').classes()).not.toContain('accordion-wrapper--open')
+    expect(wrapper.classes()).not.toContain('open')
+  })
+
+  it('shows plus icon when closed and cross icon when open', async () => {
+    const wrapper = mount(UiAccordion, {
+      props: { title: 'Question' },
+    })
+
+    // Closed: plus icon (path with "M20 5v30M35 20H5")
+    let paths = wrapper.findAll('path')
+    expect(paths.some(p => p.attributes('d')?.includes('M20 5v30'))).toBe(true)
+
+    await wrapper.find('.accordion').trigger('click')
+
+    // Open: cross icon (path with "31 9 9 31")
+    paths = wrapper.findAll('path')
+    expect(paths.some(p => p.attributes('d')?.includes('31 9 9 31'))).toBe(true)
+  })
+
+  it('renders content prop as fallback', () => {
+    const wrapper = mount(UiAccordion, {
+      props: { title: 'Q', content: 'Fallback answer' },
+    })
+    expect(wrapper.text()).toContain('Fallback answer')
+  })
+})

--- a/platform-frontend/src/__tests__/components/Typography.test.ts
+++ b/platform-frontend/src/__tests__/components/Typography.test.ts
@@ -1,0 +1,77 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Typography from '@/components/ui/typography/Typography.vue'
+
+describe('Typography', () => {
+  it('renders as <span> with body-m classes by default', () => {
+    const wrapper = mount(Typography)
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.classes()).toContain('text-base')
+  })
+
+  it('renders correct HTML tag when as prop is set', () => {
+    const wrapper = mount(Typography, { props: { as: 'h1' } })
+    expect(wrapper.element.tagName).toBe('H1')
+  })
+
+  it('applies correct classes for h1 variant', () => {
+    const wrapper = mount(Typography, { props: { variant: 'h1' } })
+    expect(wrapper.classes()).toContain('text-3xl')
+    expect(wrapper.classes()).toContain('font-bold')
+    expect(wrapper.classes()).toContain('tracking-tight')
+    expect(wrapper.classes()).toContain('uppercase')
+  })
+
+  it('applies correct classes for h2 variant', () => {
+    const wrapper = mount(Typography, { props: { variant: 'h2' } })
+    expect(wrapper.classes()).toContain('text-2xl')
+    expect(wrapper.classes()).toContain('font-bold')
+    expect(wrapper.classes()).toContain('uppercase')
+  })
+
+  it('applies correct classes for h3 variant', () => {
+    const wrapper = mount(Typography, { props: { variant: 'h3' } })
+    expect(wrapper.classes()).toContain('text-lg')
+    expect(wrapper.classes()).toContain('font-semibold')
+  })
+
+  it('applies correct classes for h4 variant', () => {
+    const wrapper = mount(Typography, { props: { variant: 'h4' } })
+    expect(wrapper.classes()).toContain('text-base')
+    expect(wrapper.classes()).toContain('font-semibold')
+  })
+
+  it('applies correct classes for body-m variant', () => {
+    const wrapper = mount(Typography, { props: { variant: 'body-m' } })
+    expect(wrapper.classes()).toContain('text-base')
+  })
+
+  it('applies correct classes for date variant', () => {
+    const wrapper = mount(Typography, { props: { variant: 'date' } })
+    expect(wrapper.classes()).toContain('text-sm')
+    expect(wrapper.classes()).toContain('text-muted-foreground')
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mount(Typography, {
+      slots: { default: 'Hello World' },
+    })
+    expect(wrapper.text()).toBe('Hello World')
+  })
+
+  it('passes through additional class prop', () => {
+    const wrapper = mount(Typography, {
+      props: { class: 'mt-4' },
+    })
+    expect(wrapper.classes()).toContain('mt-4')
+  })
+
+  it('combines variant classes with custom class', () => {
+    const wrapper = mount(Typography, {
+      props: { variant: 'h1', class: 'text-red-500' },
+    })
+    expect(wrapper.classes()).toContain('text-3xl')
+    expect(wrapper.classes()).toContain('font-bold')
+    expect(wrapper.classes()).toContain('text-red-500')
+  })
+})


### PR DESCRIPTION
## Summary
Добавлены unit-тесты для локальных UI компонентов, которые заменили itx-ui-kit:
- platform: Typography (11 тестов)
- landing: UiTypography, UiButton, UiTag, UiAccordion (22 теста)
- admin: Typography, Tag (12 тестов)

## Test plan
- [x] platform: 682 assertions passed
- [x] landing: 42 assertions passed
- [x] admin: 452 assertions passed