### PR TITLE
perf(landing): lazy-load Privacy route

### DIFF
--- a/landing-frontend/src/router/index.ts
+++ b/landing-frontend/src/router/index.ts
@@ -1,11 +1,10 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../pages/Main.vue'
-import Privacy from '../pages/Privacy.vue'
 
 const routes: RouteRecordRaw[] = [
   { path: '/', component: Home },
-  { path: '/privacy', component: Privacy },
+  { path: '/privacy', component: () => import('../pages/Privacy.vue') },
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
\`Privacy.vue\` — 939 строк текста политики + связанные \`Typography\`-компоненты. До этого коммита грузился синхронно в главный bundle, хотя 99% пользователей никогда на \`/privacy\` не заходят.

Dynamic import выносит его в отдельный chunk.

## Эффект на bundle
| | Было | Стало |
|---|---|---|
| \`index.js\` | 311.33 kB (gzip 103.26) | 267.56 kB (gzip 96.95) |
| \`Privacy.js\` | — | 45.48 kB (gzip 7.69) |

**Главный LCP улучшится** — меньше JS на parse/execute до paint. Privacy-chunk грузится только при навигации на \`/privacy\`.

## Test plan
- [x] \`npm run lint\` — pass
- [x] \`npm run type-check\` — pass
- [x] \`npm run test\` — 42 passed
- [x] \`npm run build\` — отдельный Privacy chunk создан
- [ ] После деплоя: перейти \`/\` → \`/privacy\` — подгружается доп. chunk, нет ошибок в консоли