### PR TITLE
fix: прод-билд фронтов, несколько anchor'ов на тир, таймаут deploy-bot

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
     paths:
       - 'backend/**'
+  # Ручной триггер нужен, когда push не срабатывает (merge без backend/**,
+  # или предыдущий прогон упал по таймауту и контейнер остался на старом коде).
+  workflow_dispatch: {}
 
 jobs:
   deploy_bot:
@@ -29,7 +32,10 @@ jobs:
           username: ${{ secrets.SSH_BOT_USER }}
           key:      ${{ secrets.SSH_BOT_KEY }}
           port:     ${{ secrets.SSH_BOT_PORT }}
-          command_timeout: 30m
+          # NL-сервер слабый; Go build --no-cache занимает 20–27 мин, а при
+          # конкурентных нагрузках от соседних проектов — упирается в лимит.
+          # 60m даёт запас и не плодит зависшие docker build-процессы.
+          command_timeout: 60m
           script: |
             cd /opt/itx-bot
             docker compose build --no-cache platform-bot

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,8 +46,17 @@ jobs:
           envs: VITE_YANDEX_METRIKA_ID,VITE_YANDEX_METRIKA_ENABLED
           script: |
             cd ${{ secrets.PROJECT_PROD_PATH }}
+            # Copy shared UI package into frontend directories for Docker context.
+            # Без этого admin-frontend/platform-frontend build падает при загрузке
+            # tailwind.config.js (require('../packages/ui/tailwind.preset')), а сам
+            # docker compose build завершается с ненулевым кодом, но workflow этого
+            # не видит — и up -d поднимает контейнер на старом образе.
+            cp -r packages/ui platform-frontend/_packages_ui
+            cp -r packages/ui admin-frontend/_packages_ui
             # Build new images with legacy builder (BuildKit ignores --no-cache)
             DOCKER_BUILDKIT=0 CACHEBUST=$(date +%s) docker compose -f docker-compose.prod.yml build --no-cache
+            # Remove temporary copies
+            rm -rf platform-frontend/_packages_ui admin-frontend/_packages_ui
             # Проект-локальная очистка зависших контейнеров от предыдущих неудачных деплоев.
             # docker compose --force-recreate падает с Container name already in use, если
             # старый контейнер остался c hash-prefix'ом — явно удаляем по имени.

--- a/backend/internal/service/subscription.go
+++ b/backend/internal/service/subscription.go
@@ -69,22 +69,26 @@ func (s *SubscriptionService) ResolveTierID(userID int64, botCheckFunc func(chat
 		return nil
 	}
 
-	// Build anchor map: tierID -> chatID
-	anchorMap := make(map[uint]int64)
+	// tierID -> все чаты, которые для него anchor. Раньше был map[uint]int64
+	// и при дубликате anchor'ов на один тир последний перезаписывал первые,
+	// из-за чего часть юзеров из anchor-чата мимо «выживающего» теряли тир.
+	anchorMap := make(map[uint][]int64)
 	for _, c := range anchorChats {
 		if c.AnchorForTierID != nil {
-			anchorMap[*c.AnchorForTierID] = c.ID
+			anchorMap[*c.AnchorForTierID] = append(anchorMap[*c.AnchorForTierID], c.ID)
 		}
 	}
 
 	for _, tier := range tiersDesc {
-		anchorChatID, ok := anchorMap[tier.ID]
+		chatIDs, ok := anchorMap[tier.ID]
 		if !ok {
 			continue
 		}
-		if s.IsMember(anchorChatID, userID, botCheckFunc) {
-			id := tier.ID
-			return &id
+		for _, chatID := range chatIDs {
+			if s.IsMember(chatID, userID, botCheckFunc) {
+				id := tier.ID
+				return &id
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Три независимых фикса, которые выплыли из отладки сегодняшнего хвоста задач — держу в одном PR по просьбе.

### 1. Прод-билд \`admin-frontend\` / \`platform-frontend\` падал тихо
Локально \`npm run build\` работает, на проде — нет: \`tailwind.config.js\` делает \`require('../packages/ui/tailwind.preset')\`, а в Docker-контекст \`./admin-frontend\` этой папки нет. В \`deploy-dev.yml\` шаг копирования уже есть (\`cp -r packages/ui admin-frontend/_packages_ui\`), в \`deploy-production.yml\` — **нет**. Итог: \`docker compose build\` возвращает ненулевой код, workflow этого не замечает, \`up -d\` поднимает контейнер на старом образе. Из-за этого admin-frontend на проде оставался от 9 дней назад — #259 фильтры, #260 супер-админ-прятки в UI и т.п. в прод **не ехали** уже неделями.

Добавил те же \`cp -r packages/ui ...\` и \`rm -rf\` в \`deploy-production.yml\`.

### 2. \`ResolveTierID\` ломается при двух anchor-чатах на один тир
На проде нашёл дубль: \`IT-Х: Якорь. База\` с tier=3 жил под двумя id — корректным \`-1003875584123\` и древним \`-5203153204\` (basic-group, остаток от миграции в супергруппу). В \`ResolveTierID\` сейчас \`map[uint]int64\` — при построении второй чат перезаписывал первый, бот проверял только один, пользователи из «невыжившего» теряли тир.

\`anchorMap\` стала \`map[uint][]int64\`, при ресолве проходим все anchor-чаты тира.

(Мусорную запись уже удалил руками на проде: \`DELETE FROM subscription_chats WHERE id = -5203153204\`.)

### 3. \`deploy-bot\` таймаут
Сегодня три подряд прогона легли по \`command_timeout: 30m\`. \`go build --no-cache\` на NL упирается в 25–28 минут даже когда сервер свободен, а при конкурентной нагрузке просто не успевает. SSH-action умирает, GitHub Actions считает job провалившимся, но \`docker compose build\` на сервере продолжает жить и жрёт CPU — такие «зомби» накопились пачкой, load поднимался до 40.

- \`command_timeout: 30m → 60m\`.
- Добавил \`workflow_dispatch\`, чтобы можно было руками перезапустить, когда push в \`backend/**\` не триггерит (например, нужно переделать сборку после таймаута без нового коммита).

## Test plan

- [ ] Пушнуть в master → \`deploy-bot\` запустится автоматически; также можно запустить вручную из Actions → «Deploy Bot (NL)» → Run workflow.
- [ ] После \`deploy-production\` проверить \`docker images | grep admin-frontend\` — timestamp свежий; \`curl ithozyaeva.ru/admin/assets/SubscriptionsView-*.js | grep "Без привязки"\` находит.
- [ ] В админке вкладка «Подписки → Чаты» показывает чипы-фильтры \`Все / Beginner / Foreman / Master / Без привязки\`.
- [ ] Если в будущем на одном тире окажется два anchor'а — \`/sub\` корректно определит тир для юзера, состоящего в любом из них (без «У вас нет активной подписки»).