### PR TITLE
feat(bot): фича-флаг SUBSCRIPTION_AUTO_KICK_ENABLED (default off)

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	AppMode string // "full", "api", "bot"
 
 	SubscriptionCheckIntervalHours int
+	SubscriptionAutoKickEnabled    bool
 
 	AlertReminderIntervalMinutes       int64
 	AlertReminderFirstIntervalMinutes  int64
@@ -188,6 +189,7 @@ func LoadConfig() {
 		OpenAIModel:   viper.GetString("OPENAI_MODEL"),
 
 		SubscriptionCheckIntervalHours: subCheckInterval,
+		SubscriptionAutoKickEnabled:    viper.GetBool("SUBSCRIPTION_AUTO_KICK_ENABLED"),
 		AlertReminderIntervalMinutes:       alertReminderInterval,
 		AlertReminderFirstIntervalMinutes:  alertReminderFirst,
 		AlertReminderSecondIntervalMinutes: alertReminderSecond,

--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -93,7 +93,16 @@ func (b *TelegramBot) createOneTimeInviteLink(chatID int64) (string, error) {
 }
 
 // kickFromChat kicks a user by ban+unban.
+// Управляется фича-флагом SUBSCRIPTION_AUTO_KICK_ENABLED: если он выключен,
+// бот ничего не делает и только пишет «dry-run» в лог. Это позволяет
+// безопасно отключить автоматическое удаление участников из анкорных чатов,
+// оставив логику вычисления «кого надо было бы убрать» без изменений.
 func (b *TelegramBot) kickFromChat(chatID, userID int64) {
+	if config.CFG == nil || !config.CFG.SubscriptionAutoKickEnabled {
+		log.Printf("[auto-kick disabled] dry-run: would kick user %d from chat %d", userID, chatID)
+		return
+	}
+
 	_, err := b.bot.Request(tgbotapi.BanChatMemberConfig{
 		ChatMemberConfig: tgbotapi.ChatMemberConfig{
 			ChatID: chatID,


### PR DESCRIPTION
## Summary

Бот кикает участников из анкорных чатов, когда у них «пропадает» подписка (вычисляется периодическим чекером). Пока эта логика иногда срабатывает ошибочно — временно отключаем сам клик по Telegram API, оставляя всё остальное (логика, логи, уведомления).

- Новый env-флаг `SUBSCRIPTION_AUTO_KICK_ENABLED` (`config.SubscriptionAutoKickEnabled`), **default false**.
- `kickFromChat` при выключенном флаге пишет в лог `[auto-kick disabled] dry-run: would kick user X from chat Y` и возвращается — `BanChatMemberConfig` / `UnbanChatMemberConfig` не вызываются.
- Всё, что выше по стеку (OnboardUser, шедулер подписок, invalidateMemberCache), продолжает работать как есть — можно будет посмотреть в логах, кого бот *собирался* кикнуть, и оценить масштаб, прежде чем включать обратно.

Чтобы включить позже — добавить `SUBSCRIPTION_AUTO_KICK_ENABLED=true` в env бота на NL и рестартнуть контейнер.

## Test plan

- [ ] Задеплоить на NL без `SUBSCRIPTION_AUTO_KICK_ENABLED`: при падении подписки в логе видно `[auto-kick disabled] dry-run: would kick user …`, но участник остаётся в чате.
- [ ] (позже) Выставить `SUBSCRIPTION_AUTO_KICK_ENABLED=true`, рестартнуть — dry-run пропадает, бот снова кикает.