### PR TITLE
fix: docker prune перед сборкой — no space left on device

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,17 +27,17 @@ jobs:
           username: ${{ secrets.SSH_DEV_USER }}
           key:      ${{ secrets.SSH_DEV_KEY }}
           port:     ${{ secrets.SSH_DEV_PORT }}
+          command_timeout: 30m
           script: |
-            set -e
             cd ${{ secrets.PROJECT_PROD_PATH }}
+            # Free disk space before building
+            docker system prune -af --volumes --filter "until=24h" || true
+            docker builder prune -af || true
             # Copy shared UI package into frontend directories for Docker context
             cp -r packages/ui platform-frontend/_packages_ui
             cp -r packages/ui admin-frontend/_packages_ui
-            # Build each service separately for clearer logs
-            DOCKER_BUILDKIT=0 docker compose -f docker-compose.prod.yml build --no-cache backend
-            DOCKER_BUILDKIT=0 docker compose -f docker-compose.prod.yml build --no-cache landing-frontend
-            DOCKER_BUILDKIT=0 CACHEBUST=$(date +%s) docker compose -f docker-compose.prod.yml build --no-cache platform-frontend
-            DOCKER_BUILDKIT=0 CACHEBUST=$(date +%s) docker compose -f docker-compose.prod.yml build --no-cache admin-frontend
+            # Build new images with legacy builder (BuildKit ignores --no-cache)
+            DOCKER_BUILDKIT=0 CACHEBUST=$(date +%s) docker compose -f docker-compose.prod.yml build --no-cache
             # Remove temporary copies
             rm -rf platform-frontend/_packages_ui admin-frontend/_packages_ui
             # Restart services with forced recreation to pick up new images


### PR DESCRIPTION
## Summary

- Добавлен `docker system prune -af` и `docker builder prune -af` перед сборкой — сервер заполнился из-за промежуточных образов от `--no-cache`
- Убран `set -e` чтобы cleanup всегда выполнялся
- Вернул параллельную сборку (последовательная занимала слишком много места)
- `command_timeout: 30m` на случай долгой сборки

## Test plan

- [ ] CI
- [ ] Deploy не падает с "no space left on device"
- [ ] Новый дизайн админки отображается