### PR TITLE
fix(landing): не обрезать '> answer:' в раскрытом FAQ

### DIFF
--- a/landing-frontend/src/sections/FAQSection.vue
+++ b/landing-frontend/src/sections/FAQSection.vue
@@ -90,7 +90,7 @@ function toggle(i: number) {
             :style="{ gridTemplateRows: openIndex === i ? '1fr' : '0fr' }"
           >
             <div class="overflow-hidden">
-              <div class="px-5 md:px-8 pb-6 md:pb-8 pl-14 md:pl-[66px] -mt-2">
+              <div class="px-5 md:px-8 pb-6 md:pb-8 pl-14 md:pl-[66px]">
                 <div class="font-mono text-[11px] text-accent/60 mb-2">
                   &gt; answer:
                 </div>


### PR DESCRIPTION
## Проблема
В раскрытом вопросе FAQ лейбл `> answer:` отображался обрезанным сверху — у пользователя видно только нижнюю половину текста.

## Причина
В `FAQSection.vue` у внутреннего контейнера ответа стоял `-mt-2`, а родитель с grid-анимацией раскрытия имеет `overflow-hidden`. Отрицательный верхний margin уводил контент под верхнюю границу обрезки.

## Исправление
Убрал `-mt-2`. Вертикального ритма, заданного паддингами кнопки-вопроса (`py-5 md:py-7`) и `pb-6 md:pb-8` у блока ответа, достаточно.

## Test plan
- [x] `npm run lint` в `landing-frontend`
- [x] `npm run type-check` в `landing-frontend`
- [ ] Визуально проверить, что при раскрытии любого FAQ-вопроса лейбл `> answer:` отображается полностью