### PR TITLE
chore(ci): bot deploy command_timeout 30m

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -29,6 +29,7 @@ jobs:
           username: ${{ secrets.SSH_BOT_USER }}
           key:      ${{ secrets.SSH_BOT_KEY }}
           port:     ${{ secrets.SSH_BOT_PORT }}
+          command_timeout: 30m
           script: |
             cd /opt/itx-bot
             docker compose build --no-cache platform-bot


### PR DESCRIPTION
Дефолтные 10m appleboy/ssh-action недостаточно: go build на NL-сервере занимает ~9 минут, весь билд-шаг упирался в таймаут. Deploy Bot (NL) #24443464873 упал именно на этом. Поднимаю до 30m.