### PR TITLE
fix(landing): адаптировать модалку согласия под мобильный экран

### DIFF
--- a/landing-frontend/src/components/ConfirmServiceModal.vue
+++ b/landing-frontend/src/components/ConfirmServiceModal.vue
@@ -2,7 +2,6 @@
 import { X as CloseIcon } from 'lucide-vue-next'
 import { useYandexMetrika } from 'yandex-metrika-vue3'
 import Button from '@/components/ui/UiButton.vue'
-import Typography from '@/components/ui/UiTypography.vue'
 import { useConfirmedPrivacy } from '@/composables/useUser'
 import { authService } from '@/services/auth'
 
@@ -42,51 +41,44 @@ function handleBackdropClick(event: MouseEvent) {
   <Transition name="modal-fade">
     <div
       v-if="isOpen"
-      class="fixed h-screen inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center backdrop-blur-sm"
+      class="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center backdrop-blur-sm p-4 sm:p-6"
       @click="handleBackdropClick"
     >
       <Transition name="modal-scale">
         <div
           v-if="isOpen"
-          class="bg-[#1D2723] rounded-3xl border-2 border-[#2B3D36] p-9 w-full mx-5 max-w-3xl  relative shadow-xl"
+          class="bg-[#1D2723] rounded-3xl border-2 border-[#2B3D36] p-5 sm:p-9 w-full max-w-3xl relative shadow-xl max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-3rem)] overflow-y-auto"
         >
           <button
             class="absolute right-3 top-3 cursor-pointer hover:opacity-75 transition-opacity"
             @click="handleClose"
           >
             <CloseIcon
-              class="h-8 w-8"
+              class="h-6 w-6 sm:h-8 sm:w-8"
             />
           </button>
 
-          <Typography
-            variant="h3"
-            as="p"
-            class="mb-3 text-accent"
+          <p
+            class="mb-3 pr-8 text-accent font-display uppercase font-semibold tracking-[0.04em] leading-tight text-lg sm:text-2xl"
           >
             Согласие на обработку персональных данных
-          </Typography>
+          </p>
 
-          <div class="mb-7">
-            <Typography
-              as="p"
-              variant="body-l"
-            >
+          <div class="mb-5 sm:mb-7">
+            <p class="font-sans font-medium leading-[1.4] text-sm sm:text-base md:text-lg">
               Нажимая на кнопку "Принять", Вы соглашаетесь с
-              <Typography
-                as="a"
-                variant="body-l"
+              <a
                 href="/privacy"
                 target="_blank"
                 class="text-accent underline cursor-pointer hover:text-accent/75 transition-colors"
               >
                 политикой конфиденциальности
-              </Typography>
+              </a>
               и даёте согласие на обработку персональных данных согласно Федеральному закону №152-ФЗ.
-            </Typography>
+            </p>
           </div>
 
-          <div class="flex flex-col-reverse sm:flex-row justify-start gap-5">
+          <div class="flex flex-col-reverse sm:flex-row justify-start gap-3 sm:gap-5">
             <Button
               variant="stroke"
               @click="handleClose"


### PR DESCRIPTION
## Проблема
На мобильном модалка «Согласие на обработку персональных данных» распирала вьюпорт: заголовок (h3 = 24px Unbounded uppercase) переносился на 4 строки, `p-9` на контейнере + отсутствие `max-height` делали контент выше экрана, кнопки уезжали за границу.

Дополнительно: Tailwind-утилиты вроде `text-lg` не применялись к `<Typography variant=\"h3\">`, потому что `.h3` в `UiTypography.vue` объявлен в `<style scoped>` — селектор `.h3[data-v-xxx]` имеет более высокую специфичность, чем `.text-lg`, и перебивает размер обратно на 24px.

## Исправление
- `max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-3rem)]` + `overflow-y-auto` на модалке — контент гарантированно помещается во вьюпорт.
- `p-5 sm:p-9` — компактный паддинг на мобильном.
- Заменил `<Typography variant=\"h3\">` и `<Typography variant=\"body-l\">` на обычные `<p>` с Tailwind-классами (`font-display uppercase text-lg sm:text-2xl` для заголовка, `text-sm sm:text-base md:text-lg` для тела) — чтобы заданные мобильные размеры реально применялись.
- Иконка X — `h-6 w-6 sm:h-8 sm:w-8`.
- Убрал `h-screen` у backdrop, добавил `p-4 sm:p-6` — модалка не прилипает к краям экрана.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [ ] Визуально: на iPhone SE (375×667) модалка открывается, заголовок укладывается в 2 строки, кнопки видны, при необходимости скролл внутри модалки
- [ ] Визуально: на десктопе layout без регрессий