### PR TITLE
fix(ci): пересоздавать nginx-init для регенерации default.conf

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -52,9 +52,16 @@ jobs:
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate landing-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate platform-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate admin-frontend
-            # Пересоздаём nginx: `nginx -s reload` не перечитывает envsubst в conf.d/nginx.conf.template,
-            # envsubst выполняется один раз при старте контейнера. Без recreate — изменения try_files,
-            # location-блоков и прочего не применяются.
+            # Регенерируем nginx default.conf из template: nginx-init это одноразовый контейнер,
+            # он делает envsubst только при старте; без recreate template-правки не применяются.
+            docker rm -f nginx-init 2>/dev/null || true
+            docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate nginx-init
+            # Ждём пока nginx-init завершится (он записывает default.conf на bind-mount и exit).
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              if ! docker ps --format '{{.Names}}' | grep -q '^nginx-init$'; then break; fi
+              sleep 1
+            done
+            # Теперь пересоздаём nginx, чтобы он перечитал свежий default.conf.
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate nginx
             # Clean up old images (без affecting чужих проектов)
             docker image prune -f

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,7 +59,14 @@ jobs:
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate landing-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate platform-frontend
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate admin-frontend
-            # Пересоздаём nginx: `nginx -s reload` не перечитывает envsubst в conf.d/nginx.conf.template.
+            # Регенерируем nginx default.conf из template: nginx-init одноразовый контейнер,
+            # envsubst выполняется только при старте. Без recreate изменения в template не применяются.
+            docker rm -f nginx-init 2>/dev/null || true
+            docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate nginx-init
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              if ! docker ps --format '{{.Names}}' | grep -q '^nginx-init$'; then break; fi
+              sleep 1
+            done
             docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate nginx
             # Clean up old images
             docker image prune -f


### PR DESCRIPTION
## Проблема
После production deploy #243-#248 сайт ожил (главная, robots.txt, self-host шрифты), но \`/mentors\` и \`/privacy\` всё ещё отдают SPA-fallback главной вместо своих prerendered HTML.

Причина: \`nginx-init\` — одноразовый контейнер (\`restart: "no"\`), который при старте делает \`envsubst nginx.conf.template → /etc/nginx/conf.d/default.conf\`. После первого успешного запуска он \`exit 0\` и больше не вызывается.

Изменения в \`_nginx/conf.d/nginx.conf.template\` (например \`try_files \$uri.html\` из PR #246) не применяются — \`default.conf\` на bind-mount хранит версию от первого старта. Сам nginx читает этот устаревший \`default.conf\`.

Предыдущий фикс (#249) пересоздавал только \`nginx\`, но этого недостаточно — nginx читает уже сгенерированный файл.

## Фикс
Перед recreate nginx явно пересоздать \`nginx-init\`:
\`\`\`bash
docker rm -f nginx-init 2>/dev/null || true
docker compose up -d --no-deps --force-recreate nginx-init
# Ждём пока exit
for i in 1..10; do ... break if not running ... done
docker compose up -d --no-deps --force-recreate nginx
\`\`\`

Применено и в deploy-dev, и в deploy-production.

## Проверка после мержа
1. Мерж PR → запустится deploy_dev автоматически.
2. **Дополнительно нужно руками** запустить production deploy:
   \`gh workflow run deploy-production.yml -f confirm=yes\`
3. После завершения:
\`\`\`bash
curl -s https://ithozyaeva.ru/mentors | grep -c "База менторов"    # должно быть >5
curl -s https://ithozyaeva.ru/privacy | grep -c "152-ФЗ"            # должно быть >0
curl -s https://ithozyaeva.ru/vibe-coding | grep -c "Cursor"        # должно быть >3
\`\`\`