### PR TITLE
fix: Telegram deeplink — tg:// для авторизации из РФ

### DIFF
--- a/landing-frontend/public/sitemap.xml
+++ b/landing-frontend/public/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ithozyaeva.ru/</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ithozyaeva.ru/privacy</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-04-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/landing-frontend/src/components/ConfirmServiceModal.vue
+++ b/landing-frontend/src/components/ConfirmServiceModal.vue
@@ -20,12 +20,11 @@ const yandexMetrika = useYandexMetrika()
 function handleConfirmed() {
   isConfirmedPrivacy.value = true
   emit('close')
-  const botUrl = authService.getBotUrl()
   yandexMetrika.reachGoal('privacy_modal_accept', {
     action: 'accept',
   } as any)
-  yandexMetrika.extLink(botUrl, { title: 'Стать IT-Хозяином (после модалки)' })
-  window.open(botUrl, '_blank')
+  yandexMetrika.extLink(authService.getBotUrl(), { title: 'Стать IT-Хозяином (после модалки)' })
+  authService.openBot()
 }
 
 function handleClose() {

--- a/landing-frontend/src/components/TelegramAuth.vue
+++ b/landing-frontend/src/components/TelegramAuth.vue
@@ -40,12 +40,11 @@ onMounted(() => {
 
 function handleClick() {
   if (isConfirmedPrivacy.value) {
-    const botUrl = authService.getBotUrl()
     yandexMetrika.reachGoal('become_itx_owner_click', {
       location: props.variant || 'default',
     } as any)
-    yandexMetrika.extLink(botUrl, { title: 'Стать IT-Хозяином' })
-    window.open(botUrl, '_blank')
+    yandexMetrika.extLink(authService.getBotUrl(), { title: 'Стать IT-Хозяином' })
+    authService.openBot()
   }
   else {
     isModalOpen.value = true

--- a/landing-frontend/src/services/auth.ts
+++ b/landing-frontend/src/services/auth.ts
@@ -28,4 +28,24 @@ export const authService = {
   getBotUrl(): string {
     return `https://t.me/${import.meta.env.VITE_TELEGRAM_BOT_NAME}?start=from_site`
   },
+
+  getDeepLinkUrl(): string {
+    return `tg://resolve?domain=${import.meta.env.VITE_TELEGRAM_BOT_NAME}&start=from_site`
+  },
+
+  openBot(): void {
+    const deepLink = this.getDeepLinkUrl()
+    const webLink = this.getBotUrl()
+
+    // Пробуем открыть через tg:// (работает без VPN если Telegram установлен)
+    const start = Date.now()
+    window.location.href = deepLink
+
+    // Если через 2 секунды страница не ушла — Telegram не установлен, fallback на t.me
+    setTimeout(() => {
+      if (Date.now() - start < 3000) {
+        window.open(webLink, '_blank')
+      }
+    }, 2000)
+  },
 }


### PR DESCRIPTION
## Summary
t.me заблокирован в РФ → кнопка авторизации не работала.

Новый flow:
1. `tg://resolve?domain=itx_welcome_bot&start=from_site` — открывает Telegram app напрямую, без браузера
2. Если через 2 сек не сработало (Telegram не установлен) — fallback на `https://t.me/`

## Test plan
- [ ] Нажать "Стать IT-хозяином" — открывается Telegram app
- [ ] Без Telegram — через 2 сек открывается t.me в новой вкладке
- [ ] Privacy modal тоже использует deeplink