### PR TITLE
fix: CSS @import — относительные пути для PostCSS

### DIFF
--- a/admin-frontend/src/assets/main.css
+++ b/admin-frontend/src/assets/main.css
@@ -2,8 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '@itx/ui/styles/tokens.css';
-@import '@itx/ui/styles/terminal.css';
+@import '../../../packages/ui/src/styles/tokens.css';
+@import '../../../packages/ui/src/styles/terminal.css';
 
 .terminal-table {
   border-radius: 2px !important;

--- a/platform-frontend/src/index.css
+++ b/platform-frontend/src/index.css
@@ -2,5 +2,5 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '@itx/ui/styles/tokens.css';
-@import '@itx/ui/styles/terminal.css';
+@import '../../packages/ui/src/styles/tokens.css';
+@import '../../packages/ui/src/styles/terminal.css';


### PR DESCRIPTION
## Summary

PostCSS `@import` не резолвит Vite aliases (`@itx/ui`). Токены и terminal.css не попадали в билд — sidebar и все цвета не работали. Заменено на относительные пути.

## Test plan

- [ ] CI 
- [ ] Sidebar тёмный в light mode, цвета работают