### PR TITLE
feat(bot): рассылать invite-ссылки пользователям при привязке чата к тиру

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -530,11 +530,75 @@ func (b *TelegramBot) handleSubAddChatCommand(message *tgbotapi.Message) {
 		b.subscriptionService.SetAnchor(chatID, &tier.ID)
 		b.SendDirectMessage(message.Chat.ID, fmt.Sprintf(
 			"Чат <code>%d</code> установлен как <b>anchor</b> для тира %s.", chatID, tier.Name))
-	} else {
-		b.subscriptionService.AddChatToTier(chatID, tier.ID)
-		b.SendDirectMessage(message.Chat.ID, fmt.Sprintf(
-			"Чат <code>%d</code> добавлен как <b>content</b> для тира %s.", chatID, tier.Name))
+		return
 	}
+
+	b.subscriptionService.AddChatToTier(chatID, tier.ID)
+	b.SendDirectMessage(message.Chat.ID, fmt.Sprintf(
+		"Чат <code>%d</code> добавлен как <b>content</b> для тира %s.", chatID, tier.Name))
+
+	// Рассылаем уведомления всем пользователям, у которых эффективный тир
+	// достаточного уровня и ещё нет доступа в этот чат. Делаем асинхронно,
+	// чтобы команда /subaddchat не блокировалась на N Telegram-запросах.
+	go b.notifyNewChatAccess(chatID, title, tier.Level, message.Chat.ID)
+}
+
+// notifyNewChatAccess выдаёт доступ в chatID всем пользователям с нужным
+// уровнем тира (у кого его ещё нет) и рассылает им одноразовые invite-ссылки
+// в ЛС. В конце отправляет супер-админу сводку по рассылке.
+func (b *TelegramBot) notifyNewChatAccess(chatID int64, chatTitle string, tierLevel int, adminChatID int64) {
+	users, err := b.subscriptionService.GetEligibleUsersWithoutAccessForChat(chatID, tierLevel)
+	if err != nil {
+		log.Printf("notifyNewChatAccess: failed to fetch eligible users for chat %d: %v", chatID, err)
+		b.SendDirectMessage(adminChatID, fmt.Sprintf("Не удалось собрать список получателей для чата <code>%d</code>: %v", chatID, err))
+		return
+	}
+	if len(users) == 0 {
+		b.SendDirectMessage(adminChatID, fmt.Sprintf("Рассылка не нужна: в чате <code>%d</code> уже все с подходящим тиром.", chatID))
+		return
+	}
+
+	titleEscaped := html.EscapeString(chatTitle)
+	delivered, skipped, failed := 0, 0, 0
+
+	for _, user := range users {
+		link, err := b.createOneTimeInviteLink(chatID)
+		if err != nil {
+			log.Printf("notifyNewChatAccess: invite-link failed for chat %d user %d: %v", chatID, user.ID, err)
+			failed++
+			continue
+		}
+		text := fmt.Sprintf(
+			"🆕 Вам открыт новый чат по вашей подписке:\n\n<b>%s</b>\n\n<a href=\"%s\">Перейти в чат</a>",
+			titleEscaped, link)
+		msg := tgbotapi.NewMessage(user.ID, text)
+		msg.ParseMode = "HTML"
+		msg.DisableWebPagePreview = true
+		if _, err := b.bot.Send(msg); err != nil {
+			// Forbidden = пользователь не нажимал /start боту. Не считаем это
+			// ошибкой, просто skip — ссылка «прогорает» без жертв.
+			if strings.Contains(err.Error(), "Forbidden") {
+				skipped++
+			} else {
+				log.Printf("notifyNewChatAccess: DM failed to user %d: %v", user.ID, err)
+				failed++
+			}
+			continue
+		}
+		if err := b.subscriptionService.GrantAccess(user.ID, chatID); err != nil {
+			log.Printf("notifyNewChatAccess: grant failed for user %d chat %d: %v", user.ID, chatID, err)
+			failed++
+			continue
+		}
+		delivered++
+		// Небольшая пауза между отправками, чтобы не упереться в Telegram
+		// flood-limit при рассылке на 100+ пользователей.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	b.SendDirectMessage(adminChatID, fmt.Sprintf(
+		"Рассылка по чату <code>%d</code>: доставлено %d, пропущено (бот заблокирован) %d, ошибок %d.",
+		chatID, delivered, skipped, failed))
 }
 
 func (b *TelegramBot) handleSubSetAnchorCommand(message *tgbotapi.Message) {

--- a/backend/internal/repository/subscription.go
+++ b/backend/internal/repository/subscription.go
@@ -271,6 +271,25 @@ func (r *SubscriptionRepository) CountAllUsers() (int64, error) {
 	return count, err
 }
 
+// GetEligibleUsersWithoutAccessForChat возвращает пользователей, у которых
+// эффективный тир (manual, иначе resolved) имеет уровень >= tierLevel и
+// при этом нет активной записи в subscription_user_chat_access для chatID.
+// Используется для рассылки новых чат-доступов, когда чат только что
+// привязали к тиру.
+func (r *SubscriptionRepository) GetEligibleUsersWithoutAccessForChat(
+	chatID int64, tierLevel int,
+) ([]models.SubscriptionUser, error) {
+	var users []models.SubscriptionUser
+	err := r.db.
+		Table("subscription_users AS su").
+		Select("su.*").
+		Joins(`JOIN subscription_tiers st ON st.id = COALESCE(su.manual_tier_id, su.resolved_tier_id)`).
+		Joins(`LEFT JOIN subscription_user_chat_access sa ON sa.user_id = su.id AND sa.chat_id = ? AND sa.revoked_at IS NULL`, chatID).
+		Where("su.is_active = ? AND st.level >= ? AND sa.user_id IS NULL", true, tierLevel).
+		Find(&users).Error
+	return users, err
+}
+
 func (r *SubscriptionRepository) GetUsersByTier(tierID uint) ([]models.SubscriptionUser, error) {
 	var users []models.SubscriptionUser
 	err := r.db.Where(

--- a/backend/internal/service/subscription.go
+++ b/backend/internal/service/subscription.go
@@ -285,6 +285,14 @@ func (s *SubscriptionService) SetChatTiers(chatID int64, tierIDs []uint) error {
 	return s.repo.SetChatTiers(chatID, tierIDs)
 }
 
+// GetEligibleUsersWithoutAccessForChat — пользователи с эффективным тиром
+// уровня >= tierLevel, которым доступ к этому чату ещё не выдан.
+func (s *SubscriptionService) GetEligibleUsersWithoutAccessForChat(
+	chatID int64, tierLevel int,
+) ([]models.SubscriptionUser, error) {
+	return s.repo.GetEligibleUsersWithoutAccessForChat(chatID, tierLevel)
+}
+
 func (s *SubscriptionService) DeleteChat(chatID int64) error {
 	return s.repo.DeleteChat(chatID)
 }
@@ -307,6 +315,10 @@ func (s *SubscriptionService) GetActiveAccess(userID int64) ([]models.Subscripti
 
 func (s *SubscriptionService) GetUsersWithAccessToChat(chatID int64) ([]models.SubscriptionUser, error) {
 	return s.repo.GetUsersWithAccessToChat(chatID)
+}
+
+func (s *SubscriptionService) GrantAccess(userID int64, chatID int64) error {
+	return s.repo.GrantAccess(userID, chatID)
 }
 
 func (s *SubscriptionService) RevokeAccess(userID int64, chatID int64) error {


### PR DESCRIPTION
## Summary

Фаза 1 системы оповещений о новых чатах (обсуждали в чате, там же рассматривали Redis pub/sub для UI-флоу — его оставил на отдельный PR).

Когда супер-админ вызывает \`/subaddchat <chat_id> <slug>\` и привязывает чат к content-тиру, бот теперь:

1. Выбирает всех активных пользователей, у которых эффективный тир (manual, иначе resolved) имеет уровень >= уровня привязанного тира, и у которых ещё нет активного access в этом чате. Новый repo-метод \`GetEligibleUsersWithoutAccessForChat\`.
2. Для каждого создаёт одноразовую invite-ссылку и шлёт DM «Вам открыт новый чат по подписке: <Title> — <link>».
3. Grant'ит access только после успешного DM — заблокированные ботом пользователи не считаются «уведомлёнными» и попадут в следующую рассылку.
4. Выдерживает паузу 50 ms между отправками (Telegram bot flood-limit ~30 req/s).
5. В конце пишет супер-админу сводку: доставлено / пропущено (Forbidden) / ошибок.

Anchor-чаты из рассылки исключены (\`isAnchor\` возвращает \`return\` перед goroutine): членство в anchor определяет подписку, пользователь должен зайти туда сам.

## Границы и известные ограничения

- Срабатывает **только** на bot-команде \`/subaddchat\`. Админка (\`PUT /subscriptions/chats\`) пока рассылку не триггерит — API-бэк в РФ, Telegram API оттуда недоступен. Мост Redis pub/sub — следующим PR.
- На сотни юзеров рассылка идёт ~5–10 сек, goroutine не блокирует команду.
- \`createOneTimeInviteLink\` создаёт N ссылок (по одной на юзера) — в списке invite-links чата будет шумно; можно схлопнуть в одну ссылку с \`MemberLimit: N\`, но это позже, если будет мешать.

## Test plan

- [ ] Зарегистрировать тестовую группу как content через \`/subaddchat <id> master\` → супер-админу прилетает сводка «доставлено X, пропущено Y, ошибок 0»
- [ ] Пользователям с тиром Master приходит DM «🆕 Вам открыт новый чат…», ссылка кликабельна, ведёт в чат
- [ ] Повторный \`/subaddchat\` того же чата → сводка «Рассылка не нужна: все с подходящим тиром»
- [ ] \`/subaddchat ... anchor\` → рассылки нет, только подтверждение в ЛС админа
- [ ] Для пользователя, заблокировавшего бота, access не выдаётся (\`GetActiveAccess\` его не покажет), но и ошибки в логах нет