### PR TITLE
fix(docker): идемпотентный CMD для копирования dist в volume

### DIFF
--- a/admin-frontend/Dockerfile
+++ b/admin-frontend/Dockerfile
@@ -17,4 +17,4 @@ RUN if [ -d "_packages_ui" ]; then mkdir -p /packages/ui && cp -r _packages_ui/*
 
 RUN npm run build
 
-CMD ["sh", "-c", "rm -rf /static/admin-frontend/* && cp -r /app/dist/* /static/admin-frontend/"]
+CMD ["sh", "-c", "mkdir -p /static/admin-frontend && find /static/admin-frontend -mindepth 1 -delete && cp -a /app/dist/. /static/admin-frontend/"]

--- a/landing-frontend/Dockerfile
+++ b/landing-frontend/Dockerfile
@@ -19,5 +19,8 @@ COPY . .
 
 RUN npm run build
 
-# Очищаем старую статику и копируем свежую сборку
-CMD ["sh", "-c", "rm -rf /static/landing-frontend/* && cp -r /app/dist/* /static/landing-frontend/"]
+# Очищаем старую статику и копируем свежую сборку.
+# mkdir + find вместо `rm -rf /static/.../*`: glob не раскрывается в пустой директории
+# и rm падает exit 1, из-за чего `&& cp` не выполняется и volume остаётся старым.
+# /app/dist/. — копирует содержимое директории включая dot-файлы, независимо от shell.
+CMD ["sh", "-c", "mkdir -p /static/landing-frontend && find /static/landing-frontend -mindepth 1 -delete && cp -a /app/dist/. /static/landing-frontend/"]

--- a/platform-frontend/Dockerfile
+++ b/platform-frontend/Dockerfile
@@ -17,4 +17,4 @@ RUN if [ -d "_packages_ui" ]; then mkdir -p /packages/ui && cp -r _packages_ui/*
 
 RUN npm run build
 
-CMD ["sh", "-c", "rm -rf /static/platform-frontend/* && cp -r /app/dist/* /static/platform-frontend/"]
+CMD ["sh", "-c", "mkdir -p /static/platform-frontend && find /static/platform-frontend -mindepth 1 -delete && cp -a /app/dist/. /static/platform-frontend/"]


### PR DESCRIPTION
## Root cause — почему сайт от 12 апреля
Продолжение починки деплоя (связано с #249). После мержа #249 \`docker rm -f\` + \`force-recreate nginx\` починили конфликт контейнеров, но **статика всё равно не обновилась**. Проверка:

\`\`\`bash
curl -sI https://ithozyaeva.ru/
# Last-Modified: Sun, 12 Apr 2026 12:31:05 GMT  ← после успешного deploy всё ещё старое
\`\`\`

## Что ломалось
\`landing-frontend/Dockerfile\` (и admin, и platform):
\`\`\`dockerfile
CMD ["sh", "-c", "rm -rf /static/landing-frontend/* && cp -r /app/dist/* /static/landing-frontend/"]
\`\`\`

Два подвоха:

1. **Glob \`*\` в пустой директории**. В alpine \`/bin/sh\` по умолчанию glob, не совпадающий ни с чем, оставляется как литерал. То есть \`rm -rf /static/landing-frontend/*\` при пустом bind-mount получает literal \`/static/landing-frontend/*\` (звёздочка в имени), \`rm\` не находит такой файл и возвращает **exit 1**. \`&&\` блокирует cp. Volume остаётся прежним.

2. **\`/app/dist/*\` пропускает dot-файлы** (глоб не захватывает \`.\`-префиксные имена).

Компоуз молча сообщал \`Container landing-frontend Started\` — старт прошёл, но CMD exit 1, volume не обновился. Никакого красного маркера, deploy помечался SUCCESS.

## Фикс
\`\`\`dockerfile
CMD ["sh", "-c", "mkdir -p /static/X && find /static/X -mindepth 1 -delete && cp -a /app/dist/. /static/X/"]
\`\`\`

- \`mkdir -p\` — no-op если директория есть, создаёт если её нет;
- \`find -mindepth 1 -delete\` — удаляет **содержимое**, не трогая mount-point; работает одинаково и для пустой, и для заполненной директории;
- \`cp -a /app/dist/.\` — копирует **содержимое** каталога, включая dot-файлы, сохраняя атрибуты.

Применено ко всем трём фронтам: \`landing-frontend\`, \`admin-frontend\`, \`platform-frontend\` — баг один и тот же.

## Что после мержа
1. Deploy_dev триггернётся автоматически.
2. Новые контейнеры соберутся с исправленным CMD → реально скопируют dist в volume.
3. Прод отдаст **весь накопленный стек SEO-фиксов** (PR #243–#248).

Ожидаемый результат:
\`\`\`bash
curl -sI https://ithozyaeva.ru/ | grep Last-Modified  # свежее
curl -s  https://ithozyaeva.ru/sitemap.xml | grep lastmod  # 2026-04-17
curl -s  https://ithozyaeva.ru/mentors | grep "База менторов"  # контент
curl -s  https://ithozyaeva.ru/robots.txt | grep Disallow  # /admin /platform
\`\`\`