### PR TITLE
fix: Docker context для доступа к packages/ui

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+pgdata
+certbot
+static
+docs
+*.md
+*.tsv
+platform-fix-results.tsv
+**/node_modules
+**/dist
+**/.vite

--- a/admin-frontend/Dockerfile
+++ b/admin-frontend/Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /app
 ARG VITE_TELEGRAM_BOT_NAME
 ENV VITE_TELEGRAM_BOT_NAME=${VITE_TELEGRAM_BOT_NAME}
 
-COPY package*.json ./
+COPY packages/ui/ /packages/ui/
+
+COPY admin-frontend/package*.json ./
 
 RUN npm install
 
 ARG CACHEBUST=1
-COPY . .
+COPY admin-frontend/ .
 
 RUN npm run build
 
-# Очищаем старую статику и копируем свежую сборку
 CMD ["sh", "-c", "rm -rf /static/admin-frontend/* && cp -r /app/dist/* /static/admin-frontend/"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -168,7 +168,8 @@ services:
   platform-frontend:
     container_name: ${CONTAINER_PREFIX:-}platform-frontend
     build:
-      context: ./platform-frontend
+      context: .
+      dockerfile: platform-frontend/Dockerfile
       args:
         - VITE_TELEGRAM_BOT_NAME=${VITE_TELEGRAM_BOT_NAME}
         - CACHEBUST=${CACHEBUST:-1}
@@ -180,7 +181,8 @@ services:
   admin-frontend:
     container_name: ${CONTAINER_PREFIX:-}admin-frontend
     build:
-      context: ./admin-frontend
+      context: .
+      dockerfile: admin-frontend/Dockerfile
       args:
         - VITE_TELEGRAM_BOT_NAME=${VITE_TELEGRAM_BOT_NAME}
         - CACHEBUST=${CACHEBUST:-1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,8 @@ services:
   platform-frontend:
     container_name: platform-frontend
     build:
-      context: ./platform-frontend
+      context: .
+      dockerfile: platform-frontend/Dockerfile
     volumes:
       - ./static/platform-frontend:/static/platform-frontend
     networks:
@@ -85,7 +86,8 @@ services:
   admin-frontend:
     container_name: admin-frontend
     build:
-      context: ./admin-frontend
+      context: .
+      dockerfile: admin-frontend/Dockerfile
     volumes:
       - ./static/admin-frontend:/static/admin-frontend
     depends_on:

--- a/platform-frontend/Dockerfile
+++ b/platform-frontend/Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /app
 ARG VITE_TELEGRAM_BOT_NAME
 ENV VITE_TELEGRAM_BOT_NAME=${VITE_TELEGRAM_BOT_NAME}
 
-COPY package*.json ./
+COPY packages/ui/ /packages/ui/
+
+COPY platform-frontend/package*.json ./
 
 RUN npm install
 
 ARG CACHEBUST=1
-COPY . .
+COPY platform-frontend/ .
 
 RUN npm run build
 
-# Очищаем старую статику и копируем свежую сборку
 CMD ["sh", "-c", "rm -rf /static/platform-frontend/* && cp -r /app/dist/* /static/platform-frontend/"]


### PR DESCRIPTION
## Summary

- Docker build context для admin-frontend и platform-frontend перенесён на корень монорепо — иначе Dockerfile не видит `packages/ui/`
- Обновлены Dockerfile обоих фронтендов: копируют `packages/ui/` в `/packages/ui/`
- Добавлен `.dockerignore` для исключения лишнего из контекста
- Обновлены оба docker-compose (prod + local)

## Test plan

- [ ] CI проходит
- [ ] Деплой раскатывает новый дизайн