### PR TITLE
feat(bot): автоочистка service-сообщений о вступлении/выходе

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -212,6 +212,13 @@ func (b *TelegramBot) Start() {
 			for _, newMember := range update.Message.NewChatMembers {
 				b.handleNewChatMember(update.Message.Chat.ID, &newMember)
 			}
+			b.deleteServiceMessage(update.Message.Chat.ID, update.Message.MessageID)
+			continue
+		}
+
+		// Сообщение «X вышел(а) из группы» — тоже убираем в наших чатах.
+		if update.Message.LeftChatMember != nil {
+			b.deleteServiceMessage(update.Message.Chat.ID, update.Message.MessageID)
 			continue
 		}
 
@@ -713,6 +720,19 @@ func (b *TelegramBot) sendMessage(chatID int64, text string) {
 	msg := tgbotapi.NewMessage(chatID, text)
 	if _, err := b.bot.Send(msg); err != nil {
 		log.Printf("Error sending message: %v", err)
+	}
+}
+
+// deleteServiceMessage убирает Telegram-service-сообщения (например,
+// «X вступил(а) в группу по ссылке-приглашению») в чатах, которые мы трекаем.
+// Ограничиваемся tracked_chats, чтобы не лезть с удалением в соседние чаты,
+// где бот мог оказаться случайно и без нужных прав.
+func (b *TelegramBot) deleteServiceMessage(chatID int64, messageID int) {
+	if !b.chatActivityService.IsTrackedChat(chatID) {
+		return
+	}
+	if _, err := b.bot.Request(tgbotapi.NewDeleteMessage(chatID, messageID)); err != nil {
+		log.Printf("Failed to delete service message %d in chat %d: %v", messageID, chatID, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

В anchor- и контент-чатах участников раздражают системные сообщения вроде «X вступил(а) в группу по ссылке-приглашению» и «X вышел(а) из группы» — их в IT-X десятки в день из-за деп-линка подписки. Теперь бот удаляет такие service-сообщения сразу после их появления.

- Хелпер `deleteServiceMessage` в \`telegram_bot.go\` зовёт \`tgbotapi.NewDeleteMessage\`.
- Применяется к \`update.Message.NewChatMembers\` и \`update.Message.LeftChatMember\`.
- Срабатывает **только** для чатов из \`IsTrackedChat\` (subscription-чаты, в которые мы добавили бота), чтобы не лезть с удалением в соседние проекты.
- В main-чате (\`TelegramMainChatID\`) приветственное сообщение бота (\`handleNewChatMember\`) отправляется как и раньше, но сам service-репорт о вступлении теперь уходит — лента чище.

Требование: у бота должно быть право удалять чужие сообщения в чате (\`can_delete_messages\`). Раньше этого не требовалось. Если в каком-то чате бот не админ или без этой привилегии — просто залогируется ошибка, service-сообщение останется.

## Test plan

- [ ] Добавить тестового юзера в один из tracked-чатов по инвайту → строка «X вступил(а) …» исчезает через секунду
- [ ] Убрать тестового юзера → «X вышел(а)» тоже убирается
- [ ] В main-чате (\`TELEGRAM_MAIN_CHAT_ID\`) приветственное сообщение от бота всё ещё приходит
- [ ] В логах при отсутствии прав: \`Failed to delete service message … Bad Request: message can't be deleted\` — не падает, просто warn