### PR TITLE
feat(landing): интерактивные анимации terminal-лендинга

### DIFF
--- a/landing-frontend/public/sitemap.xml
+++ b/landing-frontend/public/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ithozyaeva.ru/</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ithozyaeva.ru/privacy</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/landing-frontend/src/App.vue
+++ b/landing-frontend/src/App.vue
@@ -2,10 +2,18 @@
 import CookiesBanner from '@/components/CookiesBanner.vue'
 import Footer from '@/components/Footer.vue'
 import Header from '@/components/Header.vue'
+import { useScrollProgress } from '@/composables/useScrollProgress'
+
+const { progress } = useScrollProgress()
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col">
+    <!-- Scroll progress bar -->
+    <div
+      class="fixed top-0 left-0 h-[2px] bg-accent z-[60] origin-left transition-none"
+      :style="{ transform: `scaleX(${progress})` }"
+    />
     <Header />
     <main>
       <router-view />

--- a/landing-frontend/src/assets/base.css
+++ b/landing-frontend/src/assets/base.css
@@ -230,6 +230,153 @@ html {
   overflow: hidden;
 }
 
+/* ===== Scroll-reveal animations ===== */
+.reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+              filter 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+  filter: blur(4px);
+  will-change: opacity, transform, filter;
+}
+.reveal.revealed {
+  opacity: 1;
+  transform: translateY(0);
+  filter: blur(0);
+}
+
+/* staggered children */
+.reveal-stagger > .reveal-child {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.reveal-stagger.revealed > .reveal-child {
+  opacity: 1;
+  transform: translateY(0);
+}
+.reveal-stagger.revealed > .reveal-child:nth-child(1) { transition-delay: 0ms; }
+.reveal-stagger.revealed > .reveal-child:nth-child(2) { transition-delay: 120ms; }
+.reveal-stagger.revealed > .reveal-child:nth-child(3) { transition-delay: 240ms; }
+.reveal-stagger.revealed > .reveal-child:nth-child(4) { transition-delay: 360ms; }
+.reveal-stagger.revealed > .reveal-child:nth-child(5) { transition-delay: 480ms; }
+.reveal-stagger.revealed > .reveal-child:nth-child(6) { transition-delay: 600ms; }
+
+/* slide from left/right */
+.reveal-left {
+  opacity: 0;
+  transform: translateX(-60px);
+  transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.reveal-left.revealed {
+  opacity: 1;
+  transform: translateX(0);
+}
+.reveal-right {
+  opacity: 0;
+  transform: translateX(60px);
+  transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.reveal-right.revealed {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* ===== Glitch title effect ===== */
+.glitch-hover {
+  position: relative;
+  cursor: default;
+}
+.glitch-hover::before,
+.glitch-hover::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+.glitch-hover::before {
+  color: #ff4d8b;
+  clip-path: polygon(0 0, 100% 0, 100% 45%, 0 45%);
+}
+.glitch-hover::after {
+  color: #5eead4;
+  clip-path: polygon(0 55%, 100% 55%, 100% 100%, 0 100%);
+}
+.glitch-hover:hover::before {
+  opacity: 0.7;
+  animation: glitch-shift-1 0.3s steps(2) infinite;
+}
+.glitch-hover:hover::after {
+  opacity: 0.7;
+  animation: glitch-shift-2 0.3s steps(2) infinite;
+}
+@keyframes glitch-shift-1 {
+  0% { transform: translate(0); }
+  25% { transform: translate(-3px, 1px); }
+  50% { transform: translate(2px, -1px); }
+  75% { transform: translate(-1px, 2px); }
+  100% { transform: translate(0); }
+}
+@keyframes glitch-shift-2 {
+  0% { transform: translate(0); }
+  25% { transform: translate(3px, -1px); }
+  50% { transform: translate(-2px, 1px); }
+  75% { transform: translate(1px, -2px); }
+  100% { transform: translate(0); }
+}
+
+/* ===== Border trace on hover ===== */
+.trace-border {
+  position: relative;
+  overflow: hidden;
+}
+.trace-border::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+  pointer-events: none;
+  transition: border-color 0.3s;
+}
+.trace-border::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, hsl(var(--accent)), transparent);
+  transition: none;
+}
+.trace-border:hover::after {
+  animation: trace-top 0.6s ease-out forwards;
+}
+@keyframes trace-top {
+  from { left: -100%; }
+  to { left: 100%; }
+}
+
+/* ===== Glow pulse on CTA ===== */
+.cta-glow {
+  position: relative;
+  transition: box-shadow 0.3s ease, transform 0.2s ease;
+}
+.cta-glow:hover {
+  box-shadow: 0 0 20px hsl(var(--accent) / 0.4), 0 0 60px hsl(var(--accent) / 0.15);
+  transform: translateY(-1px);
+}
+.cta-glow:active {
+  transform: translateY(0);
+  box-shadow: 0 0 10px hsl(var(--accent) / 0.3);
+}
+
 /* ensure header/content stay above the scanline overlay */
 header, main, footer, section { position: relative; z-index: 2; }
 

--- a/landing-frontend/src/components/Footer.vue
+++ b/landing-frontend/src/components/Footer.vue
@@ -49,7 +49,7 @@ function trackJointimerClick() {
           <span class="hidden sm:inline text-[#0b0d0c]/70">[06] ~/join</span>
         </div>
 
-        <h2 class="font-display uppercase text-[38px] sm:text-[56px] md:text-[80px] lg:text-[104px] leading-[0.9] tracking-tight text-[#0b0d0c]">
+        <h2 class="reveal font-display uppercase text-[38px] sm:text-[56px] md:text-[80px] lg:text-[104px] leading-[0.9] tracking-tight text-[#0b0d0c]">
           Стань<br>
           <span class="text-[#0b0d0c]/50">IT-хозяином</span>
         </h2>

--- a/landing-frontend/src/composables/useCountUp.ts
+++ b/landing-frontend/src/composables/useCountUp.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue'
+
+export function useCountUp(target: number, duration = 1800) {
+  const value = ref(0)
+  const started = ref(false)
+
+  function start() {
+    if (started.value)
+      return
+    started.value = true
+    const startTime = performance.now()
+    const ease = (t: number) => 1 - (1 - t) ** 3
+
+    function tick(now: number) {
+      const elapsed = now - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      value.value = Math.round(ease(progress) * target)
+      if (progress < 1)
+        requestAnimationFrame(tick)
+    }
+    requestAnimationFrame(tick)
+  }
+
+  return { value, start }
+}

--- a/landing-frontend/src/composables/useMagneticHover.ts
+++ b/landing-frontend/src/composables/useMagneticHover.ts
@@ -1,0 +1,35 @@
+import type { Ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+export function useMagneticHover(elRef: Ref<HTMLElement | null>, strength = 0.35) {
+  const x = ref(0)
+  const y = ref(0)
+
+  function onMove(e: MouseEvent) {
+    const el = elRef.value
+    if (!el)
+      return
+    const rect = el.getBoundingClientRect()
+    const cx = rect.left + rect.width / 2
+    const cy = rect.top + rect.height / 2
+    x.value = (e.clientX - cx) * strength
+    y.value = (e.clientY - cy) * strength
+  }
+
+  function onLeave() {
+    x.value = 0
+    y.value = 0
+  }
+
+  onMounted(() => {
+    elRef.value?.addEventListener('mousemove', onMove)
+    elRef.value?.addEventListener('mouseleave', onLeave)
+  })
+
+  onUnmounted(() => {
+    elRef.value?.removeEventListener('mousemove', onMove)
+    elRef.value?.removeEventListener('mouseleave', onLeave)
+  })
+
+  return { x, y }
+}

--- a/landing-frontend/src/composables/useRevealObserver.ts
+++ b/landing-frontend/src/composables/useRevealObserver.ts
@@ -1,0 +1,25 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export function useRevealObserver() {
+  let observer: IntersectionObserver | null = null
+
+  onMounted(() => {
+    observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting)
+            entry.target.classList.add('revealed')
+        })
+      },
+      { threshold: 0.08, rootMargin: '0px 0px -40px 0px' },
+    )
+
+    document.querySelectorAll('.reveal, .reveal-left, .reveal-right, .reveal-stagger').forEach((el) => {
+      observer!.observe(el)
+    })
+  })
+
+  onUnmounted(() => {
+    observer?.disconnect()
+  })
+}

--- a/landing-frontend/src/composables/useScrollProgress.ts
+++ b/landing-frontend/src/composables/useScrollProgress.ts
@@ -1,0 +1,15 @@
+import { onMounted, onUnmounted, ref } from 'vue'
+
+export function useScrollProgress() {
+  const progress = ref(0)
+
+  function update() {
+    const h = document.documentElement.scrollHeight - window.innerHeight
+    progress.value = h > 0 ? Math.min(window.scrollY / h, 1) : 0
+  }
+
+  onMounted(() => window.addEventListener('scroll', update, { passive: true }))
+  onUnmounted(() => window.removeEventListener('scroll', update))
+
+  return { progress }
+}

--- a/landing-frontend/src/pages/Main.vue
+++ b/landing-frontend/src/pages/Main.vue
@@ -2,12 +2,15 @@
 import { computed } from 'vue'
 import StructuredData from '@/components/StructuredData.vue'
 import { usePageMeta } from '@/composables/useMeta'
+import { useRevealObserver } from '@/composables/useRevealObserver'
 import CalendarSection from '@/sections/CalendarSection.vue'
 import FAQSection from '@/sections/FAQSection.vue'
 import MentorsSection from '@/sections/MentorsSection.vue'
 import PromoteSection from '@/sections/PromoteSection.vue'
 import TariffSection from '@/sections/TariffSection.vue'
 import WhySection from '@/sections/WhySection.vue'
+
+useRevealObserver()
 
 usePageMeta({
   title: 'IT-ХОЗЯЕВА - закрытое сообщество IT-специалистов с менторами',

--- a/landing-frontend/src/sections/CalendarSection.vue
+++ b/landing-frontend/src/sections/CalendarSection.vue
@@ -78,12 +78,14 @@ onMounted(loadEvents)
     class="w-full pt-20 md:pt-32 lg:pt-40"
   >
     <div class="container px-6 md:px-10">
-      <SectionHeader
-        index="03"
-        path="~/community/events.log"
-        title="Расписание"
-        subtitle="Еженедельные онлайн-встречи. Скачивай в календарь — пропустить будет нельзя."
-      />
+      <div class="reveal">
+        <SectionHeader
+          index="03"
+          path="~/community/events.log"
+          title="Расписание"
+          subtitle="Еженедельные онлайн-встречи. Скачивай в календарь — пропустить будет нельзя."
+        />
+      </div>
 
       <Typography
         v-if="!hasFutureEvents"

--- a/landing-frontend/src/sections/FAQSection.vue
+++ b/landing-frontend/src/sections/FAQSection.vue
@@ -38,14 +38,16 @@ function toggle(i: number) {
     class="w-full py-20 md:py-32 lg:py-40"
   >
     <div class="container px-6 md:px-10">
-      <SectionHeader
-        index="05"
-        path="~/community/faq.txt"
-        title="Частые вопросы"
-        subtitle="Ответы на популярные вопросы о сообществе IT-ХОЗЯЕВА."
-      />
+      <div class="reveal">
+        <SectionHeader
+          index="05"
+          path="~/community/faq.txt"
+          title="Частые вопросы"
+          subtitle="Ответы на популярные вопросы о сообществе IT-ХОЗЯЕВА."
+        />
+      </div>
 
-      <div class="mt-12 md:mt-16 border border-accent/20 bg-background/60 backdrop-blur-sm">
+      <div class="mt-12 md:mt-16 border border-accent/20 bg-background/60 backdrop-blur-sm reveal">
         <div
           v-for="(q, i) in questions"
           :key="q.title"

--- a/landing-frontend/src/sections/MentorsSection.vue
+++ b/landing-frontend/src/sections/MentorsSection.vue
@@ -155,12 +155,14 @@ onMounted(fetchMentors)
         v-else
         class="flex flex-col gap-10 md:gap-14"
       >
-        <SectionHeader
-          index="02"
-          path="~/community/mentors.db"
-          title="База менторов"
-          subtitle="Эксперты сообщества, готовые поделиться опытом. Фильтруй по направлению — найди своего."
-        />
+        <div class="reveal">
+          <SectionHeader
+            index="02"
+            path="~/community/mentors.db"
+            title="База менторов"
+            subtitle="Эксперты сообщества, готовые поделиться опытом. Фильтруй по направлению — найди своего."
+          />
+        </div>
 
         <div class="flex flex-col gap-3 items-start">
           <div class="font-mono text-[11px] text-foreground/40 tracking-[0.1em] uppercase">

--- a/landing-frontend/src/sections/PromoteSection.vue
+++ b/landing-frontend/src/sections/PromoteSection.vue
@@ -4,6 +4,8 @@ import { onMounted, onUnmounted, ref } from 'vue'
 import { useYandexMetrika } from 'yandex-metrika-vue3'
 import TelegramAuth from '@/components/TelegramAuth.vue'
 import Button from '@/components/ui/UiButton.vue'
+import { useCountUp } from '@/composables/useCountUp'
+import { useMagneticHover } from '@/composables/useMagneticHover'
 import { useToken } from '@/composables/useToken.ts'
 import { useUser } from '@/composables/useUser.ts'
 
@@ -23,7 +25,6 @@ function trackPlatformClick() {
   } as any)
 }
 
-// Typewriter effect for the tagline
 const phrases = [
   'менторство_',
   'vibe_coding_',
@@ -59,7 +60,6 @@ function tick() {
   }
 }
 
-// Live "uptime" counter
 const uptime = ref('00:00:00')
 let uptimeTimer: number | undefined
 const started = Date.now()
@@ -71,10 +71,34 @@ function updateUptime() {
   uptime.value = `${h}:${m}:${s}`
 }
 
+// Count-up stats
+const stat1 = useCountUp(250, 2000)
+const stat2 = useCountUp(60, 1800)
+const stat3 = useCountUp(7, 1200)
+
+// Magnetic hover on CTA wrapper
+const ctaRef = ref<HTMLElement | null>(null)
+const { x: magX, y: magY } = useMagneticHover(ctaRef, 0.3)
+
+// Hero entrance animation
+const heroReady = ref(false)
+
 onMounted(() => {
   tick()
   updateUptime()
   uptimeTimer = window.setInterval(updateUptime, 1000)
+
+  // Staggered entrance
+  requestAnimationFrame(() => {
+    heroReady.value = true
+  })
+
+  // Start count-ups after a delay
+  setTimeout(() => {
+    stat1.start()
+    stat2.start()
+    stat3.start()
+  }, 600)
 })
 
 onUnmounted(() => {
@@ -99,26 +123,31 @@ const companies = ['Яндекс', 'Tinkoff', 'VK', 'Ozon', 'Wildberries', 'Ав
     />
     <div
       aria-hidden="true"
-      class="pointer-events-none absolute top-[18%] right-[6%] hidden lg:block"
+      class="pointer-events-none absolute top-[18%] right-[6%] hidden lg:block crosshair-spin"
     >
-      <div class="w-[520px] h-[520px] rounded-full border border-accent/10 animate-[glitch-x_6s_steps(1)_infinite]">
-        <div class="absolute inset-8 rounded-full border border-accent/15" />
+      <div class="w-[520px] h-[520px] rounded-full border border-accent/10">
+        <div class="absolute inset-8 rounded-full border border-accent/15 crosshair-spin-reverse" />
         <div class="absolute inset-20 rounded-full border border-accent/20" />
-        <div class="absolute inset-32 rounded-full border border-accent/25" />
+        <div class="absolute inset-32 rounded-full border border-accent/25 crosshair-spin-reverse" />
         <div class="absolute top-1/2 left-0 right-0 h-px bg-accent/20" />
         <div class="absolute left-1/2 top-0 bottom-0 w-px bg-accent/20" />
+        <!-- Scanning dot -->
+        <div class="absolute w-2 h-2 bg-accent rounded-full top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 shadow-[0_0_12px_hsl(var(--accent))] scan-dot" />
       </div>
     </div>
 
     <!-- Terminal status bar -->
-    <div class="container px-6 md:px-10 pt-8 md:pt-12 relative z-10">
+    <div
+      class="container px-6 md:px-10 pt-8 md:pt-12 relative z-10 transition-all duration-700"
+      :class="heroReady ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'"
+    >
       <div class="flex items-center justify-between font-mono text-[11px] md:text-xs tracking-[0.08em] text-foreground/50">
         <div class="flex items-center gap-4 md:gap-6">
           <div class="flex items-center gap-1.5">
-            <span class="w-2 h-2 rounded-full bg-accent shadow-[0_0_8px_hsl(var(--accent))]" />
+            <span class="w-2 h-2 rounded-full bg-accent shadow-[0_0_8px_hsl(var(--accent))] animate-pulse" />
             <span class="text-accent">ONLINE</span>
           </div>
-          <span class="hidden sm:inline">uptime: <span class="text-foreground/80">{{ uptime }}</span></span>
+          <span class="hidden sm:inline">uptime: <span class="text-foreground/80 tabular-nums">{{ uptime }}</span></span>
           <span class="hidden md:inline">v4.2.1</span>
         </div>
         <div class="flex items-center gap-4 md:gap-6">
@@ -131,19 +160,33 @@ const companies = ['Яндекс', 'Tinkoff', 'VK', 'Ozon', 'Wildberries', 'Ав
     <!-- Main hero content -->
     <div class="container px-6 md:px-10 flex-1 flex items-center py-12 md:py-16 relative z-10">
       <div class="w-full max-w-5xl">
-        <div class="font-mono text-xs md:text-sm text-foreground/50 mb-5 md:mb-6">
+        <!-- Prompt line -->
+        <div
+          class="font-mono text-xs md:text-sm text-foreground/50 mb-5 md:mb-6 transition-all duration-700 delay-100"
+          :class="heroReady ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'"
+        >
           <span class="text-accent">community@ithozyaeva</span>:<span class="text-term-amber">~</span>$
           <span class="text-foreground/80">./welcome --new-user</span>
         </div>
 
-        <div class="flex items-baseline gap-2 md:gap-3 mb-1">
+        <!-- Main title with glitch -->
+        <div
+          class="flex items-baseline gap-2 md:gap-3 mb-1 transition-all duration-700 delay-200"
+          :class="heroReady ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'"
+        >
           <span class="font-mono text-accent/60 text-sm md:text-base">&gt;</span>
-          <h1 class="font-display uppercase text-[38px] xs:text-[46px] sm:text-[68px] md:text-[96px] lg:text-[130px] leading-[0.85] tracking-tight text-accent">
+          <h1
+            class="glitch-hover font-display uppercase text-[38px] xs:text-[46px] sm:text-[68px] md:text-[96px] lg:text-[130px] leading-[0.85] tracking-tight text-accent"
+            data-text="IT-ХОЗЯЕВА"
+          >
             IT-ХОЗЯЕВА
           </h1>
         </div>
 
-        <div class="pl-4 md:pl-6 border-l border-accent/30 mt-6 md:mt-8 max-w-3xl">
+        <div
+          class="pl-4 md:pl-6 border-l border-accent/30 mt-6 md:mt-8 max-w-3xl transition-all duration-700 delay-300"
+          :class="heroReady ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'"
+        >
           <h2 class="font-display uppercase text-[22px] sm:text-[32px] md:text-[42px] leading-[1.05] text-foreground">
             Закрытое сообщество<br>
             <span class="text-foreground/40">IT-специалистов</span>
@@ -162,50 +205,63 @@ const companies = ['Яндекс', 'Tinkoff', 'VK', 'Ozon', 'Wildberries', 'Ав
           </p>
         </div>
 
-        <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6 mt-8 md:mt-12">
-          <TelegramAuth
-            v-if="!tgUser"
-            @auth="setUser"
-          />
-          <Button
-            v-else
-            variant="filled"
-            as="a"
-            href="/platform"
-            rel="noopener noreferrer"
-            @click="trackPlatformClick"
-          >
-            Перейти в платформу
-          </Button>
+        <!-- CTA with magnetic hover -->
+        <div
+          ref="ctaRef"
+          class="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6 mt-8 md:mt-12 transition-all duration-700 delay-[400ms]"
+          :class="heroReady ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'"
+          :style="{ transform: heroReady ? `translate(${magX}px, ${magY}px)` : undefined }"
+        >
+          <div class="cta-glow rounded-[50px]">
+            <TelegramAuth
+              v-if="!tgUser"
+              @auth="setUser"
+            />
+            <Button
+              v-else
+              variant="filled"
+              as="a"
+              href="/platform"
+              rel="noopener noreferrer"
+              @click="trackPlatformClick"
+            >
+              Перейти в платформу
+            </Button>
+          </div>
           <a
             href="#why"
-            class="font-mono text-xs md:text-sm text-foreground/50 hover:text-accent transition-colors flex items-center gap-2"
+            class="font-mono text-xs md:text-sm text-foreground/50 hover:text-accent transition-colors flex items-center gap-2 group"
           >
-            <span class="text-accent">$</span> ./scroll-down --see-more
+            <span class="text-accent group-hover:animate-pulse">$</span>
+            <span>./scroll-down --see-more</span>
+            <span class="inline-block transition-transform group-hover:translate-y-0.5">↓</span>
           </a>
         </div>
 
-        <!-- Stats strip -->
-        <div class="mt-10 md:mt-16 grid grid-cols-3 max-w-2xl divide-x divide-accent/15 border-t border-b border-accent/15">
+        <!-- Stats strip with count-up -->
+        <div
+          class="mt-10 md:mt-16 grid grid-cols-3 max-w-2xl divide-x divide-accent/15 border-t border-b border-accent/15 transition-all duration-700 delay-500"
+          :class="heroReady ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'"
+        >
           <div class="py-4 pr-4">
-            <div class="font-display text-2xl md:text-4xl text-accent">
-              250+
+            <div class="font-display text-2xl md:text-4xl text-accent tabular-nums">
+              {{ stat1.value.value }}+
             </div>
             <div class="font-mono text-[10px] md:text-xs text-foreground/50 uppercase mt-1 tracking-widest">
               участников
             </div>
           </div>
           <div class="py-4 px-4">
-            <div class="font-display text-2xl md:text-4xl text-accent">
-              60+
+            <div class="font-display text-2xl md:text-4xl text-accent tabular-nums">
+              {{ stat2.value.value }}+
             </div>
             <div class="font-mono text-[10px] md:text-xs text-foreground/50 uppercase mt-1 tracking-widest">
               менторов
             </div>
           </div>
           <div class="py-4 pl-4">
-            <div class="font-display text-2xl md:text-4xl text-accent">
-              7×
+            <div class="font-display text-2xl md:text-4xl text-accent tabular-nums">
+              {{ stat3.value.value }}×
             </div>
             <div class="font-mono text-[10px] md:text-xs text-foreground/50 uppercase mt-1 tracking-widest">
               встреч в мес.
@@ -216,17 +272,17 @@ const companies = ['Яндекс', 'Tinkoff', 'VK', 'Ozon', 'Wildberries', 'Ав
     </div>
 
     <!-- Marquee of companies -->
-    <div class="relative z-10 border-t border-accent/15 bg-background/40 backdrop-blur-sm overflow-hidden py-4">
+    <div class="relative z-10 border-t border-accent/15 bg-background/40 backdrop-blur-sm overflow-hidden py-4 group/marquee">
       <div class="flex items-center gap-3 font-mono text-[10px] md:text-xs tracking-[0.2em] uppercase">
         <div class="px-4 md:px-10 shrink-0 text-accent/70">
           // команды из:
         </div>
         <div class="flex-1 overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
-          <div class="flex gap-10 animate-marquee whitespace-nowrap will-change-transform">
+          <div class="flex gap-10 animate-marquee group-hover/marquee:[animation-play-state:paused] whitespace-nowrap will-change-transform">
             <span
               v-for="(c, i) in [...companies, ...companies]"
               :key="i"
-              class="text-foreground/60 hover:text-accent transition-colors"
+              class="text-foreground/60 hover:text-accent transition-colors cursor-default"
             >
               {{ c }} <span class="text-accent/30 ml-10">◇</span>
             </span>
@@ -242,5 +298,30 @@ const companies = ['Яндекс', 'Tinkoff', 'VK', 'Ozon', 'Wildberries', 'Ав
   .xs\:text-\[46px\] {
     font-size: 46px;
   }
+}
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Crosshair slow spin */
+.crosshair-spin {
+  animation: spin-slow 90s linear infinite;
+}
+.crosshair-spin-reverse {
+  animation: spin-slow 60s linear infinite reverse;
+}
+@keyframes spin-slow {
+  to { transform: rotate(360deg); }
+}
+
+/* Scanning dot on crosshair */
+.scan-dot {
+  animation: scan-orbit 4s ease-in-out infinite;
+}
+@keyframes scan-orbit {
+  0%, 100% { transform: translate(-50%, -50%) translateX(0); }
+  25% { transform: translate(-50%, -50%) translate(80px, -80px); }
+  50% { transform: translate(-50%, -50%) translate(0, -120px); }
+  75% { transform: translate(-50%, -50%) translate(-80px, -40px); }
 }
 </style>

--- a/landing-frontend/src/sections/TariffSection.vue
+++ b/landing-frontend/src/sections/TariffSection.vue
@@ -83,12 +83,14 @@ const { containerRef, isVisible } = useScrollReveal({ threshold: 0.05 })
     class="w-full pt-20 md:pt-32 lg:pt-40"
   >
     <div class="container px-6 md:px-10">
-      <SectionHeader
-        index="04"
-        path="~/community/access.sh"
-        title="Уровни доступа"
-        subtitle="Подписка через Boosty. План можно повысить или понизить в любой момент."
-      />
+      <div class="reveal">
+        <SectionHeader
+          index="04"
+          path="~/community/access.sh"
+          title="Уровни доступа"
+          subtitle="Подписка через Boosty. План можно повысить или понизить в любой момент."
+        />
+      </div>
 
       <div class="grid pt-14 md:pt-16 md:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-6 items-stretch">
         <div

--- a/landing-frontend/src/sections/WhySection.vue
+++ b/landing-frontend/src/sections/WhySection.vue
@@ -48,18 +48,20 @@ const features: Feature[] = [
     class="w-full pt-20 md:pt-32 lg:pt-40"
   >
     <div class="container px-6 md:px-10">
-      <SectionHeader
-        index="01"
-        path="~/community/why.md"
-        title="Зачем вступать?"
-        subtitle="IT-сообщество 250+ специалистов на стыке технологий и искусственного интеллекта: менторство, вайбкодинг, нетворкинг, подготовка к собеседованиям, обмен вакансиями и еженедельные встречи."
-      />
+      <div class="reveal">
+        <SectionHeader
+          index="01"
+          path="~/community/why.md"
+          title="Зачем вступать?"
+          subtitle="IT-сообщество 250+ специалистов на стыке технологий и искусственного интеллекта: менторство, вайбкодинг, нетворкинг, подготовка к собеседованиям, обмен вакансиями и еженедельные встречи."
+        />
+      </div>
 
-      <div class="mt-12 md:mt-16 grid grid-cols-1 md:grid-cols-2 gap-px bg-accent/15">
+      <div class="mt-12 md:mt-16 grid grid-cols-1 md:grid-cols-2 gap-px bg-accent/15 reveal-stagger">
         <article
           v-for="(feature, i) in features"
           :key="feature.id"
-          class="relative group p-7 md:p-10 bg-background/95 hover:bg-accent/5 transition-colors duration-300 min-h-[280px] flex flex-col justify-between cursor-default"
+          class="reveal-child trace-border relative group p-7 md:p-10 bg-background/95 hover:bg-accent/5 transition-colors duration-300 min-h-[280px] flex flex-col justify-between cursor-default"
         >
           <!-- Tag row -->
           <div class="flex items-start justify-between gap-4">


### PR DESCRIPTION
## Summary
Добавляет слой интерактивности поверх terminal/brutalist редизайна лендинга (#218):

- **Scroll-reveal**: все секции плавно появляются при скролле (blur → clear, translateY → 0)
- **Staggered cards**: 4 карточки WhySection каскадом с задержкой 120ms
- **Glitch hover**: наведение на "IT-ХОЗЯЕВА" — хроматический сдвиг (magenta + cyan)
- **Count-up stats**: числа 250+/60+/7× считают с нуля при загрузке (easeOutCubic)
- **Magnetic CTA**: кнопка/виджет тянется за курсором (strength 0.3)
- **Crosshair rotation**: кольца вращаются в разные стороны + orbit dot
- **Scroll progress**: зелёная полоска `scaleX` вверху страницы
- **Marquee pause**: `animation-play-state: paused` на hover
- **Trace border**: световая полоса по верху карточки при наведении
- **Hero entrance**: каскадная staggered анимация (status → prompt → title → subtitle → CTA → stats)

Новые composables: `useCountUp`, `useMagneticHover`, `useRevealObserver`, `useScrollProgress`

## Test plan
- [ ] Hero: typewriter, count-up, magnetic CTA работают
- [ ] Скролл: секции плавно появляются
- [ ] Hover на "IT-ХОЗЯЕВА": glitch effect
- [ ] Hover на marquee: пауза
- [ ] `prefers-reduced-motion`: все анимации off
- [ ] Мобилка 375px: нет горизонтального скролла