### PR TITLE
feat: автоматическая загрузка Telegram-аватарок в S3

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -2,8 +2,10 @@ package bot
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -17,6 +19,7 @@ import (
 	"ithozyeva/internal/models"
 	"ithozyeva/internal/repository"
 	"ithozyeva/internal/service"
+	"ithozyeva/internal/utils"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/redis/go-redis/v9"
@@ -606,7 +609,7 @@ func (b *TelegramBot) handleStartCommand(message *tgbotapi.Message) {
 	// Формируем URL для перенаправления с токеном
 	authUrl := fmt.Sprintf("%s?token=%s", redirectUrl, token)
 
-	sendAuthToBackend(token, message.From)
+	sendAuthToBackend(b.bot, token, message.From)
 
 	// Отправляем сообщение с кнопкой для авторизации
 	msg := tgbotapi.NewMessage(message.Chat.ID, "Нажмите кнопку ниже для авторизации")
@@ -1482,9 +1485,57 @@ type AuthRequest struct {
 	FirstName string      `json:"first_name"`
 	LastName  string      `json:"last_name"`
 	Role      models.Role `json:"role"`
+	AvatarURL string      `json:"avatar_url,omitempty"`
 }
 
-func sendAuthToBackend(token string, user *tgbotapi.User) {
+func downloadTelegramAvatar(botAPI *tgbotapi.BotAPI, userID int64) ([]byte, error) {
+	photos, err := botAPI.GetUserProfilePhotos(tgbotapi.UserProfilePhotosConfig{
+		UserID: userID,
+		Limit:  1,
+	})
+	if err != nil || photos.TotalCount == 0 {
+		return nil, fmt.Errorf("no profile photos: %v", err)
+	}
+
+	sizes := photos.Photos[0]
+	fileID := sizes[len(sizes)-1].FileID
+
+	file, err := botAPI.GetFile(tgbotapi.FileConfig{FileID: fileID})
+	if err != nil {
+		return nil, fmt.Errorf("getFile failed: %v", err)
+	}
+
+	fileURL := file.Link(botAPI.Token)
+	resp, err := telegramHTTPClient.Get(fileURL)
+	if err != nil {
+		return nil, fmt.Errorf("download failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read failed: %v", err)
+	}
+	return data, nil
+}
+
+func uploadAvatarToS3(userID int64, photoData []byte) (string, error) {
+	s3Client, err := utils.NewS3Client()
+	if err != nil {
+		return "", fmt.Errorf("s3 client: %v", err)
+	}
+
+	key := fmt.Sprintf("avatars/%d/telegram.jpg", userID)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if err := s3Client.Upload(ctx, key, photoData, "image/jpeg"); err != nil {
+		return "", fmt.Errorf("s3 upload: %v", err)
+	}
+	return key, nil
+}
+
+func sendAuthToBackend(botAPI *tgbotapi.BotAPI, token string, user *tgbotapi.User) {
 	isSubcriber, err := CheckUserInChat(user.ID)
 	if err != nil {
 		log.Println("Ошибка проверки пользователя в чате:", err)
@@ -1497,6 +1548,20 @@ func sendAuthToBackend(token string, user *tgbotapi.User) {
 		role = models.MemberRoleUnsubscriber
 	}
 
+	var avatarURL string
+	photoData, err := downloadTelegramAvatar(botAPI, user.ID)
+	if err != nil {
+		log.Printf("Avatar download skipped for user %d: %v", user.ID, err)
+	} else {
+		key, err := uploadAvatarToS3(user.ID, photoData)
+		if err != nil {
+			log.Printf("Avatar S3 upload failed for user %d: %v", user.ID, err)
+		} else {
+			avatarURL = key
+			log.Printf("Avatar uploaded to S3 for user %d: %s", user.ID, key)
+		}
+	}
+
 	data := AuthRequest{
 		Token:     token,
 		UserID:    user.ID,
@@ -1504,6 +1569,7 @@ func sendAuthToBackend(token string, user *tgbotapi.User) {
 		FirstName: user.FirstName,
 		LastName:  user.LastName,
 		Role:      role,
+		AvatarURL: avatarURL,
 	}
 
 	jsonData, err := json.Marshal(data)

--- a/backend/internal/handler/auth_token.go
+++ b/backend/internal/handler/auth_token.go
@@ -151,6 +151,7 @@ type HandleBotMessageReq struct {
 	FirstName string      `json:"first_name"`
 	LastName  string      `json:"last_name"`
 	Role      models.Role `json:"role"`
+	AvatarURL string      `json:"avatar_url"`
 }
 
 func (h *TelegramAuthHandler) HandleBotMessage(c *fiber.Ctx) error {
@@ -184,6 +185,7 @@ func (h *TelegramAuthHandler) HandleBotMessage(c *fiber.Ctx) error {
 			Username:   req.Username,
 			FirstName:  req.FirstName,
 			LastName:   req.LastName,
+			AvatarURL:  req.AvatarURL,
 			Roles:      []models.Role{role},
 		}
 
@@ -198,6 +200,9 @@ func (h *TelegramAuthHandler) HandleBotMessage(c *fiber.Ctx) error {
 		existingUser.Username = req.Username
 		existingUser.FirstName = req.FirstName
 		existingUser.LastName = req.LastName
+		if req.AvatarURL != "" {
+			existingUser.AvatarURL = req.AvatarURL
+		}
 		h.memberService.Update(existingUser)
 
 		_, err := h.authService.CreateOrUpdateToken(req.UserID, req.Token)


### PR DESCRIPTION
## Summary
При авторизации через бота (`/start`) аватарка пользователя автоматически скачивается из Telegram API и загружается в S3.

**Flow:**
1. Бот (NL, Telegram API доступен) вызывает `getUserProfilePhotos` → берёт самое большое фото
2. Скачивает файл через `getFile` → download
3. Загружает в S3 как `avatars/{telegramID}/telegram.jpg`
4. Передаёт S3-ключ в `POST /api/auth/telegram-from-bot` через поле `avatar_url`
5. Бэкенд сохраняет `avatar_url` в таблицу `members`
6. `AfterFind()` hook автоматически резолвит S3-ключ в presigned URL
7. Фронтенды уже используют `avatarUrl` — аватарки появятся без изменений фронта

**Если у пользователя нет фото или загрузка упала** — graceful degradation, авторизация проходит без аватарки.

## Test plan
- [ ] `/start` в боте → авторизация → аватарка видна на платформе
- [ ] Пользователь без фото в Telegram → авторизация проходит, placeholder
- [ ] S3 недоступен → авторизация проходит, лог ошибки
- [ ] `go build ./...` — без ошибок