### PR TITLE
fix: фильтры менторов на лендинге не кликабельны

### DIFF
--- a/landing-frontend/src/components/ui/UiTag.vue
+++ b/landing-frontend/src/components/ui/UiTag.vue
@@ -43,7 +43,6 @@ defineProps<{
 .ui-tag.default {
   outline: 1px solid var(--color-green-700);
   background-color: transparent;
-  pointer-events: none;
 }
 
 .ui-tag.default:hover:not(.disabled) {


### PR DESCRIPTION
UiTag.vue default variant имел `pointer-events: none` — неактивные теги не реагировали на клики. Убрано.