### PR TITLE
fix(db): бэкфилит tracked_chats из subscription_chats

### DIFF
--- a/backend/database/migrations/20260422170000_backfill_tracked_chats.sql
+++ b/backend/database/migrations/20260422170000_backfill_tracked_chats.sql
@@ -1,0 +1,15 @@
+-- Backfill tracked_chats from subscription_chats.
+--
+-- Авто-трекинг (PR #260) добавляет чат в tracked_chats, когда бота добавляют
+-- в группу. Чаты, которые уже были в subscription_chats до этого PR, в
+-- tracked_chats не попали — и для них не работает автоочистка service-
+-- сообщений (она фильтрует по IsTrackedChat). Одноразово заливаем все
+-- недостающие записи; у новых чатов всё продолжит работать через
+-- ChatActivityService.AddTrackedChat.
+
+INSERT INTO tracked_chats (chat_id, title, chat_type, is_active)
+SELECT sc.id, sc.title, sc.chat_type, TRUE
+FROM subscription_chats sc
+WHERE NOT EXISTS (
+    SELECT 1 FROM tracked_chats tc WHERE tc.chat_id = sc.id
+);


### PR DESCRIPTION
## Summary

После мерджа #262 (автоочистка service-сообщений о вступлении/выходе) пользователь показал, что в некоторых чатах — «IT-X: Путешествия», «IT-X: Корпорации. Карьера» — сообщения о вступлении по-прежнему не удаляются. Проверка на проде:

\`\`\`
SELECT COUNT(*) FROM subscription_chats;  -- 25
SELECT COUNT(*) FROM tracked_chats WHERE is_active;  -- 22
\`\`\`

Авто-трекинг из #260 регистрирует чат в \`tracked_chats\` только когда бота **добавляют** в группу. Чаты, которые уже были в \`subscription_chats\` до того PR, так и остались без записи в \`tracked_chats\`, поэтому \`deleteServiceMessage\` (фильтрующий по \`IsTrackedChat\`) для них не срабатывал. Новые чаты после деплоя #260 регистрируются корректно — проблема только с «старыми».

Миграция одноразово заливает недостающие записи. Идемпотентна: \`INSERT … WHERE NOT EXISTS\`. После применения + рестарта бота (чтобы перечитать in-memory кеш) автоочистка начнёт работать на всех чатах подписок.

## Test plan

- [ ] Применить миграцию на прод → \`SELECT COUNT(*) FROM tracked_chats WHERE is_active\` стало 25
- [ ] Рестарт контейнера бота (\`loadTrackedChats\` перечитывает кеш только при старте)
- [ ] Вступить в «Путешествия» через invite-link → сообщение «X вступил(а) …» пропадает через секунду