### PR TITLE
fix(seo): отдавать 404 на неизвестных роутах лендинга

### DIFF
--- a/_nginx/conf.d/nginx.conf.template
+++ b/_nginx/conf.d/nginx.conf.template
@@ -46,8 +46,9 @@ server {
 
   location / {
     root /static/landing-frontend;
-    try_files $uri $uri.html $uri/ /index.html;
+    try_files $uri $uri.html $uri/ =404;
     index index.html;
+    error_page 404 /404.html;
     location ~* \.html$ {
       add_header Cache-Control "no-cache, no-store, must-revalidate";
     }

--- a/landing-frontend/public/404.html
+++ b/landing-frontend/public/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="shortcut icon" href="/favicon.svg">
+    <title>Страница не найдена — IT-ХОЗЯЕВА</title>
+    <style>
+      body { margin: 0; font: 16px/1.5 system-ui, -apple-system, sans-serif; color: #d4d4d4; background: #0b0d0c; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+      main { max-width: 520px; padding: 32px; text-align: center; }
+      h1 { font-size: 96px; margin: 0 0 8px; color: #5eead4; line-height: 1; font-weight: 700; }
+      h2 { font-size: 22px; margin: 0 0 16px; color: #e4e4e4; font-weight: 500; }
+      p { margin: 0 0 24px; color: #a3a3a3; }
+      a { display: inline-block; padding: 12px 24px; background: #5eead4; color: #0b0d0c; text-decoration: none; border-radius: 8px; font-weight: 500; transition: background 0.2s; }
+      a:hover { background: #2dd4bf; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>404</h1>
+      <h2>Страница не найдена</h2>
+      <p>Возможно, адрес введён с ошибкой или страница была удалена.</p>
+      <a href="/">На главную</a>
+    </main>
+  </body>
+</html>

--- a/landing-frontend/public/sitemap.xml
+++ b/landing-frontend/public/sitemap.xml
@@ -2,25 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ithozyaeva.ru/</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ithozyaeva.ru/mentors</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ithozyaeva.ru/vibe-coding</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ithozyaeva.ru/privacy</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
## Проблема

Google Search Console репортит «Страница является копией, канонический вариант не выбран пользователем» для `ithozyaeva.ru`.

Причина: nginx в `_nginx/conf.d/nginx.conf.template` использовал `try_files $uri $uri.html $uri/ /index.html` — любой несуществующий URL (`/nashuar`, `/foo`, etc.) отдавался как копия главной со статусом 200 и canonical=`https://ithozyaeva.ru/`. Google видел десятки дубликатов главной.

## Фикс

- В landing-location в nginx: `=404` вместо fallback-а на `/index.html`, добавлен `error_page 404 /404.html`.
- Статичная `public/404.html` с `<meta name="robots" content="noindex, nofollow">`.

Известные SPA-роуты (`/`, `/mentors`, `/vibe-coding`, `/privacy`) работают без изменений — под них уже генерятся отдельные HTML через `scripts/generate-route-html.mjs`, nginx находит их через `$uri.html`.

Редиректы http→https и www→apex оставлены как есть — это штатное поведение, Google их корректно трактует.

## Test plan
- [ ] После деплоя: `curl -I https://ithozyaeva.ru/nashuar` → 404
- [ ] `curl -I https://ithozyaeva.ru/mentors` → 200 (как и было)
- [ ] `curl -s https://ithozyaeva.ru/nashuar | grep robots` → noindex
- [ ] В GSC через пару недель проверить, что /nashuar и подобные уходят из «копий»