### PR TITLE
fix(bot): шедулер подхватывает события без начального алерта

### DIFF
--- a/backend/database/migrations/20260418000000_add_initial_alerts_sent_at_to_events.sql
+++ b/backend/database/migrations/20260418000000_add_initial_alerts_sent_at_to_events.sql
@@ -1,0 +1,13 @@
+-- Флаг отправки инициализирующих алертов.
+-- Нужен, чтобы при APP_MODE=api (бот в отдельном процессе) бот на NL мог
+-- подхватить события без начального алерта и доотправить их.
+ALTER TABLE events ADD COLUMN IF NOT EXISTS initial_alerts_sent_at TIMESTAMP NULL;
+
+-- Backfill: прошедшие события не должны пытаться отправить алерт.
+UPDATE events SET initial_alerts_sent_at = CURRENT_TIMESTAMP
+WHERE initial_alerts_sent_at IS NULL AND date < CURRENT_TIMESTAMP;
+
+-- Backfill: будущие события, у которых уже есть подписки — значит, алерт уже уехал раньше.
+UPDATE events SET initial_alerts_sent_at = CURRENT_TIMESTAMP
+WHERE initial_alerts_sent_at IS NULL
+  AND EXISTS (SELECT 1 FROM event_alert_subscriptions WHERE event_id = events.id);

--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -1258,7 +1258,40 @@ func (b *TelegramBot) startEventAlertsScheduler() {
 	defer ticker.Stop()
 
 	for range ticker.C {
+		b.processMissingInitialAlerts()
 		b.checkAndSendEventAlerts()
+	}
+}
+
+// processMissingInitialAlerts находит будущие события без отправленного
+// начального алерта (флаг initial_alerts_sent_at IS NULL) и отправляет их.
+// Нужно для APP_MODE=api, где хендлер не может дёрнуть бота напрямую.
+// Флаг ставится в любом случае (даже при ошибке отправки), чтобы избежать
+// бесконечных ретраев, если у события нет подходящих получателей.
+func (b *TelegramBot) processMissingInitialAlerts() {
+	var eventIds []int64
+	if err := database.DB.Model(&models.Event{}).
+		Where("initial_alerts_sent_at IS NULL AND date > ?", time.Now()).
+		Pluck("id", &eventIds).Error; err != nil {
+		log.Printf("Error loading events missing initial alerts: %v", err)
+		return
+	}
+	for _, id := range eventIds {
+		event, err := b.eventService.GetById(id)
+		if err != nil {
+			log.Printf("Error loading event %d for initial alert: %v", id, err)
+			continue
+		}
+		log.Printf("Sending missed initial alert for event %d (%s)", event.Id, event.Title)
+		if alertErr := b.SendInitialEventAlerts(event); alertErr != nil {
+			log.Printf("Error sending missed initial alert for event %d: %v", event.Id, alertErr)
+		}
+		now := time.Now()
+		if updErr := database.DB.Model(&models.Event{}).
+			Where("id = ?", event.Id).
+			Update("initial_alerts_sent_at", now).Error; updErr != nil {
+			log.Printf("Error updating initial_alerts_sent_at for event %d: %v", event.Id, updErr)
+		}
 	}
 }
 

--- a/backend/internal/handler/events.go
+++ b/backend/internal/handler/events.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"fmt"
+	"ithozyeva/database"
 	"ithozyeva/internal/bot"
 	"ithozyeva/internal/models"
 	"ithozyeva/internal/repository"
@@ -10,6 +11,7 @@ import (
 	"ithozyeva/internal/utils"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
@@ -196,7 +198,9 @@ func (h *EventsHandler) Create(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Ошибка создания события"})
 	}
 
-	// Отправляем инициализирующие алерты в фоне
+	// Отправляем инициализирующие алерты в фоне.
+	// При APP_MODE=api бот в этом процессе nil — алерт отправит бот на NL
+	// по флагу initial_alerts_sent_at через свой шедулер.
 	go func() {
 		telegramBot := bot.GetGlobalBot()
 		if telegramBot == nil {
@@ -205,6 +209,14 @@ func (h *EventsHandler) Create(c *fiber.Ctx) error {
 		}
 		if err := telegramBot.SendInitialEventAlerts(result); err != nil {
 			log.Printf("Error sending initial event alerts: %v", err)
+			return
+		}
+		// Помечаем как отправленное, чтобы шедулер бота не продублировал отправку.
+		now := time.Now()
+		if err := database.DB.Model(&models.Event{}).
+			Where("id = ?", result.Id).
+			Update("initial_alerts_sent_at", now).Error; err != nil {
+			log.Printf("Error marking initial_alerts_sent_at for event %d: %v", result.Id, err)
 		}
 	}()
 

--- a/backend/internal/models/events.go
+++ b/backend/internal/models/events.go
@@ -41,6 +41,7 @@ type Event struct {
 	Hosts                    []Member   `json:"hosts" gorm:"many2many:event_hosts;foreignKey:id;joinForeignKey:event_id;References:id;joinReferences:member_id;replace:true"`
 	Members                  []Member   `json:"members" gorm:"many2many:event_members;foreignKey:id;joinForeignKey:event_id;References:id;joinReferences:member_id;replace:true"`
 	LastRepeatingAlertSentAt *time.Time `json:"lastRepeatingAlertSentAt" gorm:"column:last_repeating_alert_sent_at"`
+	InitialAlertsSentAt      *time.Time `json:"initialAlertsSentAt" gorm:"column:initial_alerts_sent_at"`
 	ExclusiveChatID         *int64     `json:"exclusiveChatId" gorm:"column:exclusive_chat_id"`
 	ExclusiveChatTitle      string     `json:"exclusiveChatTitle" gorm:"column:exclusive_chat_title;default:''"`
 }


### PR DESCRIPTION
## Проблема

После сплита на APP_MODE=api/bot начальные алерты о новых событиях перестали доходить. В хендлере создания события:

\`\`\`go
telegramBot := bot.GetGlobalBot()
if telegramBot == nil {
    log.Printf(\"Telegram bot is not initialized, skipping alerts for event %d\", result.Id)
    return
}
\`\`\`

На продовом API-сервере (APP_MODE=api) бот в этом процессе \`nil\` — алерт молча пропадает. Реальный случай — событие 36, 0 подписок, в логах \"skipping alerts for event 36\".

## Решение

Флаг \`events.initial_alerts_sent_at\`:
- Хендлер ставит после успешной отправки (APP_MODE=full) — чтобы бот не продублировал.
- Бот на NL раз в минуту ищет \`WHERE initial_alerts_sent_at IS NULL AND date > NOW()\`, дёргает \`SendInitialEventAlerts\`, ставит флаг. Флаг ставится и при ошибке, чтобы не ретраить в цикле (например, если у эксклюзивного чата нет подходящих получателей).

## Миграция

\`\`\`sql
ALTER TABLE events ADD COLUMN IF NOT EXISTS initial_alerts_sent_at TIMESTAMP NULL;
UPDATE events SET initial_alerts_sent_at = NOW() WHERE date < NOW();
UPDATE events SET initial_alerts_sent_at = NOW() WHERE EXISTS (SELECT 1 FROM event_alert_subscriptions WHERE event_id = events.id);
\`\`\`

После миграции с NULL останется только event 36 (будущее + нет подписок) — бот подхватит его через минуту после рестарта.

## Test plan

- [ ] Мердж → автодеплой \`Deploy Bot (NL)\` → бот на NL рестартует
- [ ] В логах бота: \`Sending missed initial alert for event 36\`
- [ ] Участники Базы получают сообщение в Telegram
- [ ] В БД: \`initial_alerts_sent_at\` у event 36 не NULL
- [ ] Создать новое событие — оно тоже подхватится через минуту