### PR TITLE
feat(subscriptions): категория и эмодзи для чатов

### DIFF
--- a/admin-frontend/src/components/modals/SubscriptionChatModal.vue
+++ b/admin-frontend/src/components/modals/SubscriptionChatModal.vue
@@ -58,6 +58,8 @@ function onIdInput() {
 const formRole = ref<'anchor' | 'content'>('content')
 const formAnchorTierID = ref<number | null>(null)
 const formTierIDs = ref<number[]>([])
+const formCategory = ref('')
+const formEmoji = ref('')
 
 watch(() => props.isOpen, async (open) => {
   if (!open) {
@@ -90,6 +92,8 @@ function resetForm() {
   formRole.value = 'content'
   formAnchorTierID.value = null
   formTierIDs.value = []
+  formCategory.value = ''
+  formEmoji.value = ''
 }
 
 function fillForm(detail: SubscriptionChatDetail) {
@@ -105,6 +109,8 @@ function fillForm(detail: SubscriptionChatDetail) {
     formAnchorTierID.value = null
   }
   formTierIDs.value = detail.tierIDs ?? []
+  formCategory.value = detail.category ?? ''
+  formEmoji.value = detail.emoji ?? ''
 }
 
 function handleClose() {
@@ -135,6 +141,8 @@ async function handleSave() {
         chatType: formChatType.value,
         anchorForTierID: formRole.value === 'anchor' && formAnchorTierID.value ? formAnchorTierID.value : undefined,
         tierIDs: formRole.value === 'content' ? formTierIDs.value : undefined,
+        category: formCategory.value || null,
+        emoji: formEmoji.value || null,
       })
       if (success) {
         emit('saved')
@@ -148,6 +156,9 @@ async function handleSave() {
         anchorForTierID: formRole.value === 'anchor' && formAnchorTierID.value ? formAnchorTierID.value : undefined,
         clearAnchor: formRole.value === 'content',
         tierIDs: formRole.value === 'content' ? formTierIDs.value : [],
+        category: formCategory.value || null,
+        emoji: formEmoji.value || null,
+        clearCategory: !formCategory.value && !formEmoji.value,
       })
       if (success) {
         emit('saved')
@@ -198,7 +209,7 @@ async function handleSave() {
           </div>
           <p
             v-if="resolveError"
-            class="text-xs text-muted-foreground"
+            class="text-xs text-destructive"
           >
             {{ resolveError }}
           </p>
@@ -216,7 +227,7 @@ async function handleSave() {
           <Label>Тип</Label>
           <select
             v-model="formChatType"
-            class="w-full h-9 rounded-sm border border-input bg-background px-3 text-sm font-mono text-xs"
+            class="w-full h-9 rounded-sm border border-input bg-background px-3 text-sm font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="supergroup">
               supergroup
@@ -261,7 +272,7 @@ async function handleSave() {
           <Label>Anchor для тира</Label>
           <select
             v-model.number="formAnchorTierID"
-            class="w-full h-9 rounded-sm border border-input bg-background px-3 text-sm font-mono text-xs"
+            class="w-full h-9 rounded-sm border border-input bg-background px-3 text-sm font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option :value="null">
               Выберите тир
@@ -293,6 +304,26 @@ async function handleSave() {
               />
               <span class="text-sm">{{ tier.name }} (level {{ tier.level }})</span>
             </label>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-[64px_1fr] gap-3 items-end">
+          <div class="space-y-2">
+            <Label>Эмодзи</Label>
+            <Input
+              v-model="formEmoji"
+              placeholder="💬"
+              class="text-center text-lg"
+              maxlength="8"
+            />
+          </div>
+          <div class="space-y-2">
+            <Label>Категория</Label>
+            <Input
+              v-model="formCategory"
+              placeholder="Например: По интересам"
+              maxlength="100"
+            />
           </div>
         </div>
       </div>

--- a/admin-frontend/src/services/subscriptionService.ts
+++ b/admin-frontend/src/services/subscriptionService.ts
@@ -30,6 +30,8 @@ export interface SubscriptionChat {
   tierIDs?: number[]
   tierNames?: string[]
   activeUsers: number
+  category?: string | null
+  emoji?: string | null
 }
 
 export interface SubscriptionChatDetail {
@@ -38,6 +40,8 @@ export interface SubscriptionChatDetail {
   chatType: string
   anchorForTierID?: number
   tierIDs: number[]
+  category?: string | null
+  emoji?: string | null
 }
 
 export interface SubscriptionUser {
@@ -187,7 +191,7 @@ class SubscriptionService {
     }
   }
 
-  createChat = async (data: { id: number, title: string, chatType: string, anchorForTierID?: number, tierIDs?: number[] }): Promise<boolean> => {
+  createChat = async (data: { id: number, title: string, chatType: string, anchorForTierID?: number, tierIDs?: number[], category?: string | null, emoji?: string | null }): Promise<boolean> => {
     try {
       await api.post('subscriptions/chats', { json: data }).json()
       this.toast.toast({ title: 'Успешно', description: 'Чат добавлен' })
@@ -199,7 +203,7 @@ class SubscriptionService {
     }
   }
 
-  updateChat = async (chatId: number, data: { title?: string, anchorForTierID?: number, clearAnchor?: boolean, tierIDs?: number[] }): Promise<boolean> => {
+  updateChat = async (chatId: number, data: { title?: string, anchorForTierID?: number, clearAnchor?: boolean, tierIDs?: number[], category?: string | null, emoji?: string | null, clearCategory?: boolean }): Promise<boolean> => {
     try {
       await api.put(`subscriptions/chats/${chatId}`, { json: data }).json()
       this.toast.toast({ title: 'Успешно', description: 'Чат обновлён' })

--- a/admin-frontend/src/views/SubscriptionsView.vue
+++ b/admin-frontend/src/views/SubscriptionsView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import type { SubscriptionChatDetail } from '@/services/subscriptionService'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import Anchor from '~icons/lucide/anchor'
 import ChevronRight from '~icons/lucide/chevron-right'
 import Eye from '~icons/lucide/eye'
 import Loader2 from '~icons/lucide/loader-2'
+import Pencil from '~icons/lucide/pencil'
 import Plus from '~icons/lucide/plus'
 import ShieldX from '~icons/lucide/shield-x'
 import Trash2 from '~icons/lucide/trash-2'
@@ -14,6 +15,7 @@ import SubscriptionChatModal from '@/components/modals/SubscriptionChatModal.vue
 import SubscriptionUserModal from '@/components/modals/SubscriptionUserModal.vue'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Pagination, PaginationEllipsis, PaginationFirst, PaginationLast, PaginationList, PaginationListItem, PaginationNext, PaginationPrev } from '@/components/ui/pagination'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Typography } from '@/components/ui/typography'
@@ -31,6 +33,14 @@ const expandedChatId = ref<number | null>(null)
 const expandedChatDetail = ref<SubscriptionChatDetail | null>(null)
 const expandedLoading = ref(false)
 const savingAction = ref<string | null>(null)
+const expandedCategory = ref('')
+const expandedEmoji = ref('')
+const savingCategory = ref(false)
+
+watch(expandedChatDetail, (detail) => {
+  expandedCategory.value = detail?.category ?? ''
+  expandedEmoji.value = detail?.emoji ?? ''
+})
 
 const stats = computed(() => subscriptionService.stats.value)
 
@@ -117,6 +127,28 @@ async function toggleContentTier(chatId: number, tierId: number) {
   }
   finally {
     savingAction.value = null
+  }
+}
+
+async function saveCategoryEmoji(chatId: number) {
+  savingCategory.value = true
+  try {
+    const success = await subscriptionService.updateChat(chatId, {
+      category: expandedCategory.value || null,
+      emoji: expandedEmoji.value || null,
+      clearCategory: !expandedCategory.value && !expandedEmoji.value,
+    })
+    if (success && expandedChatDetail.value) {
+      expandedChatDetail.value = {
+        ...expandedChatDetail.value,
+        category: expandedCategory.value || null,
+        emoji: expandedEmoji.value || null,
+      }
+      await subscriptionService.fetchChats()
+    }
+  }
+  finally {
+    savingCategory.value = false
   }
 }
 
@@ -468,10 +500,12 @@ onUnmounted(subscriptionService.clearPagination)
 
               <div class="flex-1 min-w-0">
                 <div class="font-medium truncate">
-                  {{ chat.title }}
+                  <span v-if="chat.emoji" class="mr-1">{{ chat.emoji }}</span>{{ chat.title }}
                 </div>
-                <div class="text-xs text-muted-foreground">
+                <div class="text-xs text-muted-foreground flex items-center gap-1.5">
                   {{ chat.chatType }} &middot; {{ chat.id }}
+                  <span v-if="chat.category" class="text-muted-foreground/70">· {{ chat.category }}</span>
+                  <span v-else class="text-muted-foreground/40 italic">без категории</span>
                 </div>
               </div>
 
@@ -501,9 +535,17 @@ onUnmounted(subscriptionService.clearPagination)
               </div>
 
               <div
-                class="shrink-0"
+                class="flex items-center gap-1 shrink-0"
                 @click.stop
               >
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  class="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+                  @click="openChatModal(chat.id)"
+                >
+                  <Pencil class="h-3.5 w-3.5" />
+                </Button>
                 <ConfirmDialog
                   title="Удалить чат?"
                   description="Чат будет удалён из системы подписок. Все привязки и доступы будут удалены."
@@ -551,7 +593,7 @@ onUnmounted(subscriptionService.clearPagination)
                     <button
                       v-for="tier in subscriptionService.tiers.value"
                       :key="tier.id"
-                      class="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg border transition-all duration-150 cursor-pointer"
+                      class="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg border transition-all duration-150 cursor-pointer active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
                       :class="expandedChatDetail.anchorForTierID === tier.id
                         ? 'bg-blue-500 text-white border-blue-500 shadow-sm'
                         : 'bg-background border-border hover:border-blue-300 hover:bg-blue-50 dark:hover:bg-blue-950/30'"
@@ -581,7 +623,7 @@ onUnmounted(subscriptionService.clearPagination)
                     <button
                       v-for="tier in subscriptionService.tiers.value"
                       :key="tier.id"
-                      class="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg border transition-all duration-150 cursor-pointer"
+                      class="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg border transition-all duration-150 cursor-pointer active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
                       :class="(expandedChatDetail.tierIDs || []).includes(tier.id)
                         ? 'bg-primary text-primary-foreground border-primary shadow-sm'
                         : 'bg-background border-border hover:border-primary/30 hover:bg-accent'"
@@ -594,6 +636,38 @@ onUnmounted(subscriptionService.clearPagination)
                       />
                       {{ tier.name }}
                     </button>
+                  </div>
+                </div>
+
+                <!-- Category / Emoji inline editor -->
+                <div>
+                  <div class="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+                    Категория в боте
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Input
+                      v-model="expandedEmoji"
+                      class="w-16 text-center text-lg"
+                      placeholder="💬"
+                      maxlength="8"
+                    />
+                    <Input
+                      v-model="expandedCategory"
+                      class="flex-1"
+                      placeholder="Название категории"
+                      maxlength="100"
+                    />
+                    <Button
+                      size="sm"
+                      :disabled="savingCategory"
+                      @click="saveCategoryEmoji(chat.id)"
+                    >
+                      <Loader2
+                        v-if="savingCategory"
+                        class="h-3.5 w-3.5 animate-spin mr-1"
+                      />
+                      {{ savingCategory ? 'Сохранение' : 'Сохранить' }}
+                    </Button>
                   </div>
                 </div>
               </div>

--- a/backend/database/migrations/20260415000000_add_chat_category_emoji.sql
+++ b/backend/database/migrations/20260415000000_add_chat_category_emoji.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subscription_chats
+    ADD COLUMN IF NOT EXISTS category VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS emoji    VARCHAR(16);

--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -228,24 +228,51 @@ func (b *TelegramBot) postAnchorWelcome(chatID int64, user *tgbotapi.User) {
 	}
 }
 
-// sendSubscriptionLinks sends invite links as inline keyboard buttons.
+// sendSubscriptionLinks sends invite links grouped by category as a single HTML message.
 func (b *TelegramBot) sendSubscriptionLinks(chatID int64, result *service.SyncResult) {
-	var rows [][]tgbotapi.InlineKeyboardButton
+	type entry struct {
+		title string
+		link  string
+	}
+	groups := make(map[string][]entry)
+	groupEmoji := make(map[string]string)
+	var order []string
+
 	for _, g := range result.Granted {
 		chat, err := b.subscriptionService.GetChat(g.ChatID)
 		title := fmt.Sprintf("Chat %d", g.ChatID)
+		cat := "Прочее"
+		emoji := "💬"
 		if err == nil {
 			title = chat.Title
+			if chat.Category != nil && *chat.Category != "" {
+				cat = *chat.Category
+			}
+			if chat.Emoji != nil && *chat.Emoji != "" {
+				emoji = *chat.Emoji
+			}
 		}
-		rows = append(rows, tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonURL(title, g.Link),
-		))
+		if _, exists := groups[cat]; !exists {
+			order = append(order, cat)
+			groupEmoji[cat] = emoji
+		}
+		groups[cat] = append(groups[cat], entry{title: title, link: g.Link})
 	}
 
-	msg := tgbotapi.NewMessage(chatID, "Подписка подтверждена! Вот ваши ссылки на чаты:")
+	text := fmt.Sprintf("Подписка подтверждена! Доступно чатов: <b>%d</b>\n", len(result.Granted))
+	for _, cat := range order {
+		text += fmt.Sprintf("\n%s <b>%s</b>\n", groupEmoji[cat], cat)
+		for _, e := range groups[cat] {
+			text += fmt.Sprintf("• <a href=\"%s\">%s</a>\n", e.link, e.title)
+		}
+	}
+
+	msg := tgbotapi.NewMessage(chatID, text)
 	msg.ParseMode = "HTML"
-	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(rows...)
-	b.bot.Send(msg)
+	msg.DisableWebPagePreview = true
+	if _, err := b.bot.Send(msg); err != nil {
+		log.Printf("Failed to send subscription links to %d: %v", chatID, err)
+	}
 }
 
 // --- Chat member event handlers ---

--- a/backend/internal/handler/subscription.go
+++ b/backend/internal/handler/subscription.go
@@ -113,6 +113,8 @@ func (h *SubscriptionHandler) GetChats(c *fiber.Ctx) error {
 			"title":       ch.Title,
 			"chatType":    ch.ChatType,
 			"activeUsers": accessCounts[ch.ID],
+			"category":    ch.Category,
+			"emoji":       ch.Emoji,
 		}
 		if ch.AnchorForTierID != nil {
 			item["anchorForTierID"] = *ch.AnchorForTierID
@@ -310,11 +312,13 @@ func (h *SubscriptionHandler) ClearOverride(c *fiber.Ctx) error {
 
 func (h *SubscriptionHandler) CreateChat(c *fiber.Ctx) error {
 	var req struct {
-		ID       int64  `json:"id"`
-		Title    string `json:"title"`
-		ChatType string `json:"chatType"`
-		AnchorForTierID *uint  `json:"anchorForTierID"`
-		TierIDs  []uint `json:"tierIDs"`
+		ID              int64   `json:"id"`
+		Title           string  `json:"title"`
+		ChatType        string  `json:"chatType"`
+		AnchorForTierID *uint   `json:"anchorForTierID"`
+		TierIDs         []uint  `json:"tierIDs"`
+		Category        *string `json:"category"`
+		Emoji           *string `json:"emoji"`
 	}
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный формат запроса"})
@@ -328,6 +332,12 @@ func (h *SubscriptionHandler) CreateChat(c *fiber.Ctx) error {
 
 	if err := h.svc.UpsertChat(req.ID, req.Title, req.ChatType); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось создать чат"})
+	}
+
+	if req.Category != nil || req.Emoji != nil {
+		if err := h.svc.UpdateChatMeta(req.ID, req.Category, req.Emoji); err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось сохранить категорию"})
+		}
 	}
 
 	if req.AnchorForTierID != nil {
@@ -361,6 +371,9 @@ func (h *SubscriptionHandler) UpdateChat(c *fiber.Ctx) error {
 		AnchorForTierID *uint   `json:"anchorForTierID"`
 		ClearAnchor     bool    `json:"clearAnchor"`
 		TierIDs         *[]uint `json:"tierIDs"`
+		Category        *string `json:"category"`
+		Emoji           *string `json:"emoji"`
+		ClearCategory   bool    `json:"clearCategory"`
 	}
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный формат запроса"})
@@ -369,6 +382,18 @@ func (h *SubscriptionHandler) UpdateChat(c *fiber.Ctx) error {
 	if req.Title != nil && *req.Title != "" {
 		if err := h.svc.UpsertChat(chatID, *req.Title, existing.ChatType); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось обновить чат"})
+		}
+	}
+
+	if req.Category != nil || req.Emoji != nil || req.ClearCategory {
+		cat := req.Category
+		emoji := req.Emoji
+		if req.ClearCategory {
+			cat = nil
+			emoji = nil
+		}
+		if err := h.svc.UpdateChatMeta(chatID, cat, emoji); err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось сохранить категорию"})
 		}
 	}
 
@@ -422,6 +447,8 @@ func (h *SubscriptionHandler) GetChatDetail(c *fiber.Ctx) error {
 		"title":    chat.Title,
 		"chatType": chat.ChatType,
 		"tierIDs":  tierIDs,
+		"category": chat.Category,
+		"emoji":    chat.Emoji,
 	}
 	if chat.AnchorForTierID != nil {
 		result["anchorForTierID"] = *chat.AnchorForTierID

--- a/backend/internal/models/subscription.go
+++ b/backend/internal/models/subscription.go
@@ -12,10 +12,12 @@ type SubscriptionTier struct {
 func (SubscriptionTier) TableName() string { return "subscription_tiers" }
 
 type SubscriptionChat struct {
-	ID              int64  `json:"id" gorm:"primaryKey;autoIncrement:false"`
-	Title           string `json:"title" gorm:"size:255"`
-	ChatType        string `json:"chat_type" gorm:"size:50;default:supergroup"`
-	AnchorForTierID *uint  `json:"anchor_for_tier_id"`
+	ID              int64   `json:"id" gorm:"primaryKey;autoIncrement:false"`
+	Title           string  `json:"title" gorm:"size:255"`
+	ChatType        string  `json:"chat_type" gorm:"size:50;default:supergroup"`
+	AnchorForTierID *uint   `json:"anchor_for_tier_id"`
+	Category        *string `json:"category" gorm:"size:100"`
+	Emoji           *string `json:"emoji" gorm:"size:16"`
 }
 
 func (SubscriptionChat) TableName() string { return "subscription_chats" }

--- a/backend/internal/repository/subscription.go
+++ b/backend/internal/repository/subscription.go
@@ -106,6 +106,11 @@ func (r *SubscriptionRepository) UpsertChat(chatID int64, title string, chatType
 	return r.db.Save(&chat).Error
 }
 
+func (r *SubscriptionRepository) UpdateChatMeta(chatID int64, category, emoji *string) error {
+	return r.db.Model(&models.SubscriptionChat{}).Where("id = ?", chatID).
+		Updates(map[string]interface{}{"category": category, "emoji": emoji}).Error
+}
+
 func (r *SubscriptionRepository) SetAnchor(chatID int64, tierID *uint) error {
 	return r.db.Model(&models.SubscriptionChat{}).Where("id = ?", chatID).
 		Update("anchor_for_tier_id", tierID).Error

--- a/backend/internal/service/subscription.go
+++ b/backend/internal/service/subscription.go
@@ -261,6 +261,10 @@ func (s *SubscriptionService) UpsertChat(chatID int64, title, chatType string) e
 	return s.repo.UpsertChat(chatID, title, chatType)
 }
 
+func (s *SubscriptionService) UpdateChatMeta(chatID int64, category, emoji *string) error {
+	return s.repo.UpdateChatMeta(chatID, category, emoji)
+}
+
 func (s *SubscriptionService) SetAnchor(chatID int64, tierID *uint) error {
 	return s.repo.SetAnchor(chatID, tierID)
 }


### PR DESCRIPTION
## Что сделано

- **БД**: миграция добавляет `category VARCHAR(100)` и `emoji VARCHAR(16)` в `subscription_chats`
- **Backend**: repository/service/handler поддерживают чтение и запись этих полей (create/update/get)
- **Bot**: `sendSubscriptionLinks` теперь группирует ссылки по категории с эмодзи-заголовками (HTML вместо кнопок)
- **Admin UI**:
  - Список чатов показывает эмодзи в названии и категорию в подзаголовке
  - Expanded panel — инлайн-редактор категории/эмодзи с кнопкой "Сохранить"
  - Кнопка карандаша открывает модал редактирования
  - Модал: поля emoji+category, красный цвет ошибки resolve, focus-ring для select
- **UX**: `active:scale-95`, `focus-visible:ring`, `disabled:opacity-50` на кнопках тиров; спиннер при сохранении

## Визуально

До: пользователь получает стену из 15+ одинаковых кнопок  
После: ссылки сгруппированы по категориям с эмодзи заголовками