### PR TITLE
fix: whitelist .dockerignore для корневого Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,13 @@
-.git
-pgdata
-certbot
-static
-docs
-*.md
-*.tsv
-platform-fix-results.tsv
+# Exclude everything by default
+*
+
+# Include only what frontend builds need
+!packages/ui/
+!admin-frontend/
+!platform-frontend/
+!landing-frontend/
+
+# Exclude heavy dirs inside included paths
 **/node_modules
 **/dist
 **/.vite


### PR DESCRIPTION
## Summary

- `.dockerignore` переведён на whitelist-подход: исключает всё (`*`), затем включает только `packages/ui/`, `admin-frontend/`, `platform-frontend/`, `landing-frontend/`
- Это убирает `backend/`, `.git/`, `pgdata/` и прочее из Docker context — раньше tar ломался на файлах backend

## Test plan

- [ ] CI проходит
- [ ] Deploy раскатывает новый дизайн