### PR TITLE
feat(landing): terminal/brutalist редизайн

### DIFF
--- a/landing-frontend/index.html
+++ b/landing-frontend/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
     
     <title>IT-ХОЗЯЕВА — IT-сообщество с AI, менторством и вайбкодингом</title>
     <meta name="description" content="IT-ХОЗЯЕВА — IT-сообщество 250+ специалистов на стыке технологий и AI. Менторство, вайбкодинг, нетворкинг, собеседования. От junior до lead. Подписка от 520 ₽/мес.">

--- a/landing-frontend/src/assets/base.css
+++ b/landing-frontend/src/assets/base.css
@@ -69,12 +69,169 @@
   }
   body {
     @apply bg-background text-foreground;
+    position: relative;
+    background-image:
+      radial-gradient(1200px 600px at 85% -10%, hsl(151 60% 54% / 0.08), transparent 60%),
+      radial-gradient(900px 500px at 10% 20%, hsl(39 100% 64% / 0.05), transparent 70%),
+      linear-gradient(to right, hsl(151 5% 18% / 0.25) 1px, transparent 1px),
+      linear-gradient(to bottom, hsl(151 5% 18% / 0.25) 1px, transparent 1px);
+    background-size: auto, auto, 64px 64px, 64px 64px;
+    background-attachment: fixed, fixed, fixed, fixed;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+    background-image: repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 2px,
+      hsl(0 0% 100% / 0.012) 2px,
+      hsl(0 0% 100% / 0.012) 3px
+    );
+    mix-blend-mode: overlay;
   }
 }
 
 html {
   scroll-behavior: smooth;
 }
+
+/* ===== Terminal / brutalist utilities ===== */
+.font-mono-ui {
+  font-family: var(--font-mono);
+  font-feature-settings: 'ss01', 'cv11';
+}
+
+.terminal-label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--accent));
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.terminal-label::before {
+  content: '//';
+  opacity: 0.5;
+}
+
+.terminal-prompt {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  color: hsl(var(--accent));
+}
+
+.terminal-prompt::before {
+  content: '~/it-hozyaeva $ ';
+  color: color-mix(in oklab, hsl(var(--accent)) 70%, white);
+  opacity: 0.65;
+}
+
+.term-caret {
+  display: inline-block;
+  width: 0.6ch;
+  height: 1em;
+  background: currentColor;
+  margin-left: 2px;
+  vertical-align: -2px;
+  animation: term-blink 1.1s steps(1) infinite;
+}
+
+@keyframes term-blink {
+  50% { opacity: 0; }
+}
+
+.sharp-card {
+  position: relative;
+  background:
+    linear-gradient(180deg, hsl(151 5% 10% / 0.9), hsl(151 5% 7% / 0.9));
+  border: 1px solid hsl(151 5% 20%);
+  border-radius: 2px;
+  transition: border-color 250ms ease, transform 250ms ease, box-shadow 250ms ease;
+}
+
+.sharp-card::before,
+.sharp-card::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-color: hsl(var(--accent));
+  pointer-events: none;
+  opacity: 0.85;
+}
+.sharp-card::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+.sharp-card::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+}
+
+.sharp-card:hover {
+  border-color: hsl(var(--accent) / 0.6);
+  box-shadow:
+    0 0 0 1px hsl(var(--accent) / 0.15),
+    0 20px 60px -30px hsl(var(--accent) / 0.35);
+}
+
+.scanlines-overlay {
+  position: relative;
+}
+.scanlines-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 3px,
+    hsl(0 0% 0% / 0.25) 3px,
+    hsl(0 0% 0% / 0.25) 4px
+  );
+  border-radius: inherit;
+}
+
+.noise-bg {
+  position: relative;
+  isolation: isolate;
+}
+.noise-bg::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/></svg>");
+  opacity: 0.06;
+  mix-blend-mode: overlay;
+}
+
+.ascii-divider {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: hsl(var(--accent) / 0.4);
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* ensure header/content stay above the scanline overlay */
+header, main, footer, section { position: relative; z-index: 2; }
 
 [id] {
     scroll-margin-top: var(--header-height);

--- a/landing-frontend/src/assets/uikit.css
+++ b/landing-frontend/src/assets/uikit.css
@@ -35,8 +35,14 @@
   --transition-popover: 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 
   /* Fonts */
-  --font-unbounded: 'Unbounded', sans-serif;
+  --font-unbounded: 'Unbounded', 'Space Grotesk', sans-serif;
   --font-inter: 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'Menlo', monospace;
+
+  /* Terminal accent */
+  --color-terminal-amber: #ffb547;
+  --color-terminal-magenta: #ff4d8b;
+  --color-terminal-cyan: #5eead4;
 
   /* Typography: h1 */
   --h1-font: var(--font-unbounded);

--- a/landing-frontend/src/components/Footer.vue
+++ b/landing-frontend/src/components/Footer.vue
@@ -3,7 +3,6 @@ import type { TelegramUser } from '@/services/auth.ts'
 import { useYandexMetrika } from 'yandex-metrika-vue3'
 import TelegramAuth from '@/components/TelegramAuth.vue'
 import Button from '@/components/ui/UiButton.vue'
-import Typography from '@/components/ui/UiTypography.vue'
 import { useToken } from '@/composables/useToken.ts'
 import { useUser } from '@/composables/useUser.ts'
 
@@ -32,67 +31,97 @@ function trackJointimerClick() {
 </script>
 
 <template>
-  <footer class="w-full md:py-0 bg-accent rounded-t-[50px]">
-    <div class="flex px-6 md:px-10 container flex-col lg:flex-row gap-8 lg:gap-9 pt-8 pb-11">
-      <div class="flex flex-col gap-5 basis-1/2">
-        <Typography
-          variant="h3"
-          as="h3"
-          class="text-2xl text-background"
-        >
-          Вступай в сообщество и становись IT-хозяином
-        </Typography>
-        <TelegramAuth
-          v-if="!tgUser"
-          variant="dark-filled"
-          @auth="setUser"
-        />
-        <Button
-          v-else
-          variant="dark-filled"
-          as="a"
-          class="block w-fit "
-          href="/platform"
-          rel="noopener noreferrer"
-          @click="trackPlatformClick"
-        >
-          Перейти в платформу
-        </Button>
-      </div>
+  <footer class="w-full mt-24 md:mt-32 relative overflow-hidden">
+    <!-- big CTA band -->
+    <div class="relative bg-accent text-[#0b0d0c]">
+      <!-- scanline overlay -->
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-0 opacity-[0.06]"
+        style="background-image: repeating-linear-gradient(to bottom, transparent 0, transparent 3px, #000 3px, #000 4px);"
+      />
 
-      <div class="flex flex-col gap-10 lg:gap-14 basis-1/2 text-background">
-        <Typography>
-          По всем вопросам:<br>
-          <Typography
+      <div class="container px-6 md:px-10 py-16 md:py-24 relative">
+        <div class="flex items-center gap-3 font-mono text-[11px] md:text-xs tracking-[0.12em] uppercase mb-6">
+          <span class="w-2 h-2 rounded-full bg-[#0b0d0c] animate-pulse" />
+          <span class="text-[#0b0d0c]">$ ./join_now --final-call</span>
+          <span class="flex-1 h-px bg-[#0b0d0c]/30" />
+          <span class="hidden sm:inline text-[#0b0d0c]/70">[06] ~/join</span>
+        </div>
+
+        <h2 class="font-display uppercase text-[38px] sm:text-[56px] md:text-[80px] lg:text-[104px] leading-[0.9] tracking-tight text-[#0b0d0c]">
+          Стань<br>
+          <span class="text-[#0b0d0c]/50">IT-хозяином</span>
+        </h2>
+
+        <div class="mt-8 md:mt-12 flex flex-col md:flex-row md:items-center gap-5 md:gap-8">
+          <TelegramAuth
+            v-if="!tgUser"
+            variant="dark-filled"
+            @auth="setUser"
+          />
+          <Button
+            v-else
+            variant="dark-filled"
             as="a"
-            variant="body-l"
-            href="https://t.me/jointimer"
-            target="_blank"
+            class="block w-fit"
+            href="/platform"
             rel="noopener noreferrer"
-            class="underline"
-            @click="trackJointimerClick"
+            @click="trackPlatformClick"
           >
-            @jointimer
-          </Typography>
-        </Typography>
-        <div class="flex flex-col gap-1 align-bottom">
-          <Typography
-            as="a"
-            variant="body-s"
-            href="/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="underline"
-          >
-            Политика обработки пользовательских данных
-          </Typography>
-          <Typography
-            as="span"
-            variant="body-s"
-            class="flex items-center"
-          >
-            ©{{ new Date().getFullYear() }}, IT-ХОЗЯЕВА. Все права защищены
-          </Typography>
+            Перейти в платформу
+          </Button>
+
+          <div class="font-mono text-xs md:text-sm text-[#0b0d0c]/70">
+            <div>
+              &gt; support:
+              <a
+                href="https://t.me/jointimer"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-[#0b0d0c] underline underline-offset-4 hover:opacity-70 transition-opacity"
+                @click="trackJointimerClick"
+              >@jointimer</a>
+            </div>
+            <div class="mt-1">
+              &gt; subscription: ~520₽/mo
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Terminal footer -->
+    <div class="bg-background border-t border-accent/15">
+      <div class="container px-6 md:px-10 py-8">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 font-mono text-[11px] md:text-xs text-foreground/50 tracking-wide">
+          <div class="flex items-center gap-4 flex-wrap">
+            <span class="text-accent">[●]</span>
+            <span>©{{ new Date().getFullYear() }} IT-ХОЗЯЕВА</span>
+            <span class="text-foreground/25">|</span>
+            <a
+              href="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:text-accent transition-colors underline underline-offset-4"
+            >
+              privacy.policy
+            </a>
+          </div>
+          <div class="flex items-center gap-4 text-foreground/35">
+            <span>build: 4.2.1</span>
+            <span class="text-foreground/20">|</span>
+            <span>region: ru-msk</span>
+            <span class="text-foreground/20">|</span>
+            <span>status: <span class="text-accent">operational</span></span>
+          </div>
+        </div>
+
+        <!-- ASCII banner -->
+        <div class="mt-6 font-mono text-[10px] leading-[1.2] text-accent/25 select-none overflow-hidden whitespace-pre hidden md:block">
+          ────────────────────────────────────────────────────────────────────────────────────────────────
+          &gt; end of transmission. stay curious. ship code. own it.
+          ────────────────────────────────────────────────────────────────────────────────────────────────
         </div>
       </div>
     </div>

--- a/landing-frontend/src/components/Header.vue
+++ b/landing-frontend/src/components/Header.vue
@@ -58,17 +58,21 @@ onUnmounted(() => {
 <template>
   <header
     class="sticky top-0 z-50 w-full transition-all duration-500"
-    :class="{ 'bg-background/0.9 backdrop-blur-[25px]': isScrolled, 'bg-transparent backdrop-blur-0': !isScrolled }"
+    :class="{ 'bg-background/80 backdrop-blur-[25px] border-b border-accent/15': isScrolled, 'bg-transparent backdrop-blur-0 border-b border-transparent': !isScrolled }"
   >
     <div class="container px-6 md:px-10 flex gap-5 h-[var(--header-height)] items-center justify-between md:justify-between">
-      <div class="flex items-center gap-4 lg:gap-16">
+      <div class="flex items-center gap-4 lg:gap-10">
         <a
           href="/"
-          class="flex items-center gap-2 font-bold text-xl"
+          class="flex items-center gap-3 font-bold text-xl group"
         >
-          <div class=" w-16  sm:w-[88px] md:w-24">
+          <div class="w-16 sm:w-[88px] md:w-24">
             <Logo />
           </div>
+          <span class="hidden md:flex items-center gap-1.5 font-mono text-[10px] text-foreground/40 uppercase tracking-widest border-l border-accent/20 pl-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-accent shadow-[0_0_6px_hsl(var(--accent))]" />
+            online
+          </span>
         </a>
         <Navigation v-if="!isMobile" />
       </div>

--- a/landing-frontend/src/components/ui/SectionHeader.vue
+++ b/landing-frontend/src/components/ui/SectionHeader.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+defineProps<{
+  index: string
+  path: string
+  title: string
+  subtitle?: string
+  accentSubtitle?: boolean
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col gap-5 md:gap-6">
+    <div class="flex items-center gap-3 md:gap-4 overflow-hidden">
+      <span class="font-mono text-[11px] md:text-xs text-accent/70 tracking-[0.15em] shrink-0">
+        [{{ index }}]
+      </span>
+      <span class="font-mono text-[11px] md:text-xs text-foreground/50 tracking-[0.08em] shrink-0">
+        {{ path }}
+      </span>
+      <span class="flex-1 h-px bg-gradient-to-r from-accent/40 via-accent/10 to-transparent" />
+      <span class="font-mono text-[11px] md:text-xs text-term-amber/80 shrink-0 hidden sm:inline">
+        ● READY
+      </span>
+    </div>
+    <h2 class="font-display text-accent text-[32px] sm:text-[44px] md:text-[56px] lg:text-[72px] leading-[0.95] tracking-tight uppercase">
+      {{ title }}
+    </h2>
+    <p
+      v-if="subtitle"
+      class="max-w-2xl text-base md:text-lg text-foreground/70 leading-relaxed"
+      :class="{ 'text-accent': accentSubtitle }"
+    >
+      {{ subtitle }}
+    </p>
+  </div>
+</template>

--- a/landing-frontend/src/components/ui/UiMentorCard.vue
+++ b/landing-frontend/src/components/ui/UiMentorCard.vue
@@ -126,15 +126,48 @@ onMounted(async () => {
 <style scoped>
 .mentor-card {
   box-sizing: border-box;
-  background-color: var(--color-green-black-600);
-  border-radius: var(--radius-card);
+  background-color: hsl(151 5% 10% / 0.85);
+  border: 1px solid hsl(151 5% 18%);
+  border-radius: 2px;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
   gap: 25px;
   width: 100%;
-  padding: 20px 23px 25px;
+  padding: 24px 24px 24px;
   display: flex;
+  position: relative;
+  transition: border-color 250ms ease, transform 250ms ease, background-color 250ms ease;
+}
+
+.mentor-card::before,
+.mentor-card::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-color: var(--color-green-700);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.mentor-card::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+.mentor-card::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+}
+.mentor-card:hover {
+  border-color: hsl(151 60% 54% / 0.5);
+  background-color: hsl(151 5% 12% / 0.95);
+}
+.mentor-card:hover::before,
+.mentor-card:hover::after {
+  opacity: 1;
 }
 
 .top-section {
@@ -148,11 +181,14 @@ onMounted(async () => {
 }
 
 .avatar {
-  border-radius: var(--radius-circle);
+  border-radius: 2px;
   flex-shrink: 0;
   width: 106px;
   height: 106px;
   overflow: hidden;
+  border: 1px solid hsl(151 5% 22%);
+  outline: 1px solid hsl(151 60% 54% / 0.2);
+  outline-offset: 3px;
 }
 
 .avatar img {

--- a/landing-frontend/src/components/ui/UiPriceCard.vue
+++ b/landing-frontend/src/components/ui/UiPriceCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
+import { Check } from 'lucide-vue-next'
 import { computed } from 'vue'
 import UiButton from './UiButton.vue'
-import UiTypography from './UiTypography.vue'
 
 const props = defineProps<{
   name: string
@@ -10,6 +10,8 @@ const props = defineProps<{
   features: string[]
   link: string
   variant?: 'default' | 'highlighted'
+  tierIndex?: string
+  tierLabel?: string
 }>()
 
 const discount = computed(() => {
@@ -25,73 +27,117 @@ const discount = computed(() => {
 
 <template>
   <div
-    class="price-card"
-    :class="variant || 'default'"
+    class="price-card group relative flex flex-col border transition-all duration-300"
+    :class="variant === 'highlighted'
+      ? 'bg-accent text-[#0b0d0c] border-accent shadow-[0_30px_80px_-30px_hsl(var(--accent)/0.5)] md:-translate-y-3'
+      : 'bg-background/80 text-foreground border-accent/20 hover:border-accent/50'"
   >
-    <div class="content">
-      <div class="header">
-        <UiTypography
-          variant="h3"
-          as="h3"
-          class="name"
-        >
-          {{ name }}
-        </UiTypography>
-        <div class="price-container">
-          <UiTypography
-            v-if="discount"
-            as="p"
-            variant="title"
-            class="discount"
-          >
-            &minus;{{ discount }}%
-          </UiTypography>
-        </div>
+    <!-- corner brackets -->
+    <span
+      class="absolute top-0 left-0 w-3 h-3 border-t-2 border-l-2"
+      :class="variant === 'highlighted' ? 'border-[#0b0d0c]' : 'border-accent'"
+    />
+    <span
+      class="absolute top-0 right-0 w-3 h-3 border-t-2 border-r-2"
+      :class="variant === 'highlighted' ? 'border-[#0b0d0c]' : 'border-accent'"
+    />
+    <span
+      class="absolute bottom-0 left-0 w-3 h-3 border-b-2 border-l-2"
+      :class="variant === 'highlighted' ? 'border-[#0b0d0c]' : 'border-accent'"
+    />
+    <span
+      class="absolute bottom-0 right-0 w-3 h-3 border-b-2 border-r-2"
+      :class="variant === 'highlighted' ? 'border-[#0b0d0c]' : 'border-accent'"
+    />
+
+    <!-- header -->
+    <div
+      class="px-6 md:px-7 pt-6 pb-5 border-b"
+      :class="variant === 'highlighted' ? 'border-[#0b0d0c]/15' : 'border-accent/15'"
+    >
+      <div
+        class="flex items-center justify-between font-mono text-[11px] tracking-[0.1em] uppercase mb-4"
+        :class="variant === 'highlighted' ? 'text-[#0b0d0c]/70' : 'text-foreground/50'"
+      >
+        <span>[ tier.{{ tierIndex }} ]</span>
+        <span
+          v-if="variant === 'highlighted'"
+          class="px-2 py-0.5 bg-[#0b0d0c] text-accent"
+        >recommended</span>
+        <span v-else-if="tierLabel">{{ tierLabel }}</span>
       </div>
-      <ul class="features-container">
-        <li
-          v-for="(feature, index) in features"
-          :key="index"
-          class="feature"
+      <h3
+        class="font-display uppercase text-2xl md:text-3xl leading-tight"
+        :class="variant === 'highlighted' ? 'text-[#0b0d0c]' : 'text-accent'"
+      >
+        {{ name }}
+      </h3>
+
+      <div class="mt-5 flex items-baseline gap-2">
+        <span
+          v-if="oldPrice"
+          class="font-mono text-sm line-through"
+          :class="variant === 'highlighted' ? 'text-[#0b0d0c]/50' : 'text-foreground/30'"
         >
-          <UiTypography variant="body-s">
-            {{ feature }}
-          </UiTypography>
-        </li>
-      </ul>
+          {{ oldPrice }}₽
+        </span>
+        <span
+          class="font-display text-4xl md:text-5xl leading-none"
+          :class="variant === 'highlighted' ? 'text-[#0b0d0c]' : 'text-foreground'"
+        >
+          {{ price }}
+        </span>
+        <span
+          class="font-display text-2xl md:text-3xl"
+          :class="variant === 'highlighted' ? 'text-[#0b0d0c]/80' : 'text-foreground/70'"
+        >
+          ₽
+        </span>
+        <span
+          class="font-mono text-xs self-end pb-1"
+          :class="variant === 'highlighted' ? 'text-[#0b0d0c]/60' : 'text-foreground/40'"
+        >
+          /мес
+        </span>
+        <span
+          v-if="discount"
+          class="ml-auto font-mono text-[11px] px-2 py-1 border tracking-wider"
+          :class="variant === 'highlighted'
+            ? 'border-[#0b0d0c] text-[#0b0d0c]'
+            : 'border-term-amber text-term-amber'"
+        >
+          −{{ discount }}%
+        </span>
+      </div>
     </div>
-    <div class="footer">
-      <div class="price-container">
-        <div class="prices">
-          <UiTypography
-            v-if="oldPrice"
-            variant="price"
-            class="old-price"
-          >
-            {{ oldPrice }}&thinsp;&#8381;
-          </UiTypography>
-          <UiTypography
-            variant="price"
-            class="price"
-          >
-            {{ price }}&thinsp;&#8381;
-          </UiTypography>
-        </div>
-        <UiTypography
-          variant="label"
-          class="period"
-        >
-          в месяц
-        </UiTypography>
-      </div>
+
+    <!-- features -->
+    <ul class="flex-1 px-6 md:px-7 py-6 space-y-3">
+      <li
+        v-for="(feature, index) in features"
+        :key="index"
+        class="flex items-start gap-3 text-sm md:text-[15px] leading-snug"
+        :class="variant === 'highlighted' ? 'text-[#0b0d0c]' : 'text-foreground/80'"
+      >
+        <Check
+          class="w-4 h-4 mt-0.5 shrink-0"
+          :class="variant === 'highlighted' ? 'text-[#0b0d0c]' : 'text-accent'"
+          stroke-width="3"
+        />
+        <span>{{ feature }}</span>
+      </li>
+    </ul>
+
+    <!-- footer -->
+    <div class="px-6 md:px-7 pb-6">
       <UiButton
         as="a"
         :href="link"
         target="_blank"
-        variant="filled"
-        class="button"
+        :variant="variant === 'highlighted' ? 'dark-filled' : 'filled'"
+        class="w-full text-center"
       >
-        Подписаться
+        Подписаться →
       </UiButton>
     </div>
   </div>
@@ -99,143 +145,12 @@ const discount = computed(() => {
 
 <style scoped>
 .price-card {
-  box-sizing: border-box;
-  border-radius: var(--radius-card);
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 32px;
-  min-width: 300px;
-  min-height: 360px;
-  padding: 28px 24px 24px;
-  display: flex;
+  border-radius: 2px;
+  min-width: 280px;
+  min-height: 480px;
 }
-
-.content {
-  text-align: center;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 24px;
-  display: flex;
-}
-
-.header {
-  text-align: center;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  display: flex;
-}
-
-.features-container {
-  text-align: start;
-  flex-direction: column;
-  align-items: start;
-  gap: 8px;
-  max-width: 400px;
-  padding-left: 20px;
-  list-style: outside;
-  display: flex;
-}
-
-.price-container {
-  flex-direction: column;
-  align-items: center;
-  display: flex;
-}
-
-.prices {
-  align-items: center;
-  gap: 6px;
-  margin: 12px 0 8px;
-  display: flex;
-}
-
-.prices .old-price {
-  text-decoration: line-through;
-}
-
-.discount {
-  border-radius: var(--radius-default);
-  border: 1px solid;
-  padding: 4px 8px;
-}
-
-.footer {
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-  display: flex;
-}
-
-.footer .button {
-  justify-content: center;
-  align-items: center;
-  width: fit-content;
-  display: flex;
-}
-
-/* Default variant */
-.price-card.default {
-  background-color: var(--color-green-black-500);
-}
-
-.price-card.default .name {
-  color: var(--color-green-700);
-}
-
-.price-card.default .discount {
-  color: var(--color-white);
-  border-color: var(--color-white);
-}
-
-.price-card.default .price {
-  color: var(--color-white);
-}
-
-.price-card.default .old-price {
-  color: var(--color-white);
-  opacity: 0.1;
-}
-
-.price-card.default .period {
-  color: var(--color-white);
-  opacity: 0.4;
-}
-
-.price-card.default .feature {
-  color: var(--color-white);
-}
-
-/* Highlighted variant */
-.price-card.highlighted {
-  background-color: var(--color-green-700);
-}
-
-.price-card.highlighted .name {
-  color: var(--color-green-black-700);
-}
-
-.price-card.highlighted .discount {
-  color: var(--color-green-black-700);
-  border-color: var(--color-green-black-700);
-}
-
-.price-card.highlighted .price {
-  color: var(--color-green-black-700);
-}
-
-.price-card.highlighted .old-price {
-  color: var(--color-green-black-700);
-  opacity: 0.3;
-}
-
-.price-card.highlighted .period {
-  color: var(--color-green-black-700);
-  opacity: 0.4;
-}
-
-.price-card.highlighted .feature {
-  color: var(--color-green-black-700);
+.price-card :deep(.ui-button) {
+  width: 100%;
+  border-radius: 2px !important;
 }
 </style>

--- a/landing-frontend/src/sections/CalendarSection.vue
+++ b/landing-frontend/src/sections/CalendarSection.vue
@@ -3,14 +3,15 @@ import type { CommunityEvent } from '@/services/events'
 import { Calendar as CalendarIcon } from 'lucide-vue-next'
 import { computed, onMounted, ref } from 'vue'
 import { useYandexMetrika } from 'yandex-metrika-vue3'
-import Card from '@/components/ui/Card.vue'
+import SectionHeader from '@/components/ui/SectionHeader.vue'
 import TgImage from '@/components/ui/TgImage.vue'
 import Button from '@/components/ui/UiButton.vue'
-import Label from '@/components/ui/UiLabel.vue'
 import Popover from '@/components/ui/UiPopover.vue'
 import Typography from '@/components/ui/UiTypography.vue'
 import { useGoogleCalendar } from '@/composables/useGoogleCalendar.ts'
 import { eventService } from '@/services/events'
+
+const SLASH_RE = /\//g
 
 const events = ref<Record<'new' | 'old', CommunityEvent[]>>({
   new: [],
@@ -19,8 +20,6 @@ const events = ref<Record<'new' | 'old', CommunityEvent[]>>({
 
 function formatEventDate(dateString: string): string {
   const utcDate = new Date(dateString)
-
-  // Конвертируем в МСК (UTC+3)
   const formatter = new Intl.DateTimeFormat('ru-RU', {
     day: 'numeric',
     month: 'long',
@@ -30,8 +29,21 @@ function formatEventDate(dateString: string): string {
     hour12: false,
     timeZone: 'Europe/Moscow',
   })
-
   return formatter.format(utcDate)
+}
+
+function formatStamp(dateString: string): string {
+  const d = new Date(dateString)
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'Europe/Moscow',
+  }).format(d)
+  return fmt.replace(',', '').replace(SLASH_RE, '-')
 }
 
 async function loadEvents() {
@@ -49,15 +61,11 @@ const { openInGoogleCalendar } = useGoogleCalendar()
 const yandexMetrika = useYandexMetrika()
 
 function handleGoogleCalendarClick(eventTitle: string) {
-  yandexMetrika.reachGoal('calendar_google_add', {
-    event: eventTitle,
-  } as any)
+  yandexMetrika.reachGoal('calendar_google_add', { event: eventTitle } as any)
 }
 
 function handleICSClick(eventTitle: string) {
-  yandexMetrika.reachGoal('calendar_ics_add', {
-    event: eventTitle,
-  } as any)
+  yandexMetrika.reachGoal('calendar_ics_add', { event: eventTitle } as any)
 }
 
 onMounted(loadEvents)
@@ -67,72 +75,60 @@ onMounted(loadEvents)
   <section
     v-if="events.new.length > 0 || events.old.length > 0"
     id="meets"
-    class="w-full py-12 md:py-18 lg:pt-20 lg:pb-14 rounded-[50px] bg-primary mt-20 lg:mt-28"
+    class="w-full pt-20 md:pt-32 lg:pt-40"
   >
     <div class="container px-6 md:px-10">
-      <div class="flex flex-col items-center justify-center space-y-4 text-center">
-        <div class="flex flex-col gap-5 items-center justify-center">
-          <Typography
-            variant="h2"
-            as="h2"
-            class="text-accent"
-          >
-            Мероприятия для участников
-          </Typography>
-          <Typography
-            variant="body-xl"
-            as="p"
-            class="max-w-[540px]"
-          >
-            Эксперты нашего сообщества, которые готовы поделиться экспертизой
-          </Typography>
-        </div>
+      <SectionHeader
+        index="03"
+        path="~/community/events.log"
+        title="Расписание"
+        subtitle="Еженедельные онлайн-встречи. Скачивай в календарь — пропустить будет нельзя."
+      />
 
-        <Typography
-          v-if="!hasFutureEvents"
-          variant="body-l"
-          as="p"
-          class="text-muted-foreground"
-        >
-          Следите за обновлениями
-        </Typography>
-      </div>
+      <Typography
+        v-if="!hasFutureEvents"
+        variant="body-l"
+        as="p"
+        class="text-muted-foreground mt-12 font-mono text-sm"
+      >
+        &gt; no scheduled events — следите за обновлениями
+      </Typography>
 
-      <div class="grid gap-3 pt-12 md:grid-cols-2 md:gap-5">
-        <Card
-          v-for="event in visibleEvents"
-          :key="event.title"
-          class="min-h-[253px]"
-        >
-          <template #header>
-            <div class="flex flex-col gap-[14px]">
-              <div class="flex items-center justify-between">
+      <div class="mt-12 md:mt-16">
+        <div class="border border-accent/20 bg-background/60 backdrop-blur-sm">
+          <!-- log header -->
+          <div class="flex items-center gap-2 px-5 py-3 border-b border-accent/20 bg-accent/5">
+            <div class="flex gap-1.5">
+              <span class="w-2.5 h-2.5 rounded-full bg-term-magenta/70" />
+              <span class="w-2.5 h-2.5 rounded-full bg-term-amber/70" />
+              <span class="w-2.5 h-2.5 rounded-full bg-accent/70" />
+            </div>
+            <span class="ml-3 font-mono text-[11px] text-foreground/50 tracking-wider">
+              tail -f /var/log/community/events.log
+            </span>
+          </div>
+
+          <!-- event entries -->
+          <ul>
+            <li
+              v-for="event in visibleEvents"
+              :key="event.title"
+              class="group relative grid grid-cols-1 md:grid-cols-[auto_1fr_auto] gap-6 md:gap-8 px-5 md:px-8 py-6 md:py-8 border-b border-accent/10 hover:bg-accent/[0.03] transition-colors last:border-b-0"
+            >
+              <!-- timestamp col -->
+              <div class="flex md:flex-col gap-3 md:gap-1 items-center md:items-start font-mono text-xs">
+                <span class="text-accent">[{{ formatStamp(event.date) }}]</span>
                 <Popover
                   :offset="12"
-                  placement="top-end"
+                  placement="top-start"
                 >
                   <template #trigger>
                     <button
                       type="button"
-                      class="flex space-x-2 items-center text-accent hover:opacity-75 transition-opacity"
+                      class="flex items-center gap-1.5 text-foreground/60 hover:text-accent transition-colors"
                     >
-                      <div class="flex flex-col">
-                        <Typography
-                          as="span"
-                          variant="date"
-                        >
-                          {{ formatEventDate(event.date) }} (МСК)
-                        </Typography>
-                        <Typography
-                          v-if="event.isRepeating && event.repeatPeriod"
-                          as="span"
-                          variant="label"
-                          class="text-xs text-muted-foreground italic"
-                        >
-                          Повторяется
-                        </Typography>
-                      </div>
-                      <CalendarIcon />
+                      <CalendarIcon class="w-3.5 h-3.5" />
+                      <span>+add</span>
                     </button>
                   </template>
                   <template #content>
@@ -156,64 +152,73 @@ onMounted(loadEvents)
                     </ul>
                   </template>
                 </Popover>
+                <span
+                  v-if="event.isRepeating && event.repeatPeriod"
+                  class="text-term-amber/80 text-[10px] uppercase tracking-wider md:mt-1"
+                >
+                  recurring
+                </span>
               </div>
-              <Typography
-                variant="h4"
-                as="h4"
-              >
-                {{ event.title }}
-              </Typography>
-              <div class="flex flex-wrap items-center gap-1">
-                <Label
-                  v-for="tag in event.eventTags"
-                  :key="tag.id"
-                >{{ tag.name }}</Label>
-              </div>
-            </div>
-          </template>
-          <template #content>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 pt-4">
-              <div
-                v-for="host in event.hosts"
-                :key="host.id"
-                class="flex items-center space-x-4 "
-              >
-                <TgImage
-                  :username="host.tg"
-                  :avatar-url="host.avatarUrl"
-                  class="rounded-full w-12 h-12 shrink-0"
-                  width="48"
-                  height="48"
-                />
-                <div>
-                  <Typography
-                    variant="name-text"
-                    as="p"
-                    class="font-semibold"
+
+              <!-- content col -->
+              <div class="flex flex-col gap-3">
+                <h3 class="font-display uppercase text-xl md:text-2xl leading-tight text-foreground group-hover:text-accent transition-colors">
+                  {{ event.title }}
+                </h3>
+                <div class="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] uppercase tracking-wider text-foreground/50">
+                  <span class="text-accent/70">// tags:</span>
+                  <span
+                    v-for="tag in event.eventTags"
+                    :key="tag.id"
+                    class="text-foreground/70"
                   >
-                    {{ host.firstName }} {{ host.lastName }}
-                  </Typography>
-                  <Typography
-                    variant="label"
-                    class="text-muted-foreground"
-                  >
-                    {{ host.tg }}
-                  </Typography>
+                    #{{ tag.name }}
+                  </span>
+                </div>
+                <div class="text-xs font-mono text-foreground/50 md:hidden">
+                  {{ formatEventDate(event.date) }} МСК
                 </div>
               </div>
-            </div>
-          </template>
-        </Card>
+
+              <!-- hosts col -->
+              <div class="flex flex-col gap-2 md:min-w-[180px]">
+                <span class="font-mono text-[10px] uppercase tracking-wider text-foreground/40">
+                  hosts
+                </span>
+                <div class="flex flex-col gap-2">
+                  <div
+                    v-for="host in event.hosts"
+                    :key="host.id"
+                    class="flex items-center gap-3"
+                  >
+                    <TgImage
+                      :username="host.tg"
+                      :avatar-url="host.avatarUrl"
+                      class="w-9 h-9 shrink-0"
+                      width="36"
+                      height="36"
+                    />
+                    <div class="flex flex-col">
+                      <span class="text-sm text-foreground">{{ host.firstName }} {{ host.lastName }}</span>
+                      <span class="font-mono text-[10px] text-foreground/50">@{{ host.tg }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
       </div>
+
+      <Button
+        v-if="events.new.length > 2"
+        variant="filled"
+        as="a"
+        href="/platform/events"
+        class="flex mx-auto mt-12"
+      >
+        Все события
+      </Button>
     </div>
-    <Button
-      v-if="events.new.length > 2"
-      variant="filled"
-      as="a"
-      href="/platform/events"
-      class="flex mx-auto mt-12"
-    >
-      Все события
-    </Button>
   </section>
 </template>

--- a/landing-frontend/src/sections/FAQSection.vue
+++ b/landing-frontend/src/sections/FAQSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import Accordion from '@/components/ui/UiAccordion.vue'
-import Typography from '@/components/ui/UiTypography.vue'
+import { ref } from 'vue'
+import SectionHeader from '@/components/ui/SectionHeader.vue'
 
 interface Question {
   title: string
@@ -25,39 +25,80 @@ const questions: Question[] = [
     answer: 'Для IT-специалистов любого грейда и направления: разработчики, AI-инженеры, тестировщики, аналитики, DevOps, менеджеры. Для тех, кто интересуется искусственным интеллектом, вайбкодингом и хочет расти через менторство и нетворкинг в IT-комьюнити. Участники из Яндекса, Тинькофф, VK — от junior до lead.',
   },
 ]
+
+const openIndex = ref<number | null>(0)
+function toggle(i: number) {
+  openIndex.value = openIndex.value === i ? null : i
+}
 </script>
 
 <template>
   <section
     id="FAQ"
-    class="w-full py-12 md:py-24 lg:py-32"
+    class="w-full py-20 md:py-32 lg:py-40"
   >
-    <div class="container px-6 md:px-10 space-y-9">
-      <div class="flex flex-col items-center justify-center space-y-4 text-center">
-        <div class="flex flex-col gap-5">
-          <Typography
-            variant="h2"
-            as="h2"
-            class="text-accent"
+    <div class="container px-6 md:px-10">
+      <SectionHeader
+        index="05"
+        path="~/community/faq.txt"
+        title="Частые вопросы"
+        subtitle="Ответы на популярные вопросы о сообществе IT-ХОЗЯЕВА."
+      />
+
+      <div class="mt-12 md:mt-16 border border-accent/20 bg-background/60 backdrop-blur-sm">
+        <div
+          v-for="(q, i) in questions"
+          :key="q.title"
+          class="border-b border-accent/15 last:border-b-0"
+        >
+          <button
+            type="button"
+            class="w-full flex items-start gap-4 md:gap-6 text-left px-5 md:px-8 py-5 md:py-7 group transition-colors hover:bg-accent/[0.04]"
+            :aria-expanded="openIndex === i"
+            @click="toggle(i)"
           >
-            Частые вопросы
-          </Typography>
-          <Typography
-            variant="body-xl"
-            as="p"
-            class="max-w-[540px]"
+            <span
+              class="font-mono text-xs md:text-sm mt-1 shrink-0 transition-transform duration-300"
+              :class="openIndex === i ? 'text-accent rotate-90' : 'text-accent/60'"
+            >
+              &gt;
+            </span>
+            <div class="flex-1 flex items-start justify-between gap-4">
+              <div class="flex flex-col gap-1.5">
+                <span class="font-mono text-[10px] md:text-xs text-foreground/40 tracking-[0.12em]">
+                  Q.{{ String(i + 1).padStart(2, '0') }}
+                </span>
+                <h3
+                  class="font-display uppercase text-base md:text-lg lg:text-xl leading-tight transition-colors"
+                  :class="openIndex === i ? 'text-accent' : 'text-foreground group-hover:text-accent'"
+                >
+                  {{ q.title }}
+                </h3>
+              </div>
+              <span
+                class="font-mono text-xs shrink-0 mt-1"
+                :class="openIndex === i ? 'text-accent' : 'text-foreground/40'"
+              >
+                {{ openIndex === i ? '[−]' : '[+]' }}
+              </span>
+            </div>
+          </button>
+          <div
+            class="grid transition-[grid-template-rows] duration-300"
+            :style="{ gridTemplateRows: openIndex === i ? '1fr' : '0fr' }"
           >
-            Ответы на популярные вопросы о сообществе IT-ХОЗЯЕВА
-          </Typography>
+            <div class="overflow-hidden">
+              <div class="px-5 md:px-8 pb-6 md:pb-8 pl-14 md:pl-[66px] -mt-2">
+                <div class="font-mono text-[11px] text-accent/60 mb-2">
+                  &gt; answer:
+                </div>
+                <p class="text-sm md:text-base text-foreground/75 leading-relaxed max-w-3xl">
+                  {{ q.answer }}
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="grid grid-cols-1 lg:grid-cols-2 items-start gap-5">
-        <Accordion
-          v-for="question in questions"
-          :key="question.title"
-          :title="question.title"
-          :content="question.answer"
-        />
       </div>
     </div>
   </section>

--- a/landing-frontend/src/sections/MentorsSection.vue
+++ b/landing-frontend/src/sections/MentorsSection.vue
@@ -3,8 +3,9 @@ import type { Mentor } from '@/components/ui/MentorsCard.vue'
 import { AlertCircle } from 'lucide-vue-next'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useYandexMetrika } from 'yandex-metrika-vue3'
-import Button from '@/components/ui/UiButton.vue'
+import SectionHeader from '@/components/ui/SectionHeader.vue'
 
+import Button from '@/components/ui/UiButton.vue'
 import MentorCard from '@/components/ui/UiMentorCard.vue'
 import TagsGroup from '@/components/ui/UiTagsGroup.vue'
 import Typography from '@/components/ui/UiTypography.vue'
@@ -126,7 +127,7 @@ onMounted(fetchMentors)
 <template>
   <section
     id="mentors"
-    class="w-full pt-16 md:pt-24 lg:pt-32"
+    class="w-full pt-20 md:pt-32 lg:pt-40"
   >
     <div class="container px-6 md:px-10">
       <div
@@ -152,30 +153,24 @@ onMounted(fetchMentors)
 
       <div
         v-else
-        class="flex flex-col gap-9"
+        class="flex flex-col gap-10 md:gap-14"
       >
-        <div class="flex flex-col items-center justify-center gap-8">
-          <div class="flex flex-col items-center justify-center gap-5">
-            <Typography
-              variant="h2"
-              as="h2"
-              class="text-accent"
-            >
-              База менторов
-            </Typography>
-            <Typography
-              variant="body-xl"
-              as="p"
-              class="text-center"
-            >
-              Эксперты нашего сообщества, которые готовы поделиться экспертизой
-            </Typography>
+        <SectionHeader
+          index="02"
+          path="~/community/mentors.db"
+          title="База менторов"
+          subtitle="Эксперты сообщества, готовые поделиться опытом. Фильтруй по направлению — найди своего."
+        />
+
+        <div class="flex flex-col gap-3 items-start">
+          <div class="font-mono text-[11px] text-foreground/40 tracking-[0.1em] uppercase">
+            $ grep --filter=specialization
           </div>
           <TagsGroup
             v-model="selectedSpecialization"
             :tags="specializations"
             :multiple="true"
-            class="justify-center"
+            class="justify-start"
           />
         </div>
 

--- a/landing-frontend/src/sections/Navigation.vue
+++ b/landing-frontend/src/sections/Navigation.vue
@@ -1,25 +1,27 @@
 <script setup lang="ts">
-import MenuItem from '@/components/ui/UiMenuItem.vue'
-
 const menuItems = [
-  { label: 'менторы', href: '#mentors' },
-  { label: 'встречи', href: '#meets' },
-  { label: 'тарифы', href: '#tariffs' },
-  { label: 'вопросы', href: '#FAQ' },
+  { id: '02', label: 'менторы', href: '#mentors' },
+  { id: '03', label: 'встречи', href: '#meets' },
+  { id: '04', label: 'тарифы', href: '#tariffs' },
+  { id: '05', label: 'вопросы', href: '#FAQ' },
 ]
 </script>
 
 <template>
-  <nav class="flex gap-2 md:gap-6 lg:gap-10">
-    <MenuItem
+  <nav class="flex gap-1 md:gap-3 lg:gap-6">
+    <a
       v-for="item in menuItems"
       :key="item.href"
       :href="item.href"
-      variant="default"
-      as="a"
-      class="capitalize border-4 border-transparent"
+      class="group relative px-2 py-2 lg:px-3 lg:py-2 flex items-center gap-2 text-foreground/70 hover:text-accent transition-colors"
     >
-      {{ item.label }}
-    </MenuItem>
+      <span class="font-mono text-[10px] opacity-40 group-hover:opacity-100 transition-opacity">
+        [{{ item.id }}]
+      </span>
+      <span class="font-display uppercase text-sm lg:text-base tracking-wide">
+        {{ item.label }}
+      </span>
+      <span class="absolute left-2 right-2 bottom-0.5 h-px bg-accent scale-x-0 origin-left group-hover:scale-x-100 transition-transform duration-300" />
+    </a>
   </nav>
 </template>

--- a/landing-frontend/src/sections/PromoteSection.vue
+++ b/landing-frontend/src/sections/PromoteSection.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { TelegramUser } from '@/services/auth.ts'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { useYandexMetrika } from 'yandex-metrika-vue3'
 import TelegramAuth from '@/components/TelegramAuth.vue'
 import Button from '@/components/ui/UiButton.vue'
-import Typography from '@/components/ui/UiTypography.vue'
 import { useToken } from '@/composables/useToken.ts'
 import { useUser } from '@/composables/useUser.ts'
 
@@ -22,55 +22,225 @@ function trackPlatformClick() {
     isAuthenticated: !!tgUser.value,
   } as any)
 }
+
+// Typewriter effect for the tagline
+const phrases = [
+  'менторство_',
+  'vibe_coding_',
+  'AI-практики_',
+  'нетворкинг_',
+  'собесы_',
+]
+const typed = ref('')
+const phraseIdx = ref(0)
+let timer: number | undefined
+let deleting = false
+
+function tick() {
+  const current = phrases[phraseIdx.value]
+  if (!deleting) {
+    typed.value = current.slice(0, typed.value.length + 1)
+    if (typed.value === current) {
+      deleting = true
+      timer = window.setTimeout(tick, 1600)
+      return
+    }
+    timer = window.setTimeout(tick, 65 + Math.random() * 40)
+  }
+  else {
+    typed.value = current.slice(0, typed.value.length - 1)
+    if (typed.value === '') {
+      deleting = false
+      phraseIdx.value = (phraseIdx.value + 1) % phrases.length
+      timer = window.setTimeout(tick, 180)
+      return
+    }
+    timer = window.setTimeout(tick, 35)
+  }
+}
+
+// Live "uptime" counter
+const uptime = ref('00:00:00')
+let uptimeTimer: number | undefined
+const started = Date.now()
+function updateUptime() {
+  const sec = Math.floor((Date.now() - started) / 1000)
+  const h = String(Math.floor(sec / 3600)).padStart(2, '0')
+  const m = String(Math.floor((sec % 3600) / 60)).padStart(2, '0')
+  const s = String(sec % 60).padStart(2, '0')
+  uptime.value = `${h}:${m}:${s}`
+}
+
+onMounted(() => {
+  tick()
+  updateUptime()
+  uptimeTimer = window.setInterval(updateUptime, 1000)
+})
+
+onUnmounted(() => {
+  if (timer)
+    clearTimeout(timer)
+  if (uptimeTimer)
+    clearInterval(uptimeTimer)
+})
+
+const companies = ['Яндекс', 'Tinkoff', 'VK', 'Ozon', 'Wildberries', 'Авито', 'X5', 'Сбер', 'Kaspersky', 'JetBrains', 'Selectel', 'Тинькофф', 'Альфа', 'МТС']
 </script>
 
 <template>
   <section
-    class="relative w-full py-16 md:py-10 lg:py-12 flex flex-col  min-h-[calc(100svh-72px)] md:min-h-fit md:h-auto justify-between items-center
-    before:absolute before:content-['']  before:-z-10 before:w-[1230px] before:h-[836px]
-    before:bg-[url('../assets/icons/crosses-bg.svg')] before:bg-no-repeat before:bg-contain
-    lg:before:-top-2/3 lg:before:-right-[20%] lg:before:bg-right-top
-    sm:before:-top-[280px] sm:before:-right-[480px] sm:before:scale-100 sm:before:opacity-100
-    before:scale-[0.65] before:-top-[200px] before:opacity-50
-    overflow-x-clip
-"
+    class="relative w-full min-h-[100svh] md:min-h-[calc(100svh-var(--header-height))] flex flex-col justify-between overflow-hidden"
   >
-    <div class="container px-6 md:px-10 flex flex-col gap-8 items-center md:items-start justify-between h-full flex-1 ">
-      <div class="flex flex-col gap-6 sm:gap-1 text-center md:text-left  sm:items-center md:items-start w-full  md:max-w-6xl">
-        <Typography
-          variant="h1"
-          as="h1"
-          class="uppercase text-accent"
-        >
-          IT-хозяева
-        </Typography>
-        <Typography
-          variant="h1"
-          as="h1"
-          class="uppercase max-sm:text-2xl break-words hyphens-auto w-full max-w-full"
-        >
-          закрытое сообщество <span class="whitespace-nowrap">IT-специалистов</span>
-        </Typography>
-        <p class="text-lg md:text-xl text-[var(--color-light-grey)] max-w-2xl">
-          250+ специалистов из Яндекса, Тинькофф, VK и стартапов. Менторство, AI, нетворкинг и подготовка к собеседованиям.
-        </p>
+    <!-- Decorative grid / crosshair -->
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 opacity-[0.12]"
+      style="background-image: radial-gradient(circle at 80% 30%, hsl(var(--accent)) 0, transparent 55%), radial-gradient(circle at 20% 80%, #ffb547 0, transparent 45%);"
+    />
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute top-[18%] right-[6%] hidden lg:block"
+    >
+      <div class="w-[520px] h-[520px] rounded-full border border-accent/10 animate-[glitch-x_6s_steps(1)_infinite]">
+        <div class="absolute inset-8 rounded-full border border-accent/15" />
+        <div class="absolute inset-20 rounded-full border border-accent/20" />
+        <div class="absolute inset-32 rounded-full border border-accent/25" />
+        <div class="absolute top-1/2 left-0 right-0 h-px bg-accent/20" />
+        <div class="absolute left-1/2 top-0 bottom-0 w-px bg-accent/20" />
       </div>
-      <div class="flex justify-start ">
-        <TelegramAuth
-          v-if="!tgUser"
-          @auth="setUser"
-        />
-        <Button
-          v-else
-          variant="filled"
-          as="a"
-          href="/platform"
-          rel="noopener noreferrer"
-          @click="trackPlatformClick"
-        >
-          Перейти в платформу
-        </Button>
+    </div>
+
+    <!-- Terminal status bar -->
+    <div class="container px-6 md:px-10 pt-8 md:pt-12 relative z-10">
+      <div class="flex items-center justify-between font-mono text-[11px] md:text-xs tracking-[0.08em] text-foreground/50">
+        <div class="flex items-center gap-4 md:gap-6">
+          <div class="flex items-center gap-1.5">
+            <span class="w-2 h-2 rounded-full bg-accent shadow-[0_0_8px_hsl(var(--accent))]" />
+            <span class="text-accent">ONLINE</span>
+          </div>
+          <span class="hidden sm:inline">uptime: <span class="text-foreground/80">{{ uptime }}</span></span>
+          <span class="hidden md:inline">v4.2.1</span>
+        </div>
+        <div class="flex items-center gap-4 md:gap-6">
+          <span class="hidden sm:inline">250+ users</span>
+          <span>msk/ru</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main hero content -->
+    <div class="container px-6 md:px-10 flex-1 flex items-center py-12 md:py-16 relative z-10">
+      <div class="w-full max-w-5xl">
+        <div class="font-mono text-xs md:text-sm text-foreground/50 mb-5 md:mb-6">
+          <span class="text-accent">community@ithozyaeva</span>:<span class="text-term-amber">~</span>$
+          <span class="text-foreground/80">./welcome --new-user</span>
+        </div>
+
+        <div class="flex items-baseline gap-2 md:gap-3 mb-1">
+          <span class="font-mono text-accent/60 text-sm md:text-base">&gt;</span>
+          <h1 class="font-display uppercase text-[38px] xs:text-[46px] sm:text-[68px] md:text-[96px] lg:text-[130px] leading-[0.85] tracking-tight text-accent">
+            IT-ХОЗЯЕВА
+          </h1>
+        </div>
+
+        <div class="pl-4 md:pl-6 border-l border-accent/30 mt-6 md:mt-8 max-w-3xl">
+          <h2 class="font-display uppercase text-[22px] sm:text-[32px] md:text-[42px] leading-[1.05] text-foreground">
+            Закрытое сообщество<br>
+            <span class="text-foreground/40">IT-специалистов</span>
+          </h2>
+
+          <div class="mt-5 md:mt-7 font-mono text-sm md:text-base text-foreground/75 flex flex-wrap items-center gap-x-2">
+            <span class="text-accent/60">&gt;&gt;</span>
+            <span class="text-foreground/60">exec:</span>
+            <span class="text-term-amber min-w-[1ch]">{{ typed }}</span>
+            <span class="inline-block w-[0.6ch] h-[1.1em] bg-term-amber align-middle animate-type-caret" />
+          </div>
+
+          <p class="mt-4 md:mt-5 text-base md:text-lg text-foreground/70 leading-relaxed max-w-2xl">
+            250+ специалистов из Яндекса, Tinkoff, VK и стартапов.
+            Менторство, AI, нетворкинг и подготовка к собеседованиям.
+          </p>
+        </div>
+
+        <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6 mt-8 md:mt-12">
+          <TelegramAuth
+            v-if="!tgUser"
+            @auth="setUser"
+          />
+          <Button
+            v-else
+            variant="filled"
+            as="a"
+            href="/platform"
+            rel="noopener noreferrer"
+            @click="trackPlatformClick"
+          >
+            Перейти в платформу
+          </Button>
+          <a
+            href="#why"
+            class="font-mono text-xs md:text-sm text-foreground/50 hover:text-accent transition-colors flex items-center gap-2"
+          >
+            <span class="text-accent">$</span> ./scroll-down --see-more
+          </a>
+        </div>
+
+        <!-- Stats strip -->
+        <div class="mt-10 md:mt-16 grid grid-cols-3 max-w-2xl divide-x divide-accent/15 border-t border-b border-accent/15">
+          <div class="py-4 pr-4">
+            <div class="font-display text-2xl md:text-4xl text-accent">
+              250+
+            </div>
+            <div class="font-mono text-[10px] md:text-xs text-foreground/50 uppercase mt-1 tracking-widest">
+              участников
+            </div>
+          </div>
+          <div class="py-4 px-4">
+            <div class="font-display text-2xl md:text-4xl text-accent">
+              60+
+            </div>
+            <div class="font-mono text-[10px] md:text-xs text-foreground/50 uppercase mt-1 tracking-widest">
+              менторов
+            </div>
+          </div>
+          <div class="py-4 pl-4">
+            <div class="font-display text-2xl md:text-4xl text-accent">
+              7×
+            </div>
+            <div class="font-mono text-[10px] md:text-xs text-foreground/50 uppercase mt-1 tracking-widest">
+              встреч в мес.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Marquee of companies -->
+    <div class="relative z-10 border-t border-accent/15 bg-background/40 backdrop-blur-sm overflow-hidden py-4">
+      <div class="flex items-center gap-3 font-mono text-[10px] md:text-xs tracking-[0.2em] uppercase">
+        <div class="px-4 md:px-10 shrink-0 text-accent/70">
+          // команды из:
+        </div>
+        <div class="flex-1 overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
+          <div class="flex gap-10 animate-marquee whitespace-nowrap will-change-transform">
+            <span
+              v-for="(c, i) in [...companies, ...companies]"
+              :key="i"
+              class="text-foreground/60 hover:text-accent transition-colors"
+            >
+              {{ c }} <span class="text-accent/30 ml-10">◇</span>
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </section>
 </template>
+
+<style scoped>
+@media (min-width: 420px) {
+  .xs\:text-\[46px\] {
+    font-size: 46px;
+  }
+}
+</style>

--- a/landing-frontend/src/sections/TariffSection.vue
+++ b/landing-frontend/src/sections/TariffSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useYandexMetrika } from 'yandex-metrika-vue3'
+import SectionHeader from '@/components/ui/SectionHeader.vue'
 import PriceCard from '@/components/ui/UiPriceCard.vue'
-import Typography from '@/components/ui/UiTypography.vue'
 import { useScrollReveal } from '@/composables/useScrollReveal'
 
 interface Tariff {
@@ -12,6 +12,8 @@ interface Tariff {
   features: string[]
   link: string
   isPopular?: boolean
+  tierIndex: string
+  tierLabel: string
 }
 
 const yandexMetrika = useYandexMetrika()
@@ -28,6 +30,8 @@ const tariffs: Tariff[] = [
     name: 'Бригадир',
     description: 'Старт в IT-сообществе',
     price: 520,
+    tierIndex: '01',
+    tierLabel: 'basic',
     features: [
       'Доступ ко всем обучающим материалам',
       'IT-чаты по направлениям и грейдам',
@@ -42,6 +46,8 @@ const tariffs: Tariff[] = [
     price: 1000,
     oldPrice: 2000,
     isPopular: true,
+    tierIndex: '02',
+    tierLabel: 'pro',
     features: [
       'Все возможности тарифа «Бригадир»',
       'Приоритетная поддержка и ревью резюме',
@@ -55,6 +61,8 @@ const tariffs: Tariff[] = [
     name: 'KING',
     description: 'Персональное менторство и продвижение',
     price: 5200,
+    tierIndex: '03',
+    tierLabel: 'max',
     features: [
       'Все возможности тарифа «ХОЗЯИН»',
       'Размещение рекламы ваших ресурсов',
@@ -72,28 +80,17 @@ const { containerRef, isVisible } = useScrollReveal({ threshold: 0.05 })
   <section
     id="tariffs"
     ref="containerRef"
-    class="w-full pt-12 md:pt-24 lg:pt-32"
+    class="w-full pt-20 md:pt-32 lg:pt-40"
   >
     <div class="container px-6 md:px-10">
-      <div class="flex flex-col items-center justify-center space-y-4 text-center">
-        <div class="space-y-2">
-          <Typography
-            variant="h2"
-            as="h2"
-            class="text-accent"
-          >
-            Тарифы и подписка
-          </Typography>
-          <Typography
-            variant="body-xl"
-            as="p"
-            class="max-w-[540px]"
-          >
-            Выберите подходящий тариф — подписка оформляется через Boosty, можно сменить план в любой момент
-          </Typography>
-        </div>
-      </div>
-      <div class="grid pt-12 md:grid-cols-2 lg:grid-cols-3 gap-5">
+      <SectionHeader
+        index="04"
+        path="~/community/access.sh"
+        title="Уровни доступа"
+        subtitle="Подписка через Boosty. План можно повысить или понизить в любой момент."
+      />
+
+      <div class="grid pt-14 md:pt-16 md:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-6 items-stretch">
         <div
           v-for="(tariff, index) in tariffs"
           :key="tariff.name"
@@ -106,6 +103,8 @@ const { containerRef, isVisible } = useScrollReveal({ threshold: 0.05 })
             :old-price="tariff.oldPrice"
             :features="tariff.features"
             :link="tariff.link"
+            :tier-index="tariff.tierIndex"
+            :tier-label="tariff.tierLabel"
             :variant="tariff.isPopular ? 'highlighted' : 'default'"
             :class="[
               isVisible

--- a/landing-frontend/src/sections/WhySection.vue
+++ b/landing-frontend/src/sections/WhySection.vue
@@ -1,86 +1,106 @@
 <script setup lang="ts">
-import type { Component } from 'vue'
-import { useWindowSize } from '@vueuse/core'
-import { computed } from 'vue'
-import {
-  GradesIcon,
-  GradesMobileIcon,
-  MeetingsIcon,
-  MeetingsMobileIcon,
-  TopicsIcon,
-  TopicsMobileIcon,
-  VacanciesIcon,
-  VacanciesMobileIcon,
-} from '@/assets/icons'
-
-import FeatureItem from '@/components/ui/FeatureItem.vue'
-import Typography from '@/components/ui/UiTypography.vue'
+import { Braces, Network, Presentation, Target } from 'lucide-vue-next'
+import SectionHeader from '@/components/ui/SectionHeader.vue'
 
 interface Feature {
+  id: string
+  tag: string
   title: string
   description: string
-  icon: Component
+  icon: any
 }
-
-const { width } = useWindowSize()
-
-const isMobile = computed(() => width.value < 600)
 
 const features: Feature[] = [
   {
-    icon: isMobile.value ? TopicsMobileIcon : TopicsIcon,
+    id: '01',
+    tag: 'topics',
     title: 'Обсуждаем технологии, карьеру и жизнь',
-    description: 'Участники делятся опытом, разбирают кейсы — от вайбкодинга до переговоров по офферу.',
+    description: 'Участники делятся опытом, разбирают кейсы — от vibe-кодинга до переговоров по офферу.',
+    icon: Braces,
   },
   {
-    icon: isMobile.value ? GradesMobileIcon : GradesIcon,
+    id: '02',
+    tag: 'grades',
     title: 'Специалисты всех грейдов и направлений',
     description: 'Разработчики, тестировщики, аналитики, DevOps — от junior до lead.',
+    icon: Target,
   },
   {
-    icon: isMobile.value ? VacanciesMobileIcon : VacanciesIcon,
+    id: '03',
+    tag: 'jobs',
     title: 'Вакансии, рефералки и подготовка к собеседованиям',
     description: 'Вакансии от участников, реферальные ссылки, помощь с резюме и мок-интервью.',
+    icon: Network,
   },
   {
-    icon: isMobile.value ? MeetingsMobileIcon : MeetingsIcon,
+    id: '04',
+    tag: 'meetings',
     title: 'Еженедельные встречи и обучение',
     description: 'Английский клуб, книжный клуб, лекции по архитектуре, AI и soft skills.',
+    icon: Presentation,
   },
-
 ]
 </script>
 
 <template>
   <section
     id="why"
-    class="w-full pt-16 md:pt-24 lg:pt-32"
+    class="w-full pt-20 md:pt-32 lg:pt-40"
   >
-    <div class="container px-6 md:px-10 flex flex-col gap-10">
-      <div class="flex flex-col gap-5 text-center lg:flex-row lg:flex-auto lg:text-start justify-between">
-        <Typography
-          variant="h2"
-          as="h2"
-          class="text-accent basis-2/5"
+    <div class="container px-6 md:px-10">
+      <SectionHeader
+        index="01"
+        path="~/community/why.md"
+        title="Зачем вступать?"
+        subtitle="IT-сообщество 250+ специалистов на стыке технологий и искусственного интеллекта: менторство, вайбкодинг, нетворкинг, подготовка к собеседованиям, обмен вакансиями и еженедельные встречи."
+      />
+
+      <div class="mt-12 md:mt-16 grid grid-cols-1 md:grid-cols-2 gap-px bg-accent/15">
+        <article
+          v-for="(feature, i) in features"
+          :key="feature.id"
+          class="relative group p-7 md:p-10 bg-background/95 hover:bg-accent/5 transition-colors duration-300 min-h-[280px] flex flex-col justify-between cursor-default"
         >
-          Зачем вступать в IT-ХОЗЯЕВА?
-        </Typography>
-        <Typography
-          variant="body-xl"
-          as="p"
-          class="basis-1/2"
-        >
-          IT-ХОЗЯЕВА — это IT-сообщество 250+ специалистов на стыке технологий и искусственного интеллекта: менторство, вайбкодинг, нетворкинг, подготовка к собеседованиям, обмен вакансиями и еженедельные встречи.
-        </Typography>
-      </div>
-      <div class="mx-auto grid grid-cols-1  md:grid-cols-1 lg:grid-cols-2 gap-5 flex-auto">
-        <FeatureItem
-          v-for="feature in features"
-          :key="feature.title"
-          :title="feature.title"
-          :description="feature.description"
-          :icon="feature.icon"
-        />
+          <!-- Tag row -->
+          <div class="flex items-start justify-between gap-4">
+            <div class="flex items-center gap-3">
+              <span class="font-mono text-xs text-accent/60 tracking-[0.12em]">
+                [{{ feature.id }}]
+              </span>
+              <span class="font-mono text-xs text-foreground/40 tracking-[0.08em]">
+                &lt;{{ feature.tag }}/&gt;
+              </span>
+            </div>
+            <div class="shrink-0 w-12 h-12 md:w-14 md:h-14 flex items-center justify-center border border-accent/30 text-accent group-hover:border-accent group-hover:bg-accent/10 transition-all duration-300">
+              <component
+                :is="feature.icon"
+                class="w-5 h-5 md:w-6 md:h-6"
+                stroke-width="1.5"
+              />
+            </div>
+          </div>
+
+          <div class="mt-8 md:mt-12">
+            <h3 class="font-display uppercase text-xl md:text-2xl lg:text-[28px] leading-[1.15] text-foreground group-hover:text-accent transition-colors duration-300">
+              {{ feature.title }}
+            </h3>
+            <p class="mt-3 text-sm md:text-base text-foreground/60 leading-relaxed max-w-lg">
+              {{ feature.description }}
+            </p>
+          </div>
+
+          <!-- Corner accents -->
+          <span class="absolute top-0 left-0 w-3 h-3 border-t-2 border-l-2 border-accent opacity-0 group-hover:opacity-100 transition-opacity" />
+          <span class="absolute bottom-0 right-0 w-3 h-3 border-b-2 border-r-2 border-accent opacity-0 group-hover:opacity-100 transition-opacity" />
+
+          <!-- Index watermark -->
+          <span
+            aria-hidden="true"
+            class="pointer-events-none absolute -bottom-4 -right-2 font-display text-[120px] md:text-[180px] leading-none text-accent/[0.03] group-hover:text-accent/[0.06] transition-colors select-none"
+          >
+            {{ i + 1 }}
+          </span>
+        </article>
       </div>
     </div>
   </section>

--- a/landing-frontend/tailwind.config.js
+++ b/landing-frontend/tailwind.config.js
@@ -16,38 +16,43 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+        display: ['Unbounded', 'Space Grotesk', 'sans-serif'],
       },
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
-        primary: {
+        'term-amber': '#ffb547',
+        'term-magenta': '#ff4d8b',
+        'term-cyan': '#5eead4',
+        'border': 'hsl(var(--border))',
+        'input': 'hsl(var(--input))',
+        'ring': 'hsl(var(--ring))',
+        'background': 'hsl(var(--background))',
+        'foreground': 'hsl(var(--foreground))',
+        'primary': {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',
         },
-        secondary: {
+        'secondary': {
           DEFAULT: 'hsl(var(--secondary))',
           foreground: 'hsl(var(--secondary-foreground))',
         },
-        destructive: {
+        'destructive': {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
-        muted: {
+        'muted': {
           DEFAULT: 'hsl(var(--muted))',
           foreground: 'hsl(var(--muted-foreground))',
         },
-        accent: {
+        'accent': {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
         },
-        popover: {
+        'popover': {
           DEFAULT: 'hsl(var(--popover))',
           foreground: 'hsl(var(--popover-foreground))',
         },
-        card: {
+        'card': {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
@@ -58,6 +63,23 @@ module.exports = {
         sm: 'calc(var(--radius) - 4px)',
       },
       keyframes: {
+        'marquee': {
+          from: { transform: 'translateX(0)' },
+          to: { transform: 'translateX(-50%)' },
+        },
+        'type-caret': {
+          '50%': { opacity: 0 },
+        },
+        'glitch-x': {
+          '0%, 100%': { transform: 'translateX(0)' },
+          '20%': { transform: 'translateX(-1px)' },
+          '40%': { transform: 'translateX(1px)' },
+          '60%': { transform: 'translateX(-0.5px)' },
+        },
+        'scan': {
+          '0%': { backgroundPosition: '0 0' },
+          '100%': { backgroundPosition: '0 200%' },
+        },
         'accordion-down': {
           from: { height: 0 },
           to: { height: 'var(--radix-accordion-content-height)' },
@@ -104,6 +126,10 @@ module.exports = {
         'accordion-up': 'accordion-up 0.2s ease-out',
         'card-reveal': 'card-reveal 0.7s cubic-bezier(0.16, 1, 0.3, 1) both',
         'card-reveal-highlight': 'card-reveal-highlight 1s cubic-bezier(0.16, 1, 0.3, 1) both',
+        'marquee': 'marquee 38s linear infinite',
+        'marquee-slow': 'marquee 60s linear infinite',
+        'type-caret': 'type-caret 1.1s steps(1) infinite',
+        'glitch-x': 'glitch-x 3s steps(1) infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
Полная визуальная переработка лендинга в стиле IDE/терминала — убирает «общий SaaS» вид и даёт лендингу узнаваемый характер, совпадающий с аудиторией IT-специалистов.

**Ключевые изменения:**
- **Design tokens**: JetBrains Mono + Space Grotesk, sharp-card утилита, сетчатый фон + сканлайны, термовые amber/magenta/cyan акценты
- **Hero**: boot-up терминала (prompt `./welcome --new-user`), typewriter с живыми exec'ами (vibe_coding_, AI-практики_...), live uptime, marquee компаний, stats strip (250+/60+/7×)
- **SectionHeader**: общий компонент с нумерацией `[01]` и monospace путями (`~/community/why.md`)
- **WhySection**: брутальные квадратные карточки, index watermark, angle-bracket corners, `<topics/>` теги
- **Mentors**: новый chrome секции + sharp-углы карточек, убраны скругления
- **Calendar**: log-style `tail -f /var/log/community/events.log` с timestamp-колонкой и dot-indicator'ами
- **Tariffs + PriceCard**: access-levels презентация с `[ tier.02 ]`, corner brackets, «recommended» бейдж
- **FAQ**: terminal-prompt accordion с `>` markers, `Q.01` индексами и `[+]/[−]` toggle
- **Footer**: big-type CTA-band на акцент-фоне + terminal status bar с ASCII подвалом
- **Header + Navigation**: status dot, `[02] менторы` mono-индексы, подчёркивание на hover

## Test plan
- [ ] Открыть `/` — проверить hero typewriter, marquee, uptime
- [ ] Скролл — убедиться что каждая секция с `SectionHeader` выглядит консистентно
- [ ] Hover по Why/Tariff/Mentor карточкам — corner brackets + цвет
- [ ] FAQ accordion — открыть/закрыть каждый вопрос
- [ ] Проверить `/privacy` — не сломалось
- [ ] Мобилка 375px, планшет 768px, десктоп 1440px — не переполняется
- [ ] Dark mode уже дефолт — отдельного light mode нет
- [ ] `prefers-reduced-motion` — анимации уже заглушаются через глобальный media query