### PR TITLE
fix: 5s таймаут на Telegram API при авторизации

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -1541,10 +1541,12 @@ func sendAuthToBackend(token string, user *tgbotapi.User) {
 	log.Println("Ответ от Fiber:", resp.Status)
 }
 
+var telegramHTTPClient = &http.Client{Timeout: 5 * time.Second}
+
 func CheckUserInChat(userID int64) (bool, error) {
 	telegramApiUrl := fmt.Sprintf("https://api.telegram.org/bot%s/getChatMember?chat_id=%d&user_id=%d", config.CFG.TelegramToken, config.CFG.TelegramMainChatID, userID)
 
-	resp, err := http.Get(telegramApiUrl)
+	resp, err := telegramHTTPClient.Get(telegramApiUrl)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary
- `CheckUserInChat` использовал `http.Get` (дефолтный клиент без таймаута) — на РФ-сервере запрос к заблокированному `api.telegram.org` висел 30 секунд
- Заменён на `telegramHTTPClient` с `Timeout: 5 * time.Second`
- В связке с PR #217 (skip role update при ошибке) авторизация теперь проходит за ~5 сек вместо ~30 сек

## Test plan
- [ ] Авторизация на ithozyaeva.ru/platform — загружается за 5-6 секунд вместо 30+
- [ ] `go build ./...` — без ошибок