### PR TITLE
fix(events): резолвить теги события по имени

### DIFF
--- a/backend/internal/handler/events.go
+++ b/backend/internal/handler/events.go
@@ -182,6 +182,14 @@ func (h *EventsHandler) Create(c *fiber.Ctx) error {
 	// Подставляем название эксклюзивного чата
 	h.resolveExclusiveChatTitle(event)
 
+	// Резолвим теги по имени (новые теги, введённые вручную, имеют Id=0)
+	resolvedTags, err := h.svc.ResolveEventTags(event.EventTags)
+	if err != nil {
+		log.Printf("resolve event tags error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Ошибка обработки тегов"})
+	}
+	event.EventTags = resolvedTags
+
 	result, err := h.service.Create(event)
 	if err != nil {
 		log.Printf("create event error: %v", err)
@@ -214,6 +222,14 @@ func (h *EventsHandler) Update(c *fiber.Ctx) error {
 
 	// Подставляем название эксклюзивного чата
 	h.resolveExclusiveChatTitle(event)
+
+	// Резолвим теги по имени (новые теги, введённые вручную, имеют Id=0)
+	resolvedTags, err := h.svc.ResolveEventTags(event.EventTags)
+	if err != nil {
+		log.Printf("resolve event tags error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Ошибка обработки тегов"})
+	}
+	event.EventTags = resolvedTags
 
 	result, err := h.service.Update(event)
 	if err != nil {

--- a/backend/internal/service/events.go
+++ b/backend/internal/service/events.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"errors"
+	"ithozyeva/database"
 	"ithozyeva/internal/models"
 	"ithozyeva/internal/repository"
+	"strings"
 	"time"
 )
 
@@ -41,6 +43,43 @@ func (s *EventsService) RemoveMember(eventId int, memberId int) (*models.Event, 
 
 func (s *EventsService) GetUpcomingEvents(limit int) ([]models.Event, error) {
 	return s.repo.GetUpcoming(limit)
+}
+
+// ResolveEventTags нормализует список тегов события: теги с Id > 0 оставляются как есть,
+// а теги без Id (приходят с фронта, когда админ вводит новое имя вручную) ищутся по имени
+// или создаются. Возвращает список тегов с корректными Id, пригодный для GORM many2many.
+func (s *EventsService) ResolveEventTags(tags []models.EventTag) ([]models.EventTag, error) {
+	if len(tags) == 0 {
+		return tags, nil
+	}
+	resolved := make([]models.EventTag, 0, len(tags))
+	seenIDs := make(map[int64]bool)
+	seenNames := make(map[string]bool)
+	for _, tag := range tags {
+		if tag.Id > 0 {
+			if seenIDs[tag.Id] {
+				continue
+			}
+			seenIDs[tag.Id] = true
+			resolved = append(resolved, tag)
+			continue
+		}
+		name := strings.TrimSpace(tag.Name)
+		if name == "" || seenNames[name] {
+			continue
+		}
+		seenNames[name] = true
+		var existing models.EventTag
+		if err := database.DB.Where("name = ?", name).FirstOrCreate(&existing, models.EventTag{Name: name}).Error; err != nil {
+			return nil, err
+		}
+		if seenIDs[existing.Id] {
+			continue
+		}
+		seenIDs[existing.Id] = true
+		resolved = append(resolved, existing)
+	}
+	return resolved, nil
 }
 
 func (s *EventsService) GetFutureEvents(now time.Time) ([]models.Event, error) {


### PR DESCRIPTION
## Проблема

При создании события в админке ловится 500 с ошибкой:
\`\`\`
insert or update on table \"event_event_tags\" violates foreign key constraint \"event_event_tags_event_tag_id_fkey\"
\`\`\`

Фронт (\`admin-frontend/src/components/forms/event/EventTags.vue\`) позволяет вводить новые теги руками — компонент создаёт объект \`{ name: text }\` без \`id\`. GORM пытался вставить связь \`event_event_tags\` с \`event_tag_id = 0\`, такого тега нет → падение.

## Решение

Добавил \`EventsService.ResolveEventTags\`: для тегов с \`Id > 0\` оставляем как есть, для остальных ищем по имени через \`FirstOrCreate\` и подменяем на полноценную модель. Дубликаты по Id и имени отбрасываются.

Метод вызывается в \`EventsHandler.Create\` и \`EventsHandler.Update\` перед сохранением.

## Test plan

- [ ] Создать событие с новым тегом, которого нет в базе → должен создаться и прицепиться
- [ ] Создать событие с существующим тегом (из автокомплита) → работает как раньше
- [ ] Отредактировать событие, добавить новый тег → сохраняется
- [ ] Ввести пустую строку / пробелы в теге → тег отбрасывается