### PR TITLE
fix: light mode контраст — тёмный sidebar, усиленные границы

### DIFF
--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -16,7 +16,7 @@
     --secondary-foreground: 150 6% 12%;
 
     --muted: 151 5% 90%;
-    --muted-foreground: 151 5% 45%;
+    --muted-foreground: 151 5% 38%;
 
     --accent: 151 60% 54%;
     --accent-foreground: 150 6% 12%;
@@ -24,8 +24,8 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 151 8% 85%;
-    --input: 151 8% 85%;
+    --border: 151 8% 80%;
+    --input: 151 8% 80%;
     --ring: 151 60% 54%;
 
     --radius: 0.75rem;
@@ -36,13 +36,13 @@
     --chart-4: 151 20% 60%;
     --chart-5: 151 50% 70%;
 
-    --sidebar: 0 0% 100%;
-    --sidebar-foreground: 150 6% 12%;
-    --sidebar-primary: 150 6% 12%;
-    --sidebar-primary-foreground: 0 0% 97%;
-    --sidebar-accent: 151 8% 92%;
-    --sidebar-accent-foreground: 150 6% 12%;
-    --sidebar-border: 151 8% 85%;
+    --sidebar: 150 6% 12%;
+    --sidebar-foreground: 0 0% 89%;
+    --sidebar-primary: 151 60% 54%;
+    --sidebar-primary-foreground: 150 6% 12%;
+    --sidebar-accent: 150 6% 18%;
+    --sidebar-accent-foreground: 0 0% 97%;
+    --sidebar-border: 150 6% 20%;
     --sidebar-ring: 151 60% 54%;
   }
 


### PR DESCRIPTION
## Summary

- Sidebar в light mode теперь тёмный (как было до миграции) — текст и группы хорошо видны
- `--muted-foreground` усилен: 45% → 38% для лучшей читаемости
- `--border` и `--input` усилены: 85% → 80% для более заметных границ

## Test plan

- [ ] CI
- [ ] Light mode: sidebar тёмный, текст виден
- [ ] Dark mode: без изменений
- [ ] Переключение темы работает