### PR TITLE
fix(ci): починить deploy — container conflict + nginx template reload

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,9 +16,10 @@ jobs:
           key:      ${{ secrets.SSH_DEV_KEY }}
           port:     ${{ secrets.SSH_DEV_PORT }}
           script: |
-            # Free disk space first
-            docker system prune -af || true
-            docker builder prune -af || true
+            # Освобождаем место только от мусора, оставшегося от наших же образов/сборок.
+            # НЕ используем docker system prune -af — он трогает ресурсы других проектов на этом хосте.
+            docker image prune -f || true
+            docker builder prune -f --filter "until=48h" || true
             cd ${{ secrets.PROJECT_PROD_PATH }}
             git fetch --all
             git reset --hard origin/master
@@ -40,12 +41,20 @@ jobs:
             DOCKER_BUILDKIT=0 CACHEBUST=$(date +%s) docker compose -f docker-compose.prod.yml build --no-cache
             # Remove temporary copies
             rm -rf platform-frontend/_packages_ui admin-frontend/_packages_ui
+            # Проект-локальная очистка зависших контейнеров от предыдущих неудачных деплоев.
+            # docker compose --force-recreate падает с Container name already in use, если
+            # старый контейнер остался c hash-prefix'ом — явно удаляем по имени.
+            for svc in backend landing-frontend platform-frontend admin-frontend; do
+              docker rm -f "$svc" 2>/dev/null || true
+            done
             # Restart services with forced recreation to pick up new images
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate landing-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate platform-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate admin-frontend
-            # Reload nginx to pick up any config changes (graceful, no downtime)
-            docker compose -f docker-compose.prod.yml exec nginx nginx -s reload || true
-            # Clean up old images
+            # Пересоздаём nginx: `nginx -s reload` не перечитывает envsubst в conf.d/nginx.conf.template,
+            # envsubst выполняется один раз при старте контейнера. Без recreate — изменения try_files,
+            # location-блоков и прочего не применяются.
+            docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate nginx
+            # Clean up old images (без affecting чужих проектов)
             docker image prune -f

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -48,12 +48,18 @@ jobs:
             cd ${{ secrets.PROJECT_PROD_PATH }}
             # Build new images with legacy builder (BuildKit ignores --no-cache)
             DOCKER_BUILDKIT=0 CACHEBUST=$(date +%s) docker compose -f docker-compose.prod.yml build --no-cache
+            # Проект-локальная очистка зависших контейнеров от предыдущих неудачных деплоев.
+            # docker compose --force-recreate падает с Container name already in use, если
+            # старый контейнер остался c hash-prefix'ом — явно удаляем по имени.
+            for svc in backend landing-frontend platform-frontend admin-frontend; do
+              docker rm -f "$svc" 2>/dev/null || true
+            done
             # Restart services with forced recreation to pick up new images
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate landing-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate platform-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate admin-frontend
-            # Reload nginx to pick up any config changes (graceful, no downtime)
-            docker compose -f docker-compose.prod.yml exec nginx nginx -s reload || true
+            # Пересоздаём nginx: `nginx -s reload` не перечитывает envsubst в conf.d/nginx.conf.template.
+            docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate nginx
             # Clean up old images
             docker image prune -f


### PR DESCRIPTION
## Проблема
Production (\`ithozyaeva.ru\`) и dev задеплоены на state от **12 апреля**. Все PR #243-#248 (canonical, self-host шрифты, SEO-shell, /privacy prerender, lazy-load, /mentors, /vibe-coding) **фактически НЕ применились** в прод, хотя последующие деплои помечались SUCCESS.

**Симптомы** (по \`curl\`):
- \`curl -sI https://ithozyaeva.ru/\` → \`Last-Modified: Sun, 12 Apr 2026\`
- \`curl -s https://ithozyaeva.ru/sitemap.xml\` → \`<lastmod>2026-04-12</lastmod>\`
- \`curl -s https://ithozyaeva.ru/\` → в HTML есть \`preconnect fonts.googleapis.com\` (PR #244 не применился)
- \`curl -s https://ithozyaeva.ru/robots.txt\` → нет \`Disallow /admin /platform\` (PR #243 не применился)
- \`curl -s https://ithozyaeva.ru/mentors\` → отдаёт SPA-fallback главной, не \`/mentors.html\` (PR #246 nginx config + PR #248 страницы)

## Две причины в workflow

### 1. Container name conflict молча ломает recreate
\`docker compose up --force-recreate\` падает с:
\`\`\`
Container name "/landing-frontend" is already in use by container "8c72b95a75fa_..."
\`\`\`
если от предыдущего неудачного деплоя остался контейнер с hash-prefix именем. Следующие шаги деплоя не ломают exit code, поэтому workflow помечается SUCCESS, **хотя landing-frontend контейнер НЕ пересоздался** и volume продолжает отдавать старую статику.

**Фикс:** явно удалять контейнеры по имени перед \`up --force-recreate\`:
\`\`\`bash
for svc in backend landing-frontend platform-frontend admin-frontend; do
  docker rm -f "\$svc" 2>/dev/null || true
done
\`\`\`

### 2. nginx reload не перечитывает envsubst
\`docker compose exec nginx nginx -s reload\` перечитывает **компилированный** конфиг из \`/etc/nginx/\`, но \`_nginx/conf.d/nginx.conf.template\` обрабатывается \`envsubst\` только один раз — при старте контейнера. Изменения \`try_files\`, \`location\`, любых \`${DOMAIN}\`-подстановок **не применяются** без пересоздания контейнера.

**Фикс:** заменил \`nginx -s reload\` на \`up -d --no-deps --force-recreate nginx\`.

## Бонус: убрал \`docker system prune -af\`
В \`deploy-dev.yml\` шаг "Free disk space" делал \`docker system prune -af || true\` — это удаляет **все** висящие образы/контейнеры/сети/volumes на хосте, включая ресурсы других проектов. По [CLAUDE.md](../CLAUDE.md) политика — не трогать соседей на общем сервере. Заменил на безопасные \`docker image prune -f\` + \`docker builder prune -f --filter until=48h\`.

## Что делать после мержа
1. Мерж этого PR → триггер нового deploy_dev на master.
2. **На этом первом деплое** workflow сделает \`docker rm -f\` всех сервисов и соберёт заново с актуальным master → через ~5 минут прод получит все SEO-PR'ы сразу (#243–#248).
3. Проверка:
\`\`\`bash
curl -sI https://ithozyaeva.ru/ | grep Last-Modified   # должно быть свежим
curl -s  https://ithozyaeva.ru/sitemap.xml | grep lastmod  # свежая дата
curl -s  https://ithozyaeva.ru/mentors | grep "База менторов"  # контент виден
curl -s  https://ithozyaeva.ru/robots.txt | grep Disallow
\`\`\`