### PR TITLE
feat(bot): команда /mygroups — доступные чаты, куда ещё не вступил

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"ithozyeva/config"
+	"ithozyeva/internal/models"
 	"ithozyeva/internal/service"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -217,6 +218,69 @@ func (b *TelegramBot) handleSubStatusCommand(message *tgbotapi.Message) {
 				log.Printf("substatus: failed to create invite link for chat %d: %v", a.ChatID, linkErr)
 				text += fmt.Sprintf("  • %s\n", title)
 			}
+		}
+	}
+
+	b.SendDirectMessage(message.Chat.ID, text)
+}
+
+// handleMyGroupsCommand shows chats available to the user's tier that they
+// haven't joined yet, with fresh one-time invite links for each.
+func (b *TelegramBot) handleMyGroupsCommand(message *tgbotapi.Message) {
+	userID := message.From.ID
+	user, err := b.subscriptionService.GetUser(userID)
+	if err != nil {
+		b.sendMessage(message.Chat.ID, "Вы не зарегистрированы. Используйте /sub, чтобы начать.")
+		return
+	}
+
+	effectiveTierID := user.EffectiveTierID()
+	if effectiveTierID == nil {
+		b.sendMessage(message.Chat.ID,
+			"У вас нет активной подписки. Используйте /sub, чтобы получить доступ к чатам.")
+		return
+	}
+
+	tier, err := b.subscriptionService.GetTier(*effectiveTierID)
+	if err != nil {
+		log.Printf("mygroups: failed to get tier %d: %v", *effectiveTierID, err)
+		b.sendMessage(message.Chat.ID, "Не удалось получить ваш тир. Попробуйте позже.")
+		return
+	}
+
+	chats, err := b.subscriptionService.GetChatsForTierLevel(tier.Level)
+	if err != nil {
+		log.Printf("mygroups: failed to list chats for level %d: %v", tier.Level, err)
+		b.sendMessage(message.Chat.ID, "Не удалось получить список чатов.")
+		return
+	}
+
+	// Фильтруем через Telegram API: оставляем только те, в которых юзер
+	// ещё не состоит. IsMember кеширует результат в Redis (5 мин TTL), так
+	// что при частых /mygroups не бомбим getChatMember.
+	notJoined := make([]models.SubscriptionChat, 0, len(chats))
+	for _, chat := range chats {
+		if !b.subscriptionService.IsMember(chat.ID, userID, b.isChatMember) {
+			notJoined = append(notJoined, chat)
+		}
+	}
+
+	if len(notJoined) == 0 {
+		b.SendDirectMessage(message.Chat.ID,
+			"Вы уже состоите во всех чатах, доступных по тиру <b>"+html.EscapeString(tier.Name)+"</b>.")
+		return
+	}
+
+	text := fmt.Sprintf(
+		"<b>Доступные чаты по подписке (%s), куда можно зайти:</b>\n\n",
+		html.EscapeString(tier.Name))
+	for _, chat := range notJoined {
+		title := html.EscapeString(chat.Title)
+		if link, linkErr := b.createOneTimeInviteLink(chat.ID); linkErr == nil {
+			text += fmt.Sprintf("• <a href=\"%s\">%s</a>\n", link, title)
+		} else {
+			log.Printf("mygroups: invite-link failed for chat %d: %v", chat.ID, linkErr)
+			text += fmt.Sprintf("• %s\n", title)
 		}
 	}
 

--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -263,6 +263,8 @@ func (b *TelegramBot) Start() {
 				b.handleSubCommand(update.Message)
 			case "substatus":
 				b.handleSubStatusCommand(update.Message)
+			case "mygroups":
+				b.handleMyGroupsCommand(update.Message)
 			// Admin subscription commands
 			case "subchats":
 				b.handleSubChatsCommand(update.Message)
@@ -297,6 +299,7 @@ func (b *TelegramBot) registerCommands() {
 	commands := []tgbotapi.BotCommand{
 		{Command: "start", Description: "Авторизация на платформе"},
 		{Command: "mypoints", Description: "Мои баллы"},
+		{Command: "mygroups", Description: "Доступные чаты, куда ещё не вступил"},
 		{Command: "events", Description: "Ближайшие события"},
 		{Command: "summarize", Description: "Саммари чата (day/week/3d/число)"},
 		{Command: "whois", Description: "Кто этот участник"},
@@ -360,6 +363,7 @@ func (b *TelegramBot) handleHelpCommand(message *tgbotapi.Message) {
 		"  Лимит: 5 запросов в день\n" +
 		"/sub - Проверить подписку и получить доступ к чатам\n" +
 		"/substatus - Статус подписки\n" +
+		"/mygroups - Доступные чаты, в которых ты ещё не состоишь\n" +
 		"/whois - Кто этот участник (ответьте на сообщение или /whois @username)\n" +
 		"/help - Помощь"
 

--- a/backend/internal/service/subscription.go
+++ b/backend/internal/service/subscription.go
@@ -293,6 +293,12 @@ func (s *SubscriptionService) GetEligibleUsersWithoutAccessForChat(
 	return s.repo.GetEligibleUsersWithoutAccessForChat(chatID, tierLevel)
 }
 
+// GetChatsForTierLevel — все content-чаты, привязанные к тирам с level <= tierLevel.
+// Anchor-чаты не включены (членство в них определяет сам тир).
+func (s *SubscriptionService) GetChatsForTierLevel(tierLevel int) ([]models.SubscriptionChat, error) {
+	return s.repo.GetChatsForTierLevel(tierLevel)
+}
+
 func (s *SubscriptionService) DeleteChat(chatID int64) error {
 	return s.repo.DeleteChat(chatID)
 }


### PR DESCRIPTION
## Summary

В меню бота теперь появляется команда \`/mygroups\`. Она шлёт пользователю список доступных ему content-чатов (по его тиру), в которых он ещё **не** состоит, с одноразовыми invite-ссылками на каждый.

Полезно, когда:
- Рассылка от #265 не дошла (юзер заблокировал бота когда-то, потом разблокировал).
- Юзер пропустил чат из \`/sub\` и хочет увидеть, куда ещё можно зайти.

- \`SubscriptionService.GetChatsForTierLevel\` — новый wrapper, чтобы бот не тянул repo напрямую.
- Членство проверяется через \`IsMember\` с Redis-кешем (5 мин TTL) — частые \`/mygroups\` не бомбят Telegram \`getChatMember\`.
- \`SetMyCommands\` обновлён — команда появляется в выпадающем меню бота (как на скриншоте у \`/mypoints\`, \`/events\` и т.д.).
- \`/help\` тоже обновлён.

Anchor-чаты из списка исключены: там членство = подписка, их не сюда.

## Test plan

- [ ] Юзер с активной подпиской вызывает \`/mygroups\` → приходит список чатов с кликабельными ссылками.
- [ ] Юзер, уже состоящий везде → «Вы уже состоите во всех чатах, доступных по тиру …».
- [ ] Юзер без подписки → «У вас нет активной подписки. Используйте /sub …».
- [ ] Команда видна в меню бота (иконка «/») рядом с \`/mypoints\`.