### PR TITLE
perf(landing): self-host шрифты через @fontsource-variable

### DIFF
--- a/landing-frontend/index.html
+++ b/landing-frontend/index.html
@@ -9,9 +9,6 @@
     <link rel="manifest" href="/manifest.json">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="canonical" href="https://ithozyaeva.ru/">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
 
     <title>IT-ХОЗЯЕВА — IT-сообщество с AI, менторством и вайбкодингом</title>
     <meta name="description" content="IT-ХОЗЯЕВА — IT-сообщество 250+ специалистов на стыке технологий и AI. Менторство, вайбкодинг, нетворкинг, собеседования. От junior до lead. Подписка от 520 ₽/мес.">

--- a/landing-frontend/package-lock.json
+++ b/landing-frontend/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@floating-ui/vue": "^1.1.6",
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/space-grotesk": "^5.2.10",
         "@tanstack/vue-query": "^5.92.9",
         "@unhead/vue": "^2.1.12",
         "@vueuse/core": "^14.2.1",
@@ -1290,6 +1293,33 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/landing-frontend/package.json
+++ b/landing-frontend/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "@floating-ui/vue": "^1.1.6",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/space-grotesk": "^5.2.10",
     "@tanstack/vue-query": "^5.92.9",
     "@unhead/vue": "^2.1.12",
     "@vueuse/core": "^14.2.1",

--- a/landing-frontend/src/assets/uikit.css
+++ b/landing-frontend/src/assets/uikit.css
@@ -1,13 +1,5 @@
 /* UI Kit design tokens — extracted from itx-ui-kit */
 
-@font-face {
-  font-family: 'Unbounded';
-  font-weight: 400 600;
-  font-style: normal;
-  font-display: swap;
-  src: url('https://fonts.googleapis.com/css2?family=Unbounded:wght@400;500;600&display=swap');
-}
-
 :root {
   /* Colors */
   --color-total-black: #000;
@@ -35,9 +27,9 @@
   --transition-popover: 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 
   /* Fonts */
-  --font-unbounded: 'Unbounded', 'Space Grotesk', sans-serif;
-  --font-inter: 'Inter', sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, 'Menlo', monospace;
+  --font-unbounded: 'Unbounded', 'Space Grotesk Variable', 'Space Grotesk', sans-serif;
+  --font-inter: 'Inter Variable', 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'Menlo', monospace;
 
   /* Terminal accent */
   --color-terminal-amber: #ffb547;

--- a/landing-frontend/src/main.ts
+++ b/landing-frontend/src/main.ts
@@ -8,6 +8,9 @@ import App from './App.vue'
 
 import { queryClient } from './plugins/vueQuery'
 import router from './router'
+import '@fontsource-variable/inter/wght.css'
+import '@fontsource-variable/jetbrains-mono/wght.css'
+import '@fontsource-variable/space-grotesk/wght.css'
 import './assets/uikit.css'
 import './assets/base.css'
 

--- a/landing-frontend/tailwind.config.js
+++ b/landing-frontend/tailwind.config.js
@@ -15,9 +15,9 @@ module.exports = {
     },
     extend: {
       fontFamily: {
-        sans: ['Inter', 'sans-serif'],
-        mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
-        display: ['Unbounded', 'Space Grotesk', 'sans-serif'],
+        sans: ['"Inter Variable"', 'Inter', 'sans-serif'],
+        mono: ['"JetBrains Mono Variable"', 'JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+        display: ['Unbounded', '"Space Grotesk Variable"', 'Space Grotesk', 'sans-serif'],
       },
       colors: {
         'term-amber': '#ffb547',


### PR DESCRIPTION
## Summary
Убирает render-blocking запрос к Google Fonts CDN — улучшает LCP и приватность.

- Inter, JetBrains Mono, Space Grotesk теперь бандлятся локально как variable-шрифты через \`@fontsource-variable/*\`. Vite делает unicode-range subset-оптимизацию, браузер качает только cyrillic/latin по факту.
- Удалены \`<link rel=\"preconnect\">\` и Google Fonts stylesheet из \`index.html\`.
- Удалён битый \`@font-face\` для Unbounded в \`uikit.css\`: в \`src\` был CSS-URL вместо файла шрифта, этот шрифт и так не загружался. Заголовки как раньше фолбэкались на Space Grotesk — визуально ничего не изменится.
- \`tailwind.config.js\` и CSS-переменные получили имена \`'X Variable'\` первым с фолбэком на старое имя.

## Визуальная проверка
Я не могу запустить браузер в текущей сессии. Нужно вручную проверить после мержа:
- [ ] Заголовки и моноширинный текст рендерятся в тех же шрифтах, что и раньше (Space Grotesk / JetBrains Mono / Inter).
- [ ] Кириллица не съезжает на системный sans.
- [ ] В Network-вкладке DevTools запросы к fonts.googleapis.com/gstatic.com отсутствуют.

## Test plan
- [x] \`npm run lint\` — pass
- [x] \`npm run type-check\` — pass
- [x] \`npm run test\` — 42 passed
- [x] \`npm run build\` — успех, woff2 ассеты в bundle
- [ ] После деплоя: PageSpeed Insights — проверить улучшение LCP