### PR TITLE
fix: аватары на лендинге — S3 вместо t.me CDN

### DIFF
--- a/landing-frontend/src/components/ui/MentorsCard.vue
+++ b/landing-frontend/src/components/ui/MentorsCard.vue
@@ -31,6 +31,7 @@ export interface Mentor {
   lastName: string
   occupation: string
   experience: string
+  avatarUrl?: string
   profTags: { id: number, title: string }[]
   contacts: Contact[]
   services: { id: number, name: string, price: number }[]

--- a/landing-frontend/src/components/ui/TgImage.vue
+++ b/landing-frontend/src/components/ui/TgImage.vue
@@ -1,42 +1,33 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import AvatarPlaceholderIcon from '@/components/ui/AvatarPlaceholderIcon.vue'
 
-defineProps<{ username: string }>()
+const props = defineProps<{
+  username: string
+  avatarUrl?: string
+}>()
 
-const imgRef = ref()
 const isError = ref(false)
+
+const imgSrc = computed(() => {
+  if (props.avatarUrl)
+    return props.avatarUrl
+  return `https://t.me/i/userpic/160/${props.username}.jpg`
+})
+
 function handleLoad(event: Event) {
   if ((event.target as HTMLImageElement).naturalWidth <= 1) {
     isError.value = true
   }
 }
-
-function handleError() {
-  isError.value = true
-}
-
-onMounted(() => {
-  if (imgRef.value) {
-    imgRef.value.addEventListener('load', handleLoad)
-    imgRef.value.addEventListener('error', handleError)
-  }
-})
-
-onUnmounted(() => {
-  if (imgRef.value) {
-    imgRef.value.removeEventListener('load', handleLoad)
-    imgRef.value.removeEventListener('error', handleError)
-  }
-})
 </script>
 
 <template>
   <img
     v-if="!isError"
-    ref="imgRef"
-    :src="`https://t.me/i/userpic/160/${username}.jpg`"
+    :src="imgSrc"
     :alt="`Аватар ${username}`"
+    @load="handleLoad"
     @error="isError = true"
   >
   <AvatarPlaceholderIcon

--- a/landing-frontend/src/sections/CalendarSection.vue
+++ b/landing-frontend/src/sections/CalendarSection.vue
@@ -180,6 +180,7 @@ onMounted(loadEvents)
               >
                 <TgImage
                   :username="host.tg"
+                  :avatar-url="host.avatarUrl"
                   class="rounded-full w-12 h-12 shrink-0"
                   width="48"
                   height="48"

--- a/landing-frontend/src/sections/MentorsSection.vue
+++ b/landing-frontend/src/sections/MentorsSection.vue
@@ -111,7 +111,7 @@ function getBestContactLink(contacts: Mentor['contacts']): string {
 const displayedMentors = computed(() =>
   filteredMentors.value.slice(0, visibleCount.value).map((mentor: Mentor) => ({
     id: mentor.id,
-    avatar: `https://t.me/i/userpic/160/${mentor.tg}.jpg`,
+    avatar: mentor.avatarUrl || `https://t.me/i/userpic/160/${mentor.tg}.jpg`,
     name: `${mentor.firstName} ${mentor.lastName}`,
     position: mentor.occupation,
     description: mentor.experience,

--- a/landing-frontend/src/services/auth.ts
+++ b/landing-frontend/src/services/auth.ts
@@ -8,6 +8,7 @@ export interface TelegramUser {
   tg: string
   firstName: string
   lastName: string
+  avatarUrl?: string
 }
 
 export const authService = {


### PR DESCRIPTION
## Summary
t.me заблокирован из РФ → аватары менторов и спикеров не грузились.
TgImage теперь принимает avatarUrl из API (S3) с fallback на t.me CDN.

## Test plan
- [ ] Аватары спикеров видны на лендинге
- [ ] Аватары менторов видны
- [ ] Fallback placeholder работает если нет ни S3 ни t.me