### PR TITLE
fix: docker prune перед git fetch — диск заполнен

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,6 +16,9 @@ jobs:
           key:      ${{ secrets.SSH_DEV_KEY }}
           port:     ${{ secrets.SSH_DEV_PORT }}
           script: |
+            # Free disk space first
+            docker system prune -af || true
+            docker builder prune -af || true
             cd ${{ secrets.PROJECT_PROD_PATH }}
             git fetch --all
             git reset --hard origin/master
@@ -30,9 +33,6 @@ jobs:
           command_timeout: 30m
           script: |
             cd ${{ secrets.PROJECT_PROD_PATH }}
-            # Free disk space before building
-            docker system prune -af --volumes --filter "until=24h" || true
-            docker builder prune -af || true
             # Copy shared UI package into frontend directories for Docker context
             cp -r packages/ui platform-frontend/_packages_ui
             cp -r packages/ui admin-frontend/_packages_ui


### PR DESCRIPTION
## Summary

Сервер заполнился Docker образами. `git fetch` падает с `No space left on device`. 
Перенёс `docker system prune -af` и `docker builder prune -af` в самое начало — до `git fetch`.

## Test plan

- [ ] CI
- [ ] Deploy проходит (git fetch + docker build)