### PR TITLE
fix: инлайн CSS токены вместо @import

### DIFF
--- a/admin-frontend/src/assets/main.css
+++ b/admin-frontend/src/assets/main.css
@@ -2,8 +2,238 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '../../../packages/ui/src/styles/tokens.css';
-@import '../../../packages/ui/src/styles/terminal.css';
+/* === Design Tokens (from packages/ui) === */
+
+@layer base {
+  :root {
+    --background: 0 0% 97%;
+    --foreground: 150 6% 12%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 150 6% 12%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 150 6% 12%;
+
+    --primary: 150 6% 12%;
+    --primary-foreground: 0 0% 97%;
+
+    --secondary: 151 8% 92%;
+    --secondary-foreground: 150 6% 12%;
+
+    --muted: 151 5% 90%;
+    --muted-foreground: 151 5% 38%;
+
+    --accent: 151 60% 54%;
+    --accent-foreground: 150 6% 12%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 151 8% 80%;
+    --input: 151 8% 80%;
+    --ring: 151 60% 54%;
+
+    --radius: 0.75rem;
+
+    --chart-1: 151 60% 54%;
+    --chart-2: 151 40% 40%;
+    --chart-3: 151 30% 30%;
+    --chart-4: 151 20% 60%;
+    --chart-5: 151 50% 70%;
+
+    --sidebar: 150 6% 12%;
+    --sidebar-foreground: 0 0% 89%;
+    --sidebar-primary: 151 60% 54%;
+    --sidebar-primary-foreground: 150 6% 12%;
+    --sidebar-accent: 150 6% 18%;
+    --sidebar-accent-foreground: 0 0% 97%;
+    --sidebar-border: 150 6% 20%;
+    --sidebar-ring: 151 60% 54%;
+  }
+
+  .dark {
+    --background: 151 5% 8%;
+    --foreground: 0 0% 89%;
+
+    --card: 150 6% 12%;
+    --card-foreground: 0 0% 100%;
+
+    --popover: 150 6% 12%;
+    --popover-foreground: 0 0% 100%;
+
+    --primary: 0 0% 89%;
+    --primary-foreground: 150 6% 12%;
+
+    --secondary: 151 5% 16%;
+    --secondary-foreground: 0 0% 89%;
+
+    --muted: 151 5% 16%;
+    --muted-foreground: 0 0% 100% / 0.5;
+
+    --accent: 151 60% 54%;
+    --accent-foreground: 150 6% 12%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 151 5% 20%;
+    --input: 151 5% 20%;
+    --ring: 151 60% 54%;
+
+    --chart-1: 151 60% 54%;
+    --chart-2: 151 40% 50%;
+    --chart-3: 151 30% 40%;
+    --chart-4: 151 20% 70%;
+    --chart-5: 151 50% 60%;
+
+    --sidebar: 150 6% 10%;
+    --sidebar-foreground: 0 0% 89%;
+    --sidebar-primary: 151 60% 54%;
+    --sidebar-primary-foreground: 150 6% 12%;
+    --sidebar-accent: 151 5% 16%;
+    --sidebar-accent-foreground: 0 0% 89%;
+    --sidebar-border: 151 5% 20%;
+    --sidebar-ring: 151 60% 54%;
+  }
+}
+
+/* === Terminal Utilities (from packages/ui) === */
+
+.font-mono-ui {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-feature-settings: 'ss01', 'cv11';
+}
+
+.terminal-card {
+  border-radius: 2px !important;
+  border: 1px solid hsl(var(--border));
+  position: relative;
+  transition: border-color 250ms ease, box-shadow 250ms ease;
+}
+
+.dark .terminal-card {
+  background: linear-gradient(180deg, hsl(151 5% 11% / 0.95), hsl(151 5% 9% / 0.95));
+}
+
+.terminal-card::before,
+.terminal-card::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-color: hsl(var(--accent));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.terminal-card::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+.terminal-card::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+}
+.terminal-card:hover::before,
+.terminal-card:hover::after {
+  opacity: 1;
+}
+.terminal-card:hover {
+  border-color: hsl(var(--accent) / 0.5);
+  box-shadow: 0 0 0 1px hsl(var(--accent) / 0.1), 0 15px 40px -20px hsl(var(--accent) / 0.25);
+}
+
+.terminal-stat {
+  border-radius: 2px !important;
+  border: 1px solid hsl(var(--border));
+  position: relative;
+  overflow: hidden;
+}
+
+.terminal-stat::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: hsl(var(--accent));
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+
+.terminal-stat:hover::before {
+  opacity: 1;
+}
+
+.dark .terminal-stat {
+  background: linear-gradient(180deg, hsl(151 5% 11% / 0.95), hsl(151 5% 9% / 0.95));
+}
+
+.dark body {
+  background-image:
+    linear-gradient(to right, hsl(151 5% 15% / 0.15) 1px, transparent 1px),
+    linear-gradient(to bottom, hsl(151 5% 15% / 0.15) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--border)) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--border));
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+[data-reveal] {
+  opacity: 0;
+  filter: blur(4px);
+  transform: translateY(60px) scale(0.95);
+}
+
+/* === Admin-specific utilities === */
 
 .terminal-table {
   border-radius: 2px !important;

--- a/platform-frontend/src/index.css
+++ b/platform-frontend/src/index.css
@@ -2,5 +2,233 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '../../packages/ui/src/styles/tokens.css';
-@import '../../packages/ui/src/styles/terminal.css';
+/* === Design Tokens (from packages/ui) === */
+
+@layer base {
+  :root {
+    --background: 0 0% 97%;
+    --foreground: 150 6% 12%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 150 6% 12%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 150 6% 12%;
+
+    --primary: 150 6% 12%;
+    --primary-foreground: 0 0% 97%;
+
+    --secondary: 151 8% 92%;
+    --secondary-foreground: 150 6% 12%;
+
+    --muted: 151 5% 90%;
+    --muted-foreground: 151 5% 38%;
+
+    --accent: 151 60% 54%;
+    --accent-foreground: 150 6% 12%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 151 8% 80%;
+    --input: 151 8% 80%;
+    --ring: 151 60% 54%;
+
+    --radius: 0.75rem;
+
+    --chart-1: 151 60% 54%;
+    --chart-2: 151 40% 40%;
+    --chart-3: 151 30% 30%;
+    --chart-4: 151 20% 60%;
+    --chart-5: 151 50% 70%;
+
+    --sidebar: 150 6% 12%;
+    --sidebar-foreground: 0 0% 89%;
+    --sidebar-primary: 151 60% 54%;
+    --sidebar-primary-foreground: 150 6% 12%;
+    --sidebar-accent: 150 6% 18%;
+    --sidebar-accent-foreground: 0 0% 97%;
+    --sidebar-border: 150 6% 20%;
+    --sidebar-ring: 151 60% 54%;
+  }
+
+  .dark {
+    --background: 151 5% 8%;
+    --foreground: 0 0% 89%;
+
+    --card: 150 6% 12%;
+    --card-foreground: 0 0% 100%;
+
+    --popover: 150 6% 12%;
+    --popover-foreground: 0 0% 100%;
+
+    --primary: 0 0% 89%;
+    --primary-foreground: 150 6% 12%;
+
+    --secondary: 151 5% 16%;
+    --secondary-foreground: 0 0% 89%;
+
+    --muted: 151 5% 16%;
+    --muted-foreground: 0 0% 100% / 0.5;
+
+    --accent: 151 60% 54%;
+    --accent-foreground: 150 6% 12%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 151 5% 20%;
+    --input: 151 5% 20%;
+    --ring: 151 60% 54%;
+
+    --chart-1: 151 60% 54%;
+    --chart-2: 151 40% 50%;
+    --chart-3: 151 30% 40%;
+    --chart-4: 151 20% 70%;
+    --chart-5: 151 50% 60%;
+
+    --sidebar: 150 6% 10%;
+    --sidebar-foreground: 0 0% 89%;
+    --sidebar-primary: 151 60% 54%;
+    --sidebar-primary-foreground: 150 6% 12%;
+    --sidebar-accent: 151 5% 16%;
+    --sidebar-accent-foreground: 0 0% 89%;
+    --sidebar-border: 151 5% 20%;
+    --sidebar-ring: 151 60% 54%;
+  }
+}
+
+/* === Terminal Utilities (from packages/ui) === */
+
+.font-mono-ui {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-feature-settings: 'ss01', 'cv11';
+}
+
+.terminal-card {
+  border-radius: 2px !important;
+  border: 1px solid hsl(var(--border));
+  position: relative;
+  transition: border-color 250ms ease, box-shadow 250ms ease;
+}
+
+.dark .terminal-card {
+  background: linear-gradient(180deg, hsl(151 5% 11% / 0.95), hsl(151 5% 9% / 0.95));
+}
+
+.terminal-card::before,
+.terminal-card::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-color: hsl(var(--accent));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.terminal-card::before {
+  top: -1px; left: -1px;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+.terminal-card::after {
+  bottom: -1px; right: -1px;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+}
+.terminal-card:hover::before,
+.terminal-card:hover::after {
+  opacity: 1;
+}
+.terminal-card:hover {
+  border-color: hsl(var(--accent) / 0.5);
+  box-shadow: 0 0 0 1px hsl(var(--accent) / 0.1), 0 15px 40px -20px hsl(var(--accent) / 0.25);
+}
+
+.terminal-stat {
+  border-radius: 2px !important;
+  border: 1px solid hsl(var(--border));
+  position: relative;
+  overflow: hidden;
+}
+
+.terminal-stat::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: hsl(var(--accent));
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+
+.terminal-stat:hover::before {
+  opacity: 1;
+}
+
+.dark .terminal-stat {
+  background: linear-gradient(180deg, hsl(151 5% 11% / 0.95), hsl(151 5% 9% / 0.95));
+}
+
+.dark body {
+  background-image:
+    linear-gradient(to right, hsl(151 5% 15% / 0.15) 1px, transparent 1px),
+    linear-gradient(to bottom, hsl(151 5% 15% / 0.15) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--border)) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--border));
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+[data-reveal] {
+  opacity: 0;
+  filter: blur(4px);
+  transform: translateY(60px) scale(0.95);
+}


### PR DESCRIPTION
## Summary

`@import` из `packages/ui` не работает в Docker (PostCSS не резолвит пути за пределами build context). Инлайнил все CSS tokens и terminal utilities напрямую в main.css обоих фронтендов.

## Test plan

- [ ] CI
- [ ] Стили работают в light и dark mode
- [ ] Sidebar тёмный, карточки с terminal-card, цвета видны