### PR TITLE
fix(bot): /substatus присылает чаты со ссылками

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -203,8 +203,19 @@ func (b *TelegramBot) handleSubStatusCommand(message *tgbotapi.Message) {
 		text += "\nДоступные чаты:\n"
 		for _, a := range access {
 			chat, err := b.subscriptionService.GetChat(a.ChatID)
-			if err == nil {
-				text += fmt.Sprintf("  • %s\n", chat.Title)
+			if err != nil {
+				continue
+			}
+			title := html.EscapeString(chat.Title)
+			// Для каждой записи создаём свежую одноразовую invite-ссылку — в
+			// subscription_user_chat_access ссылки не хранятся, а раздавать
+			// старые уже использованные одноразовые смысла нет. Если бот не
+			// админ в чате или API вернул ошибку — отдаём просто название.
+			if link, linkErr := b.createOneTimeInviteLink(a.ChatID); linkErr == nil {
+				text += fmt.Sprintf("  • <a href=\"%s\">%s</a>\n", link, title)
+			} else {
+				log.Printf("substatus: failed to create invite link for chat %d: %v", a.ChatID, linkErr)
+				text += fmt.Sprintf("  • %s\n", title)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Команда /substatus возвращала только названия чатов — пользователь видел список, но не мог никуда нажать и в итоге всё равно вызывал /sub. Теперь к каждому чату из \`subscription_user_chat_access\` генерируется свежая одноразовая invite-ссылка через \`createOneTimeInviteLink\` (та же, что и в /sub), и название выводится как кликабельный \`<a>\`-hyperlink.

Title проходит через \`html.EscapeString\` — сообщение уже идёт HTML parse-mode. Если для какого-то чата Telegram API вернёт ошибку (например, бот не админ) — fallback на обычный текст, вся команда не падает.

## Test plan

- [ ] /substatus у пользователя с активной подпиской → список чатов кликабельный, каждая ссылка ведёт в нужный чат
- [ ] /substatus у пользователя без подписки → тот же текст, что и раньше («Тир: Нет», без блока «Доступные чаты»)
- [ ] Если бот не админ в одном из чатов — этот чат показывается без ссылки, остальные работают