### PR TITLE
fix: header overflow на средних экранах

### DIFF
--- a/landing-frontend/src/components/Header.vue
+++ b/landing-frontend/src/components/Header.vue
@@ -61,7 +61,7 @@ onUnmounted(() => {
     :class="{ 'bg-background/80 backdrop-blur-[25px] border-b border-accent/15': isScrolled, 'bg-transparent backdrop-blur-0 border-b border-transparent': !isScrolled }"
   >
     <div class="container px-6 md:px-10 flex gap-5 h-[var(--header-height)] items-center justify-between md:justify-between">
-      <div class="flex items-center gap-4 lg:gap-10">
+      <div class="flex items-center gap-3 lg:gap-8 min-w-0">
         <a
           href="/"
           class="flex items-center gap-3 font-bold text-xl group"
@@ -78,7 +78,7 @@ onUnmounted(() => {
       </div>
       <div
         v-if="!isMobile"
-        class="flex justify-end "
+        class="flex justify-end shrink-0"
       >
         <TelegramAuth
           v-if="!tgUser"

--- a/landing-frontend/src/sections/Navigation.vue
+++ b/landing-frontend/src/sections/Navigation.vue
@@ -8,17 +8,17 @@ const menuItems = [
 </script>
 
 <template>
-  <nav class="flex gap-1 md:gap-3 lg:gap-6">
+  <nav class="flex gap-0.5 md:gap-1 lg:gap-4">
     <a
       v-for="item in menuItems"
       :key="item.href"
       :href="item.href"
-      class="group relative px-2 py-2 lg:px-3 lg:py-2 flex items-center gap-2 text-foreground/70 hover:text-accent transition-colors"
+      class="group relative px-1.5 py-2 lg:px-3 lg:py-2 flex items-center gap-1.5 text-foreground/70 hover:text-accent transition-colors"
     >
-      <span class="font-mono text-[10px] opacity-40 group-hover:opacity-100 transition-opacity">
+      <span class="font-mono text-[10px] opacity-40 group-hover:opacity-100 transition-opacity hidden lg:inline">
         [{{ item.id }}]
       </span>
-      <span class="font-display uppercase text-sm lg:text-base tracking-wide">
+      <span class="font-display uppercase text-xs lg:text-base tracking-wide">
         {{ item.label }}
       </span>
       <span class="absolute left-2 right-2 bottom-0.5 h-px bg-accent scale-x-0 origin-left group-hover:scale-x-100 transition-transform duration-300" />


### PR DESCRIPTION
## Summary
Кнопка «Перейти в платформу» уезжала за правый край на экранах 1024-1200px.

- Nav индексы `[02]`-`[05]` скрыты на md, видны на lg+
- Уменьшены gap/padding в навигации
- CTA кнопка: `shrink-0`

## Test plan
- [ ] 1024px — кнопка видна полностью
- [ ] 1440px — индексы [02]-[05] видны
- [ ] Мобилка — навигация скрыта, бургер работает