### PR TITLE
feat(platform): terminal/brutalist redesign — phase 1

### DIFF
--- a/platform-frontend/index.html
+++ b/platform-frontend/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <title>IT-X: Платформа</title>
   </head>
   <body>

--- a/platform-frontend/src/components/Profile/ContactsForm.vue
+++ b/platform-frontend/src/components/Profile/ContactsForm.vue
@@ -51,7 +51,7 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-3xl h-fit">
+  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-sm terminal-card h-fit">
     <div class="flex relative flex-col items-center space-y-3">
       <Edit class="absolute right-0 top-0 cursor-pointer text-muted-foreground hover:text-foreground" @click="toggleEdit" />
       <Typography variant="h3" as="h5">

--- a/platform-frontend/src/components/Profile/MemberProfileForm.vue
+++ b/platform-frontend/src/components/Profile/MemberProfileForm.vue
@@ -81,7 +81,7 @@ async function handleAvatarUpload(event: Event) {
 </script>
 
 <template>
-  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-3xl">
+  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-sm terminal-card">
     <div class="flex relative flex-col items-center space-y-6">
       <Edit
         class="absolute right-0 top-0 cursor-pointer text-muted-foreground hover:text-foreground"

--- a/platform-frontend/src/components/Profile/MentorInfoForm.vue
+++ b/platform-frontend/src/components/Profile/MentorInfoForm.vue
@@ -40,7 +40,7 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-3xl w-full">
+  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-sm terminal-card w-full">
     <div class="flex relative flex-col items-center space-y-6">
       <Edit class="absolute right-0 top-0 cursor-pointer text-muted-foreground hover:text-foreground" @click="isEdit = !isEdit" />
       <div class="space-y-2 w-full mt-2">

--- a/platform-frontend/src/components/Profile/NotificationSettingsForm.vue
+++ b/platform-frontend/src/components/Profile/NotificationSettingsForm.vue
@@ -93,7 +93,7 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-3xl">
+  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-sm terminal-card">
     <div class="flex relative flex-col items-center space-y-4">
       <div class="flex items-center gap-2">
         <Bell class="h-5 w-5 text-muted-foreground" />

--- a/platform-frontend/src/components/Profile/ProfTagsForm.vue
+++ b/platform-frontend/src/components/Profile/ProfTagsForm.vue
@@ -109,7 +109,7 @@ function toggleEdit() {
 </script>
 
 <template>
-  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-3xl h-fit">
+  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-sm terminal-card h-fit">
     <div class="flex relative flex-col items-center space-y-3">
       <Edit class="absolute right-0 top-0 cursor-pointer text-muted-foreground hover:text-foreground" @click="toggleEdit" />
       <Typography variant="h3" as="h5">

--- a/platform-frontend/src/components/Profile/ServicesForm.vue
+++ b/platform-frontend/src/components/Profile/ServicesForm.vue
@@ -58,7 +58,7 @@ function toggleEdit() {
 </script>
 
 <template>
-  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-3xl h-fit">
+  <div class="p-6 md:p-8 bg-card backdrop-blur-lg border border-border shadow-lg rounded-sm terminal-card h-fit">
     <div class="flex relative flex-col items-center space-y-3">
       <Edit class="absolute right-0 top-0 cursor-pointer text-muted-foreground hover:text-foreground" @click="toggleEdit" />
       <Typography variant="h3" as="h5">

--- a/platform-frontend/src/components/Resume/ResumeUploadForm.vue
+++ b/platform-frontend/src/components/Resume/ResumeUploadForm.vue
@@ -70,7 +70,7 @@ async function handleUpload() {
 </script>
 
 <template>
-  <div class="rounded-3xl border bg-card p-4 md:p-6 space-y-4">
+  <div class="rounded-sm border bg-card p-4 md:p-6 space-y-4 terminal-card">
     <div class="flex items-center space-x-3">
       <UploadCloud class="text-accent" />
       <div>

--- a/platform-frontend/src/components/ReviewModal.vue
+++ b/platform-frontend/src/components/ReviewModal.vue
@@ -43,7 +43,7 @@ function handleBackdropClick(event: MouseEvent) {
       @click="handleBackdropClick"
     >
       <Transition name="modal-scale">
-        <div v-if="isOpen" class="bg-card text-card-foreground rounded-3xl p-6 w-full max-w-md relative shadow-xl">
+        <div v-if="isOpen" class="bg-card text-card-foreground rounded-sm p-6 w-full max-w-md relative shadow-xl">
           <button
             type="button"
             class="absolute right-4 top-4 text-muted-foreground hover:text-foreground cursor-pointer"

--- a/platform-frontend/src/components/common/EmptyState.vue
+++ b/platform-frontend/src/components/common/EmptyState.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 
 <template>
   <div class="flex flex-col items-center justify-center py-12 px-4 text-center">
-    <div class="flex items-center justify-center w-16 h-16 rounded-2xl bg-muted mb-4">
+    <div class="flex items-center justify-center w-16 h-16 rounded-sm bg-muted mb-4">
       <component
         :is="icon"
         class="h-8 w-8 text-muted-foreground"

--- a/platform-frontend/src/components/common/ErrorState.vue
+++ b/platform-frontend/src/components/common/ErrorState.vue
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 
 <template>
   <div class="flex flex-col items-center justify-center py-12 px-4 text-center">
-    <div class="flex items-center justify-center w-16 h-16 rounded-2xl bg-destructive/10 mb-4">
+    <div class="flex items-center justify-center w-16 h-16 rounded-sm bg-destructive/10 mb-4">
       <WifiOff
         v-if="props.type === 'network'"
         class="h-8 w-8 text-destructive"

--- a/platform-frontend/src/components/common/OnboardingOverlay.vue
+++ b/platform-frontend/src/components/common/OnboardingOverlay.vue
@@ -134,7 +134,7 @@ onUnmounted(() => {
 
       <!-- Tooltip -->
       <div
-        class="absolute z-[102] w-80 bg-card border border-border rounded-2xl p-5 shadow-xl transition-all duration-300"
+        class="absolute z-[102] w-80 bg-card border border-border rounded-sm p-5 shadow-xl transition-all duration-300"
         :class="arrowClass"
         :style="tooltipStyle"
       >

--- a/platform-frontend/src/components/events/ContentGrid.vue
+++ b/platform-frontend/src/components/events/ContentGrid.vue
@@ -52,7 +52,7 @@ function formatDate(dateStr: string) {
       <div
         v-for="video in videos"
         :key="video.id"
-        class="rounded-2xl border bg-card overflow-hidden group"
+        class="rounded-sm border bg-card overflow-hidden group"
       >
         <div
           class="relative w-full overflow-hidden"

--- a/platform-frontend/src/components/events/EventCard.vue
+++ b/platform-frontend/src/components/events/EventCard.vue
@@ -134,7 +134,7 @@ const { openInGoogleCalendar } = useGoogleCalendar()
 <template>
   <div
     data-reveal
-    class="rounded-3xl border p-4 transition-all duration-200 flex flex-col gap-2"
+    class="rounded-sm border p-4 transition-all duration-200 flex flex-col gap-2 terminal-card"
     :class="isExclusive
       ? 'bg-gradient-to-br from-amber-50/80 to-yellow-50/50 dark:from-amber-950/30 dark:to-yellow-950/20 border-amber-300/60 dark:border-amber-600/40 hover:shadow-lg hover:shadow-amber-200/30 dark:hover:shadow-amber-900/20'
       : 'bg-card hover:shadow-md'"

--- a/platform-frontend/src/components/events/EventCardSkeleton.vue
+++ b/platform-frontend/src/components/events/EventCardSkeleton.vue
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 </script>
 
 <template>
-  <div class="bg-card rounded-3xl border p-4 flex flex-col gap-2">
+  <div class="bg-card rounded-sm border p-4 flex flex-col gap-2">
     <Skeleton class="h-6 w-3/4 rounded-lg" />
     <div class="flex gap-1">
       <Skeleton class="h-5 w-16 rounded-full" />

--- a/platform-frontend/src/components/guilds/GuildCardSkeleton.vue
+++ b/platform-frontend/src/components/guilds/GuildCardSkeleton.vue
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 </script>
 
 <template>
-  <div class="rounded-2xl border bg-card border-border overflow-hidden">
+  <div class="rounded-sm border bg-card border-border overflow-hidden">
     <Skeleton class="h-2 rounded-none" />
     <div class="p-4">
       <Skeleton class="h-5 w-1/2 mb-2" />

--- a/platform-frontend/src/components/layout/Footer.vue
+++ b/platform-frontend/src/components/layout/Footer.vue
@@ -12,21 +12,25 @@ const links = [
 </script>
 
 <template>
-  <footer class="w-full border-t py-6">
-    <div class="container mx-auto px-4 flex flex-col gap-6">
+  <footer class="w-full border-t py-4">
+    <div class="container mx-auto px-4 flex flex-col gap-4">
       <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-4 sm:gap-x-8 gap-y-2">
         <RouterLink
           v-for="link in links"
           :key="link.path"
           :to="link.path"
-          class="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          class="font-mono text-xs text-muted-foreground hover:text-accent transition-colors tracking-wide"
         >
-          {{ link.label }}
+          ./{{ link.label.toLowerCase() }}
         </RouterLink>
       </div>
-      <p class="text-center text-sm text-muted-foreground">
-        © {{ new Date().getFullYear() }} IT-ХОЗЯЕВА. Все права защищены.
-      </p>
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 font-mono text-[11px] text-muted-foreground/70 tracking-wide border-t border-border pt-3">
+        <span>© {{ new Date().getFullYear() }} IT-ХОЗЯЕВА // all rights reserved</span>
+        <span class="flex items-center gap-2">
+          <span class="w-1.5 h-1.5 rounded-full bg-accent" />
+          status: operational
+        </span>
+      </div>
     </div>
   </footer>
 </template>

--- a/platform-frontend/src/components/layout/Header.vue
+++ b/platform-frontend/src/components/layout/Header.vue
@@ -52,6 +52,10 @@ function logout() {
           />
         </svg>
       </a>
+      <span class="hidden md:flex items-center gap-1.5 font-mono text-[10px] text-muted-foreground uppercase tracking-widest">
+        <span class="w-1.5 h-1.5 rounded-full bg-accent shadow-[0_0_6px_hsl(var(--accent))]" />
+        online
+      </span>
       <div class="flex-1" />
       <div
         v-if="user"

--- a/platform-frontend/src/components/layout/Sidebar.vue
+++ b/platform-frontend/src/components/layout/Sidebar.vue
@@ -70,6 +70,11 @@ async function handleSaveReview(text: string) {
               <X class="w-6 h-6" />
             </button>
           </div>
+          <!-- Terminal system header -->
+          <div class="px-4 py-3 border-b border-sidebar-border hidden md:flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full bg-accent shadow-[0_0_6px_hsl(var(--accent))]" />
+            <span class="font-mono text-xs font-medium tracking-wider text-sidebar-foreground/80">[SYS] IT-X</span>
+          </div>
           <div class="flex-1 py-4">
             <div
               v-for="(group, groupIndex) in sidebarGroups"
@@ -78,24 +83,25 @@ async function handleSaveReview(text: string) {
             >
               <p
                 v-if="group.label"
-                class="px-4 mb-1.5 text-[11px] font-medium uppercase tracking-wider text-sidebar-foreground/40"
+                class="px-4 mb-1.5 text-[11px] font-mono font-medium uppercase tracking-wider text-sidebar-foreground/40"
               >
-                {{ group.label }}
+                // {{ group.label }}
               </p>
               <ul class="space-y-0.5">
                 <li
-                  v-for="item in group.items"
+                  v-for="(item, itemIndex) in group.items"
                   :key="item.path"
                   :data-onboarding="item.dataOnboarding"
                 >
                   <Button
                     variant="ghost"
-                    class="w-full justify-start py-2 cursor-pointer text-sidebar-foreground hover:bg-accent hover:text-accent-foreground"
+                    class="w-full justify-start py-2 cursor-pointer rounded-sm text-sidebar-foreground hover:bg-accent hover:text-accent-foreground"
                     :class="[
                       isActive(item.path) ? 'bg-accent text-accent-foreground' : '',
                     ]"
                     @click="navigateTo(item.path)"
                   >
+                    <span class="font-mono text-[10px] text-sidebar-foreground/40 mr-1.5 w-4 shrink-0">{{ String(itemIndex + 1).padStart(2, '0') }}</span>
                     <component
                       :is="item.icon"
                       class="h-5 w-5 mr-2"

--- a/platform-frontend/src/components/marketplace/MarketplaceItemSkeleton.vue
+++ b/platform-frontend/src/components/marketplace/MarketplaceItemSkeleton.vue
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 </script>
 
 <template>
-  <div class="rounded-2xl border bg-card border-border overflow-hidden">
+  <div class="rounded-sm border bg-card border-border overflow-hidden">
     <Skeleton class="w-full h-48 rounded-none" />
     <div class="p-4">
       <div class="flex items-start justify-between gap-2 mb-2">

--- a/platform-frontend/src/components/mentors/MentorCard.vue
+++ b/platform-frontend/src/components/mentors/MentorCard.vue
@@ -17,7 +17,7 @@ function getInitials(mentor: Mentor) {
   <RouterLink
     :to="`/mentors/${props.mentor.id}`"
     data-reveal
-    class="bg-card rounded-3xl border p-4 hover:border-accent/50 hover:-translate-y-0.5 transition-all duration-200 flex gap-4 cursor-pointer"
+    class="bg-card rounded-sm border p-4 hover:border-accent/50 hover:-translate-y-0.5 transition-all duration-200 flex gap-4 cursor-pointer terminal-card"
   >
     <!-- Avatar -->
     <div class="shrink-0">

--- a/platform-frontend/src/components/mentors/MentorCardSkeleton.vue
+++ b/platform-frontend/src/components/mentors/MentorCardSkeleton.vue
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 </script>
 
 <template>
-  <div class="bg-card rounded-3xl border p-4 flex flex-col gap-2">
+  <div class="bg-card rounded-sm border p-4 flex flex-col gap-2">
     <Skeleton class="h-6 w-2/3 rounded-lg" />
     <Skeleton class="h-4 w-1/2" />
     <Skeleton class="h-4 w-3/4" />

--- a/platform-frontend/src/components/quests/QuestCardSkeleton.vue
+++ b/platform-frontend/src/components/quests/QuestCardSkeleton.vue
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 </script>
 
 <template>
-  <div class="rounded-3xl border bg-card p-5">
+  <div class="rounded-sm border bg-card p-5">
     <div class="flex items-start gap-3">
       <Skeleton class="w-10 h-10 rounded-xl shrink-0" />
       <div class="flex-1 min-w-0">

--- a/platform-frontend/src/components/referals/ReferalLinkCard.vue
+++ b/platform-frontend/src/components/referals/ReferalLinkCard.vue
@@ -99,7 +99,7 @@ const { gradesObject, referalLinkStatusesObject } = useDictionary(['grades', 're
 <template>
   <div
     data-reveal
-    class="bg-card rounded-3xl border p-4 hover:shadow-md transition-shadow flex flex-col gap-1"
+    class="bg-card rounded-sm border p-4 hover:shadow-md transition-shadow flex flex-col gap-1 terminal-card"
   >
     <!-- Режим просмотра -->
     <div v-if="!isEditing">

--- a/platform-frontend/src/components/tasks/TaskCardSkeleton.vue
+++ b/platform-frontend/src/components/tasks/TaskCardSkeleton.vue
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 </script>
 
 <template>
-  <div class="rounded-2xl p-4 border bg-card border-border">
+  <div class="rounded-sm p-4 border bg-card border-border">
     <div class="flex items-start justify-between gap-2 mb-2">
       <Skeleton class="h-4 w-2/3" />
       <Skeleton class="h-5 w-16 rounded-full shrink-0" />

--- a/platform-frontend/src/components/ui/alert-dialog/AlertDialogContent.vue
+++ b/platform-frontend/src/components/ui/alert-dialog/AlertDialogContent.vue
@@ -30,7 +30,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="forwarded"
       :class="
         cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-3xl',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-sm',
           props.class,
         )"
     >

--- a/platform-frontend/src/components/ui/card/Card.vue
+++ b/platform-frontend/src/components/ui/card/Card.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   <div
     :class="
       cn(
-        'rounded-3xl border bg-card text-card-foreground shadow hover:shadow-md transition-shadow',
+        'rounded-sm border bg-card text-card-foreground transition-all terminal-card',
         props.class,
       )
     "

--- a/platform-frontend/src/components/ui/dialog/DialogContent.vue
+++ b/platform-frontend/src/components/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="forwarded"
       :class="
         cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-3xl',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-sm',
           props.class,
         )"
     >

--- a/platform-frontend/src/components/ui/dialog/DialogScrollContent.vue
+++ b/platform-frontend/src/components/ui/dialog/DialogScrollContent.vue
@@ -33,7 +33,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       <DialogContent
         :class="
           cn(
-            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-3xl md:w-full',
+            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-sm md:w-full',
             props.class,
           )
         "

--- a/platform-frontend/src/index.css
+++ b/platform-frontend/src/index.css
@@ -96,6 +96,61 @@
   }
 }
 
+/* Terminal utilities for platform */
+.font-mono-ui {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-feature-settings: 'ss01', 'cv11';
+}
+
+.terminal-card {
+  border-radius: 2px !important;
+  border: 1px solid hsl(var(--border));
+  position: relative;
+  transition: border-color 250ms ease, box-shadow 250ms ease;
+}
+
+.dark .terminal-card {
+  background: linear-gradient(180deg, hsl(151 5% 11% / 0.95), hsl(151 5% 9% / 0.95));
+}
+
+.terminal-card::before,
+.terminal-card::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-color: hsl(var(--accent));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.terminal-card::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+.terminal-card::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+}
+.terminal-card:hover::before,
+.terminal-card:hover::after {
+  opacity: 1;
+}
+.terminal-card:hover {
+  border-color: hsl(var(--accent) / 0.5);
+  box-shadow: 0 0 0 1px hsl(var(--accent) / 0.1), 0 15px 40px -20px hsl(var(--accent) / 0.25);
+}
+
+.dark body {
+  background-image:
+    linear-gradient(to right, hsl(151 5% 15% / 0.2) 1px, transparent 1px),
+    linear-gradient(to bottom, hsl(151 5% 15% / 0.2) 1px, transparent 1px);
+  background-size: 64px 64px;
+  background-attachment: fixed;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/platform-frontend/src/pages/Achievements.vue
+++ b/platform-frontend/src/pages/Achievements.vue
@@ -126,6 +126,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/achievements
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -169,7 +172,7 @@ onMounted(() => {
         <div
           v-for="achievement in filteredItems"
           :key="achievement.id"
-          class="rounded-2xl p-4 transition-colors border cursor-pointer hover:shadow-md"
+          class="rounded-sm p-4 transition-colors border cursor-pointer hover:shadow-md"
           :class="achievement.unlocked
             ? 'bg-green-500/5 border-green-500/30'
             : 'bg-card border-border opacity-60'"

--- a/platform-frontend/src/pages/AutoApplyBot.vue
+++ b/platform-frontend/src/pages/AutoApplyBot.vue
@@ -57,6 +57,9 @@ function toggleFaq(index: number) {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8 max-w-3xl">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/auto-apply-bot
+    </div>
     <Typography
       variant="h2"
       as="h1"
@@ -66,9 +69,9 @@ function toggleFaq(index: number) {
     </Typography>
 
     <!-- Hero card -->
-    <div class="bg-card rounded-3xl border p-6 md:p-8 mb-6">
+    <div class="bg-card rounded-sm terminal-card border p-6 md:p-8 mb-6">
       <div class="flex items-center gap-4 mb-4">
-        <div class="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary shrink-0">
+        <div class="flex items-center justify-center w-14 h-14 rounded-sm bg-primary/10 text-primary shrink-0">
           <Bot :size="28" />
         </div>
         <div>
@@ -106,7 +109,7 @@ function toggleFaq(index: number) {
         <div
           v-for="(step, index) in steps"
           :key="index"
-          class="flex gap-3 rounded-2xl border bg-card border-border p-4"
+          class="flex gap-3 rounded-sm border bg-card border-border p-4"
         >
           <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 text-primary shrink-0">
             <span class="text-sm font-bold">{{ index + 1 }}</span>
@@ -132,7 +135,7 @@ function toggleFaq(index: number) {
         <div
           v-for="feature in features"
           :key="feature.title"
-          class="flex gap-3 rounded-2xl border bg-card border-border p-4"
+          class="flex gap-3 rounded-sm border bg-card border-border p-4"
         >
           <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-muted shrink-0">
             <component
@@ -161,7 +164,7 @@ function toggleFaq(index: number) {
         <div
           v-for="(item, index) in faqItems"
           :key="index"
-          class="rounded-2xl border bg-card border-border overflow-hidden"
+          class="rounded-sm border bg-card border-border overflow-hidden"
         >
           <button
             class="w-full flex items-center justify-between p-4 text-left text-sm font-medium hover:bg-muted/50 transition-colors"

--- a/platform-frontend/src/pages/Casino.vue
+++ b/platform-frontend/src/pages/Casino.vue
@@ -311,6 +311,9 @@ onBeforeUnmount(() => {
       <!-- Header with balance -->
       <div class="flex items-center justify-between mb-8">
         <div>
+          <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+            ~/community/casino
+          </div>
           <h1 class="casino-title">
             Мини-игры
           </h1>

--- a/platform-frontend/src/pages/Dashboard.vue
+++ b/platform-frontend/src/pages/Dashboard.vue
@@ -237,7 +237,7 @@ onMounted(async () => {
       class="space-y-5"
     >
       <!-- Greeting card skeleton -->
-      <div class="rounded-3xl border bg-card p-6 md:p-8">
+      <div class="rounded-sm border bg-card p-6 md:p-8">
         <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div class="space-y-2">
             <div class="h-8 w-64 animate-pulse rounded-lg bg-muted" />
@@ -257,7 +257,7 @@ onMounted(async () => {
           <div
             v-for="i in 3"
             :key="i"
-            class="flex items-center gap-2.5 rounded-2xl bg-muted/50 p-3"
+            class="flex items-center gap-2.5 rounded-sm bg-muted/50 p-3"
           >
             <div class="w-9 h-9 animate-pulse rounded-xl bg-muted" />
             <div class="space-y-1.5">
@@ -269,7 +269,7 @@ onMounted(async () => {
       </div>
 
       <!-- Event section skeleton -->
-      <div class="rounded-3xl border bg-card p-5 md:p-6">
+      <div class="rounded-sm border bg-card p-5 md:p-6">
         <div class="flex items-center gap-2 mb-3">
           <div class="h-4 w-4 animate-pulse rounded bg-muted" />
           <div class="h-4 w-36 animate-pulse rounded bg-muted" />
@@ -287,7 +287,7 @@ onMounted(async () => {
         <div
           v-for="i in 2"
           :key="i"
-          class="rounded-3xl border bg-card p-5"
+          class="rounded-sm border bg-card p-5"
         >
           <div class="flex items-center gap-2 mb-4">
             <div class="h-4 w-4 animate-pulse rounded bg-muted" />
@@ -297,7 +297,7 @@ onMounted(async () => {
             <div
               v-for="j in 2"
               :key="j"
-              class="rounded-2xl bg-muted/40 p-3.5"
+              class="rounded-sm bg-muted/30 border border-border/50 p-3.5"
             >
               <div class="h-4 w-3/4 animate-pulse rounded bg-muted mb-2" />
               <div class="h-3 w-1/2 animate-pulse rounded bg-muted" />
@@ -311,11 +311,15 @@ onMounted(async () => {
       <!-- Hero Greeting -->
       <div
         data-onboarding="dashboard"
-        class="relative rounded-3xl border bg-card p-6 md:p-8 overflow-hidden"
+        class="relative rounded-sm border bg-card p-6 md:p-8 overflow-hidden terminal-card"
       >
         <!-- Subtle accent gradient -->
         <div class="absolute top-0 right-0 w-48 h-48 rounded-full bg-accent/5 -translate-y-1/2 translate-x-1/4 blur-2xl" />
         <div class="relative">
+          <div class="font-mono text-[11px] text-accent/70 tracking-wider mb-3">
+            <span class="text-muted-foreground">{{ new Date().toISOString().slice(0, 10) }}</span> //
+            session.active
+          </div>
           <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
             <div>
               <h1 class="text-2xl md:text-3xl font-bold tracking-tight">
@@ -351,7 +355,7 @@ onMounted(async () => {
           <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-6">
             <RouterLink
               to="/points"
-              class="flex items-center gap-2.5 rounded-2xl bg-muted/50 hover:bg-muted/80 transition-colors p-3"
+              class="flex items-center gap-2.5 rounded-sm border border-border bg-muted/30 hover:border-accent/40 transition-colors p-3"
             >
               <div class="flex items-center justify-center w-9 h-9 rounded-xl bg-yellow-500/10">
                 <Star class="h-4 w-4 text-yellow-500" />
@@ -368,7 +372,7 @@ onMounted(async () => {
 
             <RouterLink
               to="/achievements"
-              class="flex items-center gap-2.5 rounded-2xl bg-muted/50 hover:bg-muted/80 transition-colors p-3"
+              class="flex items-center gap-2.5 rounded-sm border border-border bg-muted/30 hover:border-accent/40 transition-colors p-3"
             >
               <div class="flex items-center justify-center w-9 h-9 rounded-xl bg-purple-500/10">
                 <Trophy class="h-4 w-4 text-purple-500" />
@@ -385,7 +389,7 @@ onMounted(async () => {
 
             <RouterLink
               to="/events"
-              class="flex items-center gap-2.5 rounded-2xl bg-muted/50 hover:bg-muted/80 transition-colors p-3"
+              class="flex items-center gap-2.5 rounded-sm border border-border bg-muted/30 hover:border-accent/40 transition-colors p-3"
             >
               <div class="flex items-center justify-center w-9 h-9 rounded-xl bg-blue-500/10">
                 <Calendar class="h-4 w-4 text-blue-500" />
@@ -411,7 +415,7 @@ onMounted(async () => {
         <div
           v-for="event in nearestEvents"
           :key="event.id"
-          class="rounded-3xl border overflow-hidden"
+          class="rounded-sm terminal-card overflow-hidden"
           :class="event.exclusiveChatId
             ? 'bg-gradient-to-br from-amber-50/80 to-yellow-50/50 dark:from-amber-950/30 dark:to-yellow-950/20 border-amber-300/60 dark:border-amber-600/40'
             : 'bg-card'"
@@ -422,6 +426,7 @@ onMounted(async () => {
               <span class="text-xs font-semibold uppercase tracking-wide">{{ event.exclusiveChatTitle || 'Эксклюзив' }}</span>
             </div>
             <div class="flex items-center gap-2 mb-3">
+              <span class="font-mono text-[10px] text-muted-foreground/60 mr-1">[01]</span>
               <Zap class="h-4 w-4 text-accent" />
               <span class="text-sm font-medium text-accent">Ближайшее событие</span>
               <span
@@ -484,10 +489,11 @@ onMounted(async () => {
 
       <div
         v-else
-        class="mt-5 rounded-3xl border bg-card overflow-hidden"
+        class="mt-5 rounded-sm terminal-card bg-card overflow-hidden"
       >
         <div class="p-5 md:p-6">
           <div class="flex items-center gap-2 mb-3">
+            <span class="font-mono text-[10px] text-muted-foreground/60 mr-1">[01]</span>
             <Zap class="h-4 w-4 text-accent" />
             <span class="text-sm font-medium text-accent">Ближайшие события</span>
           </div>
@@ -508,10 +514,11 @@ onMounted(async () => {
       <div class="mt-5 grid gap-5 md:grid-cols-2">
         <!-- Chat Quests -->
         <div
-          class="rounded-3xl border bg-card p-5"
+          class="rounded-sm terminal-card bg-card p-5"
         >
           <div class="flex items-center justify-between mb-4">
             <div class="flex items-center gap-2">
+              <span class="font-mono text-[10px] text-muted-foreground/60 mr-1">[02]</span>
               <Flame class="h-4 w-4 text-orange-500" />
               <span class="text-sm font-semibold">Задания в чатах</span>
             </div>
@@ -530,7 +537,7 @@ onMounted(async () => {
             <div
               v-for="quest in activeQuests.slice(0, 3)"
               :key="quest.id"
-              class="rounded-2xl bg-muted/40 p-3.5"
+              class="rounded-sm bg-muted/30 border border-border/50 p-3.5"
             >
               <div class="flex items-start justify-between gap-2">
                 <div class="flex items-center gap-2.5 min-w-0">
@@ -595,10 +602,11 @@ onMounted(async () => {
 
         <!-- Open Tasks -->
         <div
-          class="rounded-3xl border bg-card p-5"
+          class="rounded-sm terminal-card bg-card p-5"
         >
           <div class="flex items-center justify-between mb-4">
             <div class="flex items-center gap-2">
+              <span class="font-mono text-[10px] text-muted-foreground/60 mr-1">[03]</span>
               <ClipboardList class="h-4 w-4 text-blue-500" />
               <span class="text-sm font-semibold">Биржа заданий</span>
             </div>
@@ -618,7 +626,7 @@ onMounted(async () => {
               v-for="task in openTasks"
               :key="task.id"
               to="/tasks"
-              class="block rounded-2xl bg-muted/40 hover:bg-muted/60 transition-colors p-3.5"
+              class="block rounded-sm bg-muted/30 border border-border/50 hover:bg-muted/60 transition-colors p-3.5"
             >
               <div class="flex items-start justify-between gap-2">
                 <div class="min-w-0">
@@ -653,9 +661,10 @@ onMounted(async () => {
       <!-- Chat Highlights -->
       <div
         v-if="highlights.length > 0"
-        class="mt-5 rounded-3xl border bg-card p-5"
+        class="mt-5 rounded-sm terminal-card bg-card p-5"
       >
         <div class="flex items-center gap-2 mb-4">
+          <span class="font-mono text-[10px] text-muted-foreground/60 mr-1">[04]</span>
           <MessageSquare class="h-4 w-4 text-yellow-500" />
           <span class="text-sm font-semibold">Лучшее из чатов</span>
         </div>
@@ -663,7 +672,7 @@ onMounted(async () => {
           <div
             v-for="hl in highlights"
             :key="hl.id"
-            class="rounded-2xl bg-muted/40 p-3.5"
+            class="rounded-sm bg-muted/30 border border-border/50 p-3.5"
           >
             <div class="flex items-center gap-2 mb-1.5">
               <div class="flex items-center justify-center w-7 h-7 rounded-full bg-accent/10 shrink-0">
@@ -693,10 +702,11 @@ onMounted(async () => {
 
       <!-- Achievements Preview -->
       <div
-        class="mt-5 rounded-3xl border bg-card p-5"
+        class="mt-5 rounded-sm terminal-card bg-card p-5"
       >
         <div class="flex items-center justify-between mb-4">
           <div class="flex items-center gap-2">
+            <span class="font-mono text-[10px] text-muted-foreground/60 mr-1">[05]</span>
             <Award class="h-4 w-4 text-purple-500" />
             <span class="text-sm font-semibold">Достижения</span>
           </div>
@@ -714,7 +724,7 @@ onMounted(async () => {
           <div
             v-for="ach in achievements.recent"
             :key="ach.id"
-            class="flex items-center gap-2.5 rounded-2xl bg-muted/40 px-4 py-3 shrink-0"
+            class="flex items-center gap-2.5 rounded-sm bg-muted/30 border border-border/50 px-4 py-3 shrink-0"
           >
             <div class="flex items-center justify-center w-10 h-10 rounded-full bg-green-500/20 shrink-0">
               <component
@@ -751,7 +761,7 @@ onMounted(async () => {
       >
         <RouterLink
           to="/leaderboard"
-          class="rounded-2xl border bg-card hover:bg-muted/50 transition-colors p-4 text-center"
+          class="rounded-sm border bg-card hover:bg-muted/50 transition-colors p-4 text-center terminal-card"
         >
           <Trophy class="h-5 w-5 mx-auto text-yellow-500 mb-1.5" />
           <p class="text-xs font-medium">
@@ -760,7 +770,7 @@ onMounted(async () => {
         </RouterLink>
         <RouterLink
           to="/marketplace"
-          class="rounded-2xl border bg-card hover:bg-muted/50 transition-colors p-4 text-center"
+          class="rounded-sm border bg-card hover:bg-muted/50 transition-colors p-4 text-center terminal-card"
         >
           <Star class="h-5 w-5 mx-auto text-accent mb-1.5" />
           <p class="text-xs font-medium">
@@ -769,7 +779,7 @@ onMounted(async () => {
         </RouterLink>
         <RouterLink
           to="/mentors"
-          class="rounded-2xl border bg-card hover:bg-muted/50 transition-colors p-4 text-center"
+          class="rounded-sm border bg-card hover:bg-muted/50 transition-colors p-4 text-center terminal-card"
         >
           <Users class="h-5 w-5 mx-auto text-blue-500 mb-1.5" />
           <p class="text-xs font-medium">
@@ -778,7 +788,7 @@ onMounted(async () => {
         </RouterLink>
         <RouterLink
           to="/referals"
-          class="rounded-2xl border bg-card hover:bg-muted/50 transition-colors p-4 text-center"
+          class="rounded-sm border bg-card hover:bg-muted/50 transition-colors p-4 text-center terminal-card"
         >
           <Zap class="h-5 w-5 mx-auto text-orange-500 mb-1.5" />
           <p class="text-xs font-medium">

--- a/platform-frontend/src/pages/Events.vue
+++ b/platform-frontend/src/pages/Events.vue
@@ -154,6 +154,9 @@ const tabs: { value: TabValue, label: string }[] = [
 
 <template>
   <div ref="containerRef" class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/events
+    </div>
     <div class="flex items-center justify-between mb-4 md:mb-6">
       <Typography variant="h2" as="h1">
         События сообщества
@@ -271,7 +274,7 @@ const tabs: { value: TabValue, label: string }[] = [
     <ContentGrid v-else-if="activeTab === 'content'" />
 
     <!-- Calendar tab -->
-    <div v-else-if="activeTab === 'calendar'" class="rounded-2xl border bg-card border-border p-4">
+    <div v-else-if="activeTab === 'calendar'" class="rounded-sm border bg-card border-border p-4 terminal-card">
       <div v-if="isLoadingCalendar" class="flex justify-center py-12">
         <Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
       </div>

--- a/platform-frontend/src/pages/FAQ.vue
+++ b/platform-frontend/src/pages/FAQ.vue
@@ -41,6 +41,9 @@ const sections = [
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8 max-w-3xl">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/faq
+    </div>
     <Typography
       variant="h2"
       as="h1"
@@ -57,7 +60,7 @@ const sections = [
         v-for="(item, index) in sections"
         :key="index"
         :value="`item-${index}`"
-        class="rounded-2xl border bg-card overflow-hidden"
+        class="rounded-sm border bg-card overflow-hidden"
       >
         <AccordionHeader>
           <AccordionTrigger class="flex w-full items-center justify-between px-5 py-4 text-left text-sm font-medium hover:bg-muted/50 transition-colors group">

--- a/platform-frontend/src/pages/Guilds.vue
+++ b/platform-frontend/src/pages/Guilds.vue
@@ -152,6 +152,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/guilds
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -189,7 +192,7 @@ onMounted(() => {
         <div
           v-for="guild in guilds"
           :key="guild.id"
-          class="rounded-2xl border bg-card border-border overflow-hidden"
+          class="rounded-sm border bg-card border-border overflow-hidden terminal-card"
         >
           <div
             class="h-2"

--- a/platform-frontend/src/pages/Kudos.vue
+++ b/platform-frontend/src/pages/Kudos.vue
@@ -124,6 +124,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/kudos
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -167,7 +170,7 @@ onMounted(() => {
         <div
           v-for="item in items"
           :key="item.id"
-          class="rounded-2xl border bg-card border-border p-4"
+          class="rounded-sm border bg-card border-border p-4"
         >
           <div class="flex items-start gap-3">
             <img

--- a/platform-frontend/src/pages/Leaderboard.vue
+++ b/platform-frontend/src/pages/Leaderboard.vue
@@ -75,6 +75,9 @@ function isCurrentUser(entry: LeaderboardEntry) {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/leaderboard
+    </div>
     <Typography
       variant="h2"
       as="h1"
@@ -109,7 +112,7 @@ function isCurrentUser(entry: LeaderboardEntry) {
     >
       <div
         v-if="currentUserEntry && !isCurrentUserVisible"
-        class="p-4 bg-primary/10 border border-primary/30 rounded-2xl shadow-sm mb-4"
+        class="p-4 bg-primary/10 border border-primary/30 rounded-sm shadow-sm mb-4"
       >
         <RouterLink
           :to="`/members/${currentUserEntry.entry.memberId}`"
@@ -153,7 +156,7 @@ function isCurrentUser(entry: LeaderboardEntry) {
         v-for="(entry, index) in visibleEntries"
         :key="entry.memberId"
         :to="`/members/${entry.memberId}`"
-        class="flex items-center gap-4 p-4 bg-card border border-border rounded-2xl shadow-sm hover:border-primary/30 transition-colors"
+        class="flex items-center gap-4 p-4 bg-card border border-border rounded-sm shadow-sm hover:border-primary/30 transition-colors"
         :class="{
           'border-yellow-500/50 bg-yellow-500/5': index < 3 && !isCurrentUser(entry),
           'border-primary/50 bg-primary/10 ring-1 ring-primary/20': isCurrentUser(entry),

--- a/platform-frontend/src/pages/Marketplace.vue
+++ b/platform-frontend/src/pages/Marketplace.vue
@@ -275,6 +275,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/marketplace
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -375,7 +378,7 @@ onMounted(() => {
         <div
           v-for="item in filteredItems"
           :key="item.id"
-          class="rounded-2xl border bg-card border-border overflow-hidden"
+          class="rounded-sm border bg-card border-border overflow-hidden terminal-card"
         >
           <!-- Image -->
           <img
@@ -383,11 +386,11 @@ onMounted(() => {
             :src="item.imagePath"
             :alt="item.title"
             loading="lazy"
-            class="w-full h-36 sm:h-48 object-cover rounded-t-2xl bg-muted"
+            class="w-full h-36 sm:h-48 object-cover rounded-t-sm bg-muted"
           >
           <div
             v-else
-            class="w-full h-36 sm:h-48 bg-muted flex items-center justify-center rounded-t-2xl"
+            class="w-full h-36 sm:h-48 bg-muted flex items-center justify-center rounded-t-sm"
           >
             <Package class="h-12 w-12 text-muted-foreground opacity-40" aria-hidden="true" />
           </div>

--- a/platform-frontend/src/pages/MemberProfile.vue
+++ b/platform-frontend/src/pages/MemberProfile.vue
@@ -156,6 +156,9 @@ onMounted(loadProfile)
 
 <template>
   <div class="container mx-auto px-4 py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/member-profile
+    </div>
     <button
       class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-6"
       @click="router.back()"
@@ -175,7 +178,7 @@ onMounted(loadProfile)
       v-else-if="profile"
       class="space-y-6"
     >
-      <div class="bg-card rounded-3xl border p-6">
+      <div class="bg-card rounded-sm terminal-card border p-6">
         <div class="flex items-start gap-5">
           <div class="w-20 h-20 rounded-full overflow-hidden shrink-0 bg-accent/20 flex items-center justify-center">
             <img
@@ -227,7 +230,7 @@ onMounted(loadProfile)
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div class="bg-card rounded-3xl border p-6 flex items-center gap-3">
+        <div class="bg-card rounded-sm terminal-card border p-6 flex items-center gap-3">
           <Trophy class="h-5 w-5 text-yellow-500 shrink-0" />
           <div>
             <div class="text-2xl font-bold">
@@ -240,7 +243,7 @@ onMounted(loadProfile)
         </div>
         <div
           v-if="daysSinceJoined"
-          class="bg-card rounded-3xl border p-6"
+          class="bg-card rounded-sm terminal-card border p-6"
         >
           <div class="text-2xl font-bold">
             {{ daysSinceJoined }}
@@ -249,7 +252,7 @@ onMounted(loadProfile)
             {{ pluralizeDays(daysSinceJoined) }} с нами
           </div>
         </div>
-        <div class="bg-card rounded-3xl border p-6">
+        <div class="bg-card rounded-sm terminal-card border p-6">
           <div class="text-2xl font-bold">
             {{ subscriptionLevel }}
           </div>
@@ -268,7 +271,7 @@ onMounted(loadProfile)
         v-if="stats"
         class="grid grid-cols-2 sm:grid-cols-4 gap-4"
       >
-        <div class="bg-card rounded-3xl border p-4 text-center">
+        <div class="bg-card rounded-sm terminal-card border p-4 text-center">
           <div class="text-2xl font-bold">
             {{ stats.eventsAttended }}
           </div>
@@ -276,7 +279,7 @@ onMounted(loadProfile)
             Событий посещено
           </div>
         </div>
-        <div class="bg-card rounded-3xl border p-4 text-center">
+        <div class="bg-card rounded-sm terminal-card border p-4 text-center">
           <div class="text-2xl font-bold">
             {{ stats.tasksCreated + stats.tasksDone }}
           </div>
@@ -284,7 +287,7 @@ onMounted(loadProfile)
             Заданий
           </div>
         </div>
-        <div class="bg-card rounded-3xl border p-4 text-center">
+        <div class="bg-card rounded-sm terminal-card border p-4 text-center">
           <div class="text-2xl font-bold">
             {{ stats.kudosReceived }}
           </div>
@@ -292,7 +295,7 @@ onMounted(loadProfile)
             Благодарностей
           </div>
         </div>
-        <div class="bg-card rounded-3xl border p-4 text-center">
+        <div class="bg-card rounded-sm terminal-card border p-4 text-center">
           <div class="text-2xl font-bold">
             {{ stats.reviewsCount }}
           </div>
@@ -304,7 +307,7 @@ onMounted(loadProfile)
 
       <div
         v-if="profile.isMentor && profile.mentor"
-        class="bg-card rounded-3xl border p-6"
+        class="bg-card rounded-sm terminal-card border p-6"
       >
         <Typography
           variant="h3"
@@ -330,7 +333,7 @@ onMounted(loadProfile)
 
       <div
         v-if="achievements && achievements.unlockedCount > 0"
-        class="bg-card rounded-3xl border p-6"
+        class="bg-card rounded-sm terminal-card border p-6"
       >
         <div class="flex items-center gap-2 mb-4">
           <Award class="h-5 w-5 text-yellow-500" />

--- a/platform-frontend/src/pages/MentorProfile.vue
+++ b/platform-frontend/src/pages/MentorProfile.vue
@@ -37,6 +37,9 @@ onMounted(loadMentor)
 
 <template>
   <div class="container mx-auto px-4 py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/mentor-profile
+    </div>
     <RouterLink to="/mentors" class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-6">
       <ArrowLeft class="h-4 w-4" />
       Назад к менторам
@@ -49,7 +52,7 @@ onMounted(loadMentor)
     <ErrorState v-else-if="loadError" :message="loadError" @retry="loadMentor" />
 
     <div v-else-if="mentor" class="space-y-6">
-      <div class="bg-card rounded-3xl border p-6">
+      <div class="bg-card rounded-sm terminal-card border p-6">
         <Typography variant="h2" as="h1" class="mb-2">
           {{ mentor.firstName }} {{ mentor.lastName }}
         </Typography>
@@ -78,7 +81,7 @@ onMounted(loadMentor)
         </a>
       </div>
 
-      <div v-if="mentor.contacts?.length" class="bg-card rounded-3xl border p-6">
+      <div v-if="mentor.contacts?.length" class="bg-card rounded-sm terminal-card border p-6">
         <Typography variant="h3" as="h2" class="mb-4">
           Контакты
         </Typography>
@@ -91,7 +94,7 @@ onMounted(loadMentor)
         </div>
       </div>
 
-      <div v-if="mentor.services?.length" class="bg-card rounded-3xl border p-6">
+      <div v-if="mentor.services?.length" class="bg-card rounded-sm terminal-card border p-6">
         <Typography variant="h3" as="h2" class="mb-4">
           Услуги
         </Typography>
@@ -107,7 +110,7 @@ onMounted(loadMentor)
         </div>
       </div>
 
-      <div v-if="mentor.reviews?.length" class="bg-card rounded-3xl border p-6">
+      <div v-if="mentor.reviews?.length" class="bg-card rounded-sm terminal-card border p-6">
         <Typography variant="h3" as="h2" class="mb-4">
           Отзывы
         </Typography>
@@ -129,7 +132,7 @@ onMounted(loadMentor)
         </div>
       </div>
 
-      <div v-if="mentor.services?.length" class="bg-card rounded-3xl border p-6">
+      <div v-if="mentor.services?.length" class="bg-card rounded-sm terminal-card border p-6">
         <ReviewForm
           :mentor-id="mentor.id"
           :services="mentor.services"

--- a/platform-frontend/src/pages/Mentors.vue
+++ b/platform-frontend/src/pages/Mentors.vue
@@ -98,6 +98,9 @@ onMounted(loadMentors)
 
 <template>
   <div ref="containerRef" class="container mx-auto px-4 py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/mentors
+    </div>
     <Typography variant="h2" as="h1" class="mb-8">
       Менторы
     </Typography>

--- a/platform-frontend/src/pages/MyPoints.vue
+++ b/platform-frontend/src/pages/MyPoints.vue
@@ -159,6 +159,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/my-points
+    </div>
     <Typography
       variant="h2"
       as="h1"
@@ -176,7 +179,7 @@ onMounted(() => {
 
     <template v-else-if="data">
       <!-- Баланс -->
-      <div class="bg-card border border-border rounded-2xl p-6 mb-8 flex items-center gap-4">
+      <div class="bg-card border border-border rounded-sm terminal-card p-6 mb-8 flex items-center gap-4">
         <div class="flex items-center justify-center w-14 h-14 rounded-full bg-yellow-500/20">
           <Star class="h-7 w-7 text-yellow-500" />
         </div>
@@ -203,7 +206,7 @@ onMounted(() => {
           v-for="quest in quests"
           :key="quest.to"
           :to="quest.to"
-          class="flex items-center gap-3 rounded-2xl p-4 transition-colors"
+          class="flex items-center gap-3 rounded-sm p-4 transition-colors"
           :class="isQuestCompleted(quest.reason)
             ? 'bg-green-500/5 border border-green-500/30'
             : 'bg-card border border-border hover:border-primary/50'"
@@ -253,7 +256,7 @@ onMounted(() => {
         <div
           v-for="quest in weeklyQuests"
           :key="quest.reason"
-          class="flex items-center gap-3 rounded-2xl p-4 transition-colors"
+          class="flex items-center gap-3 rounded-sm p-4 transition-colors"
           :class="isQuestCompleted(quest.reason)
             ? 'bg-green-500/5 border border-green-500/30'
             : 'bg-card border border-border'"
@@ -303,7 +306,7 @@ onMounted(() => {
           <div
             v-for="quest in chatQuests"
             :key="quest.id"
-            class="rounded-2xl p-4 transition-colors"
+            class="rounded-sm p-4 transition-colors"
             :class="quest.completed
               ? 'bg-green-500/5 border border-green-500/30'
               : 'bg-card border border-border'"
@@ -370,7 +373,7 @@ onMounted(() => {
       >
         За что начисляются баллы
       </Typography>
-      <div class="bg-card border border-border rounded-2xl overflow-x-auto mb-8">
+      <div class="bg-card border border-border rounded-sm terminal-card overflow-x-auto mb-8">
         <table class="w-full text-sm min-w-[320px]">
           <thead>
             <tr class="border-b border-border">
@@ -418,7 +421,7 @@ onMounted(() => {
           <div
             v-for="tx in visibleTransactions"
             :key="tx.id"
-            class="flex items-center gap-4 p-4 bg-card border border-border rounded-2xl"
+            class="flex items-center gap-4 p-4 bg-card border border-border rounded-sm"
           >
             <div class="flex-1 min-w-0">
               <div class="font-medium text-sm truncate">

--- a/platform-frontend/src/pages/MyReviews.vue
+++ b/platform-frontend/src/pages/MyReviews.vue
@@ -97,6 +97,9 @@ onMounted(loadReviews)
 
 <template>
   <div class="container mx-auto px-4 py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/my-reviews
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -135,7 +138,7 @@ onMounted(loadReviews)
       <div
         v-for="review in reviews"
         :key="review.id"
-        class="bg-card border border-border rounded-2xl p-4"
+        class="bg-card border border-border rounded-sm p-4"
       >
         <div class="flex items-center justify-between mb-2">
           <span

--- a/platform-frontend/src/pages/MyStats.vue
+++ b/platform-frontend/src/pages/MyStats.vue
@@ -253,6 +253,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/my-stats
+    </div>
     <Typography
       variant="h2"
       as="h1"
@@ -265,7 +268,7 @@ onMounted(() => {
     <div v-if="isLoading" class="space-y-6">
       <!-- Summary row skeleton -->
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <div v-for="i in 3" :key="i" class="rounded-2xl border bg-card border-border p-4">
+        <div v-for="i in 3" :key="i" class="rounded-sm border bg-card border-border terminal-card p-4">
           <Skeleton class="h-3 w-20 rounded mb-2" />
           <Skeleton class="h-7 w-24 rounded-lg mb-1" />
           <Skeleton class="h-3 w-32 rounded" />
@@ -273,7 +276,7 @@ onMounted(() => {
       </div>
       <!-- Stat grid skeleton -->
       <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
-        <div v-for="i in 9" :key="i" class="rounded-2xl border bg-card border-border p-4">
+        <div v-for="i in 9" :key="i" class="rounded-sm border bg-card border-border terminal-card p-4">
           <div class="flex items-center gap-2 mb-2">
             <Skeleton class="w-8 h-8 rounded-lg" />
             <Skeleton class="h-3 w-20 rounded" />
@@ -282,7 +285,7 @@ onMounted(() => {
         </div>
       </div>
       <!-- Chart skeleton -->
-      <div class="rounded-2xl border bg-card border-border p-4">
+      <div class="rounded-sm border bg-card border-border terminal-card p-4">
         <Skeleton class="h-5 w-40 rounded mb-4" />
         <Skeleton class="h-40 w-full rounded-lg" />
       </div>
@@ -297,7 +300,7 @@ onMounted(() => {
     <template v-else-if="stats">
       <!-- Summary row -->
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
-        <div class="rounded-2xl border bg-card border-border p-4">
+        <div class="rounded-sm border bg-card border-border terminal-card p-4">
           <p class="text-xs text-muted-foreground mb-1">
             Участник с
           </p>
@@ -309,7 +312,7 @@ onMounted(() => {
           </p>
         </div>
 
-        <div class="rounded-2xl border bg-card border-border p-4">
+        <div class="rounded-sm border bg-card border-border terminal-card p-4">
           <p class="text-xs text-muted-foreground mb-1">
             Общая активность
           </p>
@@ -323,7 +326,7 @@ onMounted(() => {
 
         <div
           v-if="leaderboardPosition"
-          class="rounded-2xl border bg-card border-border p-4"
+          class="rounded-sm border bg-card border-border terminal-card p-4"
         >
           <p class="text-xs text-muted-foreground mb-1">
             Место в рейтинге
@@ -342,7 +345,7 @@ onMounted(() => {
         <div
           v-for="card in statCards"
           :key="card.label"
-          class="rounded-2xl border bg-card border-border p-4"
+          class="rounded-sm border bg-card border-border terminal-card p-4"
         >
           <div class="flex items-center gap-2 mb-2">
             <div
@@ -366,7 +369,7 @@ onMounted(() => {
       <!-- Points by source -->
       <div
         v-if="topSources.length > 0"
-        class="rounded-2xl border bg-card border-border p-4 mb-6"
+        class="rounded-sm border bg-card border-border terminal-card p-4 mb-6"
       >
         <div class="flex items-center gap-2 mb-4">
           <Star class="h-4 w-4 text-yellow-500" />
@@ -397,7 +400,7 @@ onMounted(() => {
       <!-- Achievements progress -->
       <div
         v-if="stats.achievementsTotal > 0"
-        class="rounded-2xl border bg-card border-border p-4 mb-6"
+        class="rounded-sm border bg-card border-border terminal-card p-4 mb-6"
       >
         <div class="flex items-center justify-between mb-3">
           <div class="flex items-center gap-2">
@@ -430,7 +433,7 @@ onMounted(() => {
       <!-- Points history chart -->
       <div
         v-if="stats.pointsHistory && stats.pointsHistory.length > 0"
-        class="rounded-2xl border bg-card border-border p-4 mb-6"
+        class="rounded-sm border bg-card border-border terminal-card p-4 mb-6"
       >
         <div class="flex items-center justify-between mb-4">
           <div class="flex items-center gap-2">
@@ -527,7 +530,7 @@ onMounted(() => {
       <!-- Contribution graph -->
       <div
         v-if="contributionWeeks.length > 0"
-        class="rounded-2xl border bg-card border-border p-4"
+        class="rounded-sm border bg-card border-border terminal-card p-4"
       >
         <div class="flex items-center justify-between mb-4">
           <div class="flex items-center gap-2">

--- a/platform-frontend/src/pages/Quests.vue
+++ b/platform-frontend/src/pages/Quests.vue
@@ -84,6 +84,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/quests
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -130,7 +133,7 @@ onMounted(() => {
         <div
           v-for="quest in filteredQuests"
           :key="quest.id"
-          class="rounded-3xl border bg-card p-5 transition-colors"
+          class="rounded-sm border bg-card p-5 transition-colors terminal-card"
           :class="quest.completed ? 'border-green-500/30 bg-green-500/5' : ''"
         >
           <div class="flex items-start gap-3">

--- a/platform-frontend/src/pages/Raffles.vue
+++ b/platform-frontend/src/pages/Raffles.vue
@@ -93,6 +93,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/raffles
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -151,7 +154,7 @@ onMounted(() => {
           <div
             v-for="raffle in activeRaffles"
             :key="raffle.id"
-            class="rounded-2xl border bg-card border-border p-5"
+            class="rounded-sm border bg-card border-border terminal-card p-5"
           >
             <div class="flex items-start justify-between mb-3">
               <div class="min-w-0">
@@ -235,7 +238,7 @@ onMounted(() => {
           <div
             v-for="raffle in finishedRaffles"
             :key="raffle.id"
-            class="rounded-2xl border bg-card border-border p-5 opacity-75"
+            class="rounded-sm border bg-card border-border terminal-card p-5 opacity-75"
           >
             <h3 class="font-semibold mb-1">
               {{ raffle.title }}

--- a/platform-frontend/src/pages/ReferalLinks.vue
+++ b/platform-frontend/src/pages/ReferalLinks.vue
@@ -109,6 +109,9 @@ function handleLinkDeleted(deletedLinkId: number) {
 
 <template>
   <div ref="containerRef" class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/referals
+    </div>
     <Typography variant="h2" as="h1" class="mb-4">
       Реферальные ссылки
     </Typography>
@@ -135,7 +138,7 @@ function handleLinkDeleted(deletedLinkId: number) {
     />
 
     <div v-else class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-      <div class="bg-card rounded-3xl border p-4 shadow-md ">
+      <div class="bg-card rounded-sm border p-4 shadow-md ">
         <button
           v-if="!showAddForm"
           type="button"
@@ -161,7 +164,7 @@ function handleLinkDeleted(deletedLinkId: number) {
         @deleted="handleLinkDeleted"
       />
 
-      <button v-if="referalLinks.length < totalLinks" type="button" class="bg-card rounded-3xl border p-4 hover:shadow-md flex justify-center items-center cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" :disabled="isLoadingMore" @click="loadMore">
+      <button v-if="referalLinks.length < totalLinks" type="button" class="bg-card rounded-sm border p-4 hover:shadow-md flex justify-center items-center cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" :disabled="isLoadingMore" @click="loadMore">
         <Loader2 v-if="isLoadingMore" class="h-5 w-5 animate-spin" />
         <span v-else class="m-auto">
           Показать ещё

--- a/platform-frontend/src/pages/Resumes.vue
+++ b/platform-frontend/src/pages/Resumes.vue
@@ -131,6 +131,9 @@ onMounted(loadResumes)
 <template>
   <div class="min-h-screen pt-20 pb-10">
     <div class="container mx-auto px-4 max-w-4xl">
+      <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+        ~/community/resumes
+      </div>
       <div class="flex items-center justify-between mb-6">
         <Typography
           variant="h2"
@@ -176,7 +179,7 @@ onMounted(loadResumes)
         <div
           v-for="resume in resumes"
           :key="resume.id"
-          class="rounded-3xl border bg-card p-4"
+          class="rounded-sm border bg-card p-4 terminal-card"
         >
           <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
             <div class="min-w-0 flex-1">

--- a/platform-frontend/src/pages/Seasons.vue
+++ b/platform-frontend/src/pages/Seasons.vue
@@ -68,6 +68,9 @@ onMounted(() => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/seasons
+    </div>
     <Typography
       variant="h2"
       as="h1"
@@ -116,7 +119,7 @@ onMounted(() => {
 
       <template v-else>
         <!-- Season info -->
-        <div class="rounded-2xl border bg-card border-border p-4 mb-6">
+        <div class="rounded-sm border bg-card border-border p-4 mb-6 terminal-card">
           <div class="flex items-center justify-between">
             <div>
               <h3 class="font-semibold text-lg">

--- a/platform-frontend/src/pages/TaskExchange.vue
+++ b/platform-frontend/src/pages/TaskExchange.vue
@@ -371,6 +371,9 @@ watch(showEditDialog, (open) => {
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/task-exchange
+    </div>
     <div class="flex items-center justify-between mb-6">
       <Typography
         variant="h2"
@@ -439,7 +442,7 @@ watch(showEditDialog, (open) => {
         <div
           v-for="task in filteredTasks"
           :key="task.id"
-          class="rounded-2xl p-4 border bg-card border-border"
+          class="rounded-sm p-4 border bg-card border-border terminal-card"
         >
           <div class="flex items-start justify-between gap-2 mb-2">
             <h3 class="font-medium text-sm leading-tight break-words min-w-0">

--- a/platform-frontend/src/pages/User.vue
+++ b/platform-frontend/src/pages/User.vue
@@ -42,6 +42,9 @@ const quickLinks = [
 
 <template>
   <div class="container mx-auto px-4 py-6 md:py-8">
+    <div class="font-mono text-[11px] text-muted-foreground/60 tracking-wider mb-2">
+      ~/community/profile
+    </div>
     <Typography variant="h2" as="h1" class="mb-6">
       Мой профиль
     </Typography>
@@ -52,7 +55,7 @@ const quickLinks = [
         v-for="link in quickLinks"
         :key="link.path"
         :to="link.path"
-        class="flex flex-col items-center gap-1.5 rounded-2xl border bg-card p-3 sm:p-4 hover:bg-muted/50 hover:border-accent/30 transition-all text-center"
+        class="flex flex-col items-center gap-1.5 rounded-sm border bg-card p-3 sm:p-4 hover:bg-muted/50 hover:border-accent/30 transition-all text-center"
       >
         <component :is="link.icon" class="h-5 w-5 text-muted-foreground" />
         <span class="text-[10px] sm:text-xs text-muted-foreground leading-tight">{{ link.title }}</span>

--- a/platform-frontend/tailwind.config.cjs
+++ b/platform-frontend/tailwind.config.cjs
@@ -16,49 +16,53 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
       },
       colors: {
-        border: 'hsl(var(--border) / <alpha-value>)',
-        input: 'hsl(var(--input) / <alpha-value>)',
-        ring: 'hsl(var(--ring) / <alpha-value>)',
-        background: 'hsl(var(--background) / <alpha-value>)',
-        foreground: 'hsl(var(--foreground) / <alpha-value>)',
-        primary: {
+        'term-amber': '#ffb547',
+        'term-magenta': '#ff4d8b',
+        'term-cyan': '#5eead4',
+        'border': 'hsl(var(--border) / <alpha-value>)',
+        'input': 'hsl(var(--input) / <alpha-value>)',
+        'ring': 'hsl(var(--ring) / <alpha-value>)',
+        'background': 'hsl(var(--background) / <alpha-value>)',
+        'foreground': 'hsl(var(--foreground) / <alpha-value>)',
+        'primary': {
           DEFAULT: 'hsl(var(--primary) / <alpha-value>)',
           foreground: 'hsl(var(--primary-foreground) / <alpha-value>)',
         },
-        secondary: {
+        'secondary': {
           DEFAULT: 'hsl(var(--secondary) / <alpha-value>)',
           foreground: 'hsl(var(--secondary-foreground) / <alpha-value>)',
         },
-        destructive: {
+        'destructive': {
           DEFAULT: 'hsl(var(--destructive) / <alpha-value>)',
           foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)',
         },
-        muted: {
+        'muted': {
           DEFAULT: 'hsl(var(--muted) / <alpha-value>)',
           foreground: 'hsl(var(--muted-foreground) / <alpha-value>)',
         },
-        accent: {
+        'accent': {
           DEFAULT: 'hsl(var(--accent) / <alpha-value>)',
           foreground: 'hsl(var(--accent-foreground) / <alpha-value>)',
         },
-        popover: {
+        'popover': {
           DEFAULT: 'hsl(var(--popover) / <alpha-value>)',
           foreground: 'hsl(var(--popover-foreground) / <alpha-value>)',
         },
-        card: {
+        'card': {
           DEFAULT: 'hsl(var(--card) / <alpha-value>)',
           foreground: 'hsl(var(--card-foreground) / <alpha-value>)',
         },
-        chart: {
+        'chart': {
           1: 'hsl(var(--chart-1) / <alpha-value>)',
           2: 'hsl(var(--chart-2) / <alpha-value>)',
           3: 'hsl(var(--chart-3) / <alpha-value>)',
           4: 'hsl(var(--chart-4) / <alpha-value>)',
           5: 'hsl(var(--chart-5) / <alpha-value>)',
         },
-        sidebar: {
+        'sidebar': {
           'DEFAULT': 'hsl(var(--sidebar) / <alpha-value>)',
           'foreground': 'hsl(var(--sidebar-foreground) / <alpha-value>)',
           'primary': 'hsl(var(--sidebar-primary) / <alpha-value>)',


### PR DESCRIPTION
## Summary
Применяет terminal/brutalist визуальный стиль к platform-frontend для консистентности с лендингом (#218).

**Изменения:**
- **Design tokens**: JetBrains Mono, terminal accent colors (amber/magenta/cyan), grid-фон для dark mode
- **`.terminal-card`**: sharp corners (2px), bracket accents на hover, glow shadow
- **Card.vue**: `rounded-3xl shadow` → `rounded-sm terminal-card` (глобально все карточки)
- **Sidebar**: `[SYS] IT-X` header, `//` group labels, mono-индексы на пунктах
- **Header**: green dot + `ONLINE` status indicator
- **Footer**: terminal links (`./менторы`), `status: operational`
- **Dashboard**: date prompt, `[01]`-`[05]` section markers, sharp cards

## Test plan
- [ ] 682/682 тестов проходят (`npm test`)
- [ ] `npm run build` — без ошибок
- [ ] Dark mode: grid background + terminal cards видны
- [ ] Light mode: карточки не ломаются (terminal-card стиль для dark only)
- [ ] Sidebar на мобилке: меню открывается/закрывается
- [ ] Dashboard: все секции отображаются с новыми стилями
- [ ] Hover на карточки: bracket corners появляются