### PR TITLE
feat(subs): группировка чатов, рассылка из UI, /substatus по тиру

### DIFF
--- a/admin-frontend/src/services/subscriptionService.ts
+++ b/admin-frontend/src/services/subscriptionService.ts
@@ -32,6 +32,7 @@ export interface SubscriptionChat {
   activeUsers: number
   category?: string | null
   emoji?: string | null
+  priority?: number
 }
 
 export interface SubscriptionChatDetail {
@@ -42,6 +43,7 @@ export interface SubscriptionChatDetail {
   tierIDs: number[]
   category?: string | null
   emoji?: string | null
+  priority?: number
 }
 
 export interface SubscriptionUser {
@@ -191,7 +193,7 @@ class SubscriptionService {
     }
   }
 
-  createChat = async (data: { id: number, title: string, chatType: string, anchorForTierID?: number, tierIDs?: number[], category?: string | null, emoji?: string | null }): Promise<boolean> => {
+  createChat = async (data: { id: number, title: string, chatType: string, anchorForTierID?: number, tierIDs?: number[], category?: string | null, emoji?: string | null, priority?: number }): Promise<boolean> => {
     try {
       await api.post('subscriptions/chats', { json: data }).json()
       this.toast.toast({ title: 'Успешно', description: 'Чат добавлен' })
@@ -203,7 +205,7 @@ class SubscriptionService {
     }
   }
 
-  updateChat = async (chatId: number, data: { title?: string, anchorForTierID?: number, clearAnchor?: boolean, tierIDs?: number[], category?: string | null, emoji?: string | null, clearCategory?: boolean }): Promise<boolean> => {
+  updateChat = async (chatId: number, data: { title?: string, anchorForTierID?: number, clearAnchor?: boolean, tierIDs?: number[], category?: string | null, emoji?: string | null, clearCategory?: boolean, priority?: number }): Promise<boolean> => {
     try {
       await api.put(`subscriptions/chats/${chatId}`, { json: data }).json()
       this.toast.toast({ title: 'Успешно', description: 'Чат обновлён' })

--- a/admin-frontend/src/views/SubscriptionsView.vue
+++ b/admin-frontend/src/views/SubscriptionsView.vue
@@ -39,6 +39,7 @@ const expandedLoading = ref(false)
 const savingAction = ref<string | null>(null)
 const expandedCategory = ref('')
 const expandedEmoji = ref('')
+const expandedPriority = ref<number>(0)
 const savingCategory = ref(false)
 
 // Фильтр списка чатов: выбранные tierId + флаг "без привязки".
@@ -108,6 +109,7 @@ const unlinkedCount = computed(() =>
 watch(expandedChatDetail, (detail) => {
   expandedCategory.value = detail?.category ?? ''
   expandedEmoji.value = detail?.emoji ?? ''
+  expandedPriority.value = detail?.priority ?? 0
 })
 
 const stats = computed(() => subscriptionService.stats.value)
@@ -205,16 +207,19 @@ async function toggleContentTier(chatId: number, tierId: number) {
 async function saveCategoryEmoji(chatId: number) {
   savingCategory.value = true
   try {
+    const priority = Number.isFinite(expandedPriority.value) ? expandedPriority.value : 0
     const success = await subscriptionService.updateChat(chatId, {
       category: expandedCategory.value || null,
       emoji: expandedEmoji.value || null,
       clearCategory: !expandedCategory.value && !expandedEmoji.value,
+      priority,
     })
     if (success && expandedChatDetail.value) {
       expandedChatDetail.value = {
         ...expandedChatDetail.value,
         category: expandedCategory.value || null,
         emoji: expandedEmoji.value || null,
+        priority,
       }
       await subscriptionService.fetchChats()
     }
@@ -753,10 +758,10 @@ onUnmounted(subscriptionService.clearPagination)
                   </div>
                 </div>
 
-                <!-- Category / Emoji inline editor -->
+                <!-- Category / Emoji / Priority inline editor -->
                 <div>
                   <div class="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
-                    Категория в боте
+                    Категория и приоритет
                   </div>
                   <div class="flex items-center gap-2">
                     <Input
@@ -771,6 +776,13 @@ onUnmounted(subscriptionService.clearPagination)
                       placeholder="Название категории"
                       maxlength="100"
                     />
+                    <Input
+                      v-model.number="expandedPriority"
+                      type="number"
+                      class="w-20 text-center"
+                      placeholder="0"
+                      title="Чем выше — тем выше категория в списках бота"
+                    />
                     <Button
                       size="sm"
                       :disabled="savingCategory"
@@ -782,6 +794,9 @@ onUnmounted(subscriptionService.clearPagination)
                       />
                       {{ savingCategory ? 'Сохранение' : 'Сохранить' }}
                     </Button>
+                  </div>
+                  <div class="mt-1 text-xs text-muted-foreground/70">
+                    Приоритет: чем больше число, тем выше категория в меню бота (0 = дефолт).
                   </div>
                 </div>
               </div>

--- a/backend/database/migrations/20260423000000_add_chat_priority.sql
+++ b/backend/database/migrations/20260423000000_add_chat_priority.sql
@@ -1,0 +1,11 @@
+-- priority управляет порядком категорий в списках чатов, которые бот шлёт
+-- пользователям (/sub, /substatus, /mygroups, рассылки). При группировке по
+-- category группы сортируются по MAX(priority) DESC — так «элитные» чаты
+-- (База Стародубцева, AI-X) можно вывести наверх, просто проставив им
+-- высокий priority; дефолт 0 сохраняет текущее поведение.
+
+ALTER TABLE subscription_chats
+    ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_subscription_chats_priority
+    ON subscription_chats (priority DESC);

--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -194,31 +195,44 @@ func (b *TelegramBot) handleSubStatusCommand(message *tgbotapi.Message) {
 		}
 	}
 
+	// Собираем доступные юзеру чаты по двум источникам:
+	//  1. Записи в subscription_user_chat_access — явно выданный доступ.
+	//  2. Чаты, привязанные к его тиру (или ниже) — доступны даже если
+	//     access-запись ещё не проставлена (например, чат добавили недавно,
+	//     рассылка не прошла или юзер заблокировал бота).
+	// Объединение даёт полный ответ на вопрос «что мне доступно по подписке».
+	unique := map[int64]models.SubscriptionChat{}
 	access, _ := b.subscriptionService.GetActiveAccess(message.From.ID)
+	for _, a := range access {
+		if chat, err := b.subscriptionService.GetChat(a.ChatID); err == nil {
+			unique[a.ChatID] = *chat
+		}
+	}
+	if tierID != nil {
+		if tier, err := b.subscriptionService.GetTier(*tierID); err == nil {
+			chats, _ := b.subscriptionService.GetChatsForTierLevel(tier.Level)
+			for _, c := range chats {
+				unique[c.ID] = c
+			}
+		}
+	}
 
 	text := fmt.Sprintf("<b>Статус подписки</b>\n\n"+
 		"Тир: %s\n"+
-		"Активных чатов: %d\n", tierName, len(access))
+		"Доступных чатов: %d\n", tierName, len(unique))
 
-	if len(access) > 0 {
-		text += "\nДоступные чаты:\n"
-		for _, a := range access {
-			chat, err := b.subscriptionService.GetChat(a.ChatID)
-			if err != nil {
-				continue
+	if len(unique) > 0 {
+		items := make([]chatListItem, 0, len(unique))
+		for _, chat := range unique {
+			// Одноразовая ссылка на каждый чат: хранить их смысла нет, в БД
+			// ссылки не держим (см. комментарий в /substatus v1).
+			link, linkErr := b.createOneTimeInviteLink(chat.ID)
+			if linkErr != nil {
+				log.Printf("substatus: failed to create invite link for chat %d: %v", chat.ID, linkErr)
 			}
-			title := html.EscapeString(chat.Title)
-			// Для каждой записи создаём свежую одноразовую invite-ссылку — в
-			// subscription_user_chat_access ссылки не хранятся, а раздавать
-			// старые уже использованные одноразовые смысла нет. Если бот не
-			// админ в чате или API вернул ошибку — отдаём просто название.
-			if link, linkErr := b.createOneTimeInviteLink(a.ChatID); linkErr == nil {
-				text += fmt.Sprintf("  • <a href=\"%s\">%s</a>\n", link, title)
-			} else {
-				log.Printf("substatus: failed to create invite link for chat %d: %v", a.ChatID, linkErr)
-				text += fmt.Sprintf("  • %s\n", title)
-			}
+			items = append(items, chatListItem{chat: chat, link: link})
 		}
+		text += formatChatsGrouped(items)
 	}
 
 	b.SendDirectMessage(message.Chat.ID, text)
@@ -255,34 +269,34 @@ func (b *TelegramBot) handleMyGroupsCommand(message *tgbotapi.Message) {
 		return
 	}
 
-	// Фильтруем через Telegram API: оставляем только те, в которых юзер
-	// ещё не состоит. IsMember кеширует результат в Redis (5 мин TTL), так
-	// что при частых /mygroups не бомбим getChatMember.
-	notJoined := make([]models.SubscriptionChat, 0, len(chats))
-	for _, chat := range chats {
-		if !b.subscriptionService.IsMember(chat.ID, userID, b.isChatMember) {
-			notJoined = append(notJoined, chat)
-		}
-	}
-
-	if len(notJoined) == 0 {
+	if len(chats) == 0 {
 		b.SendDirectMessage(message.Chat.ID,
-			"Вы уже состоите во всех чатах, доступных по тиру <b>"+html.EscapeString(tier.Name)+"</b>.")
+			"По вашему тиру <b>"+html.EscapeString(tier.Name)+"</b> пока нет подключённых чатов.")
 		return
 	}
 
-	text := fmt.Sprintf(
-		"<b>Доступные чаты по подписке (%s), куда можно зайти:</b>\n\n",
-		html.EscapeString(tier.Name))
-	for _, chat := range notJoined {
-		title := html.EscapeString(chat.Title)
-		if link, linkErr := b.createOneTimeInviteLink(chat.ID); linkErr == nil {
-			text += fmt.Sprintf("• <a href=\"%s\">%s</a>\n", link, title)
-		} else {
+	// Показываем все доступные чаты, а не только «куда ещё не вступил».
+	// Для каждого делаем одноразовую invite-ссылку; рядом с теми, где юзер
+	// уже состоит, ставим ✅ — так человек видит полный scope своей подписки
+	// и может проверить, что нигде не пропустил.
+	items := make([]chatListItem, 0, len(chats))
+	for _, chat := range chats {
+		link, linkErr := b.createOneTimeInviteLink(chat.ID)
+		if linkErr != nil {
 			log.Printf("mygroups: invite-link failed for chat %d: %v", chat.ID, linkErr)
-			text += fmt.Sprintf("• %s\n", title)
 		}
+		items = append(items, chatListItem{
+			chat:     chat,
+			link:     link,
+			isMember: b.subscriptionService.IsMember(chat.ID, userID, b.isChatMember),
+		})
 	}
+
+	text := fmt.Sprintf(
+		"<b>Доступные чаты по подписке (%s):</b>\n",
+		html.EscapeString(tier.Name))
+	text += formatChatsGrouped(items)
+	text += "\n<i>✅ — чат, в котором вы уже состоите.</i>"
 
 	b.SendDirectMessage(message.Chat.ID, text)
 }
@@ -321,44 +335,101 @@ func (b *TelegramBot) postAnchorWelcome(chatID int64, user *tgbotapi.User) {
 	}
 }
 
+// chatListItem — строка в форматируемом списке: чат с, возможно, заранее
+// сгенерированной invite-ссылкой и отметкой «юзер уже там» для /mygroups.
+type chatListItem struct {
+	chat     models.SubscriptionChat
+	link     string
+	isMember bool
+}
+
+// formatChatsGrouped группирует items по Category (NULL → «Прочее»),
+// сортирует категории по MAX(priority) DESC, внутри категории — по title.
+// Результат — HTML-строка с заголовками-категориями и пунктами-списком.
+// Передавайте прегенерированные link-и (для юзерских команд — одноразовые);
+// если link пуст, выводится просто название.
+func formatChatsGrouped(items []chatListItem) string {
+	const fallbackCategory = "Прочее"
+	const fallbackEmoji = "💬"
+
+	type group struct {
+		items       []chatListItem
+		emoji       string
+		maxPriority int
+	}
+	groups := make(map[string]*group)
+	for _, it := range items {
+		cat := fallbackCategory
+		emoji := fallbackEmoji
+		if it.chat.Category != nil && *it.chat.Category != "" {
+			cat = *it.chat.Category
+		}
+		if it.chat.Emoji != nil && *it.chat.Emoji != "" {
+			emoji = *it.chat.Emoji
+		}
+		g, ok := groups[cat]
+		if !ok {
+			g = &group{emoji: emoji, maxPriority: it.chat.Priority}
+			groups[cat] = g
+		} else if g.emoji == fallbackEmoji && emoji != fallbackEmoji {
+			// Если в группе появился чат с явно заданным emoji — используем его.
+			g.emoji = emoji
+		}
+		if it.chat.Priority > g.maxPriority {
+			g.maxPriority = it.chat.Priority
+		}
+		g.items = append(g.items, it)
+	}
+
+	order := make([]string, 0, len(groups))
+	for cat := range groups {
+		order = append(order, cat)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		gi, gj := groups[order[i]], groups[order[j]]
+		if gi.maxPriority != gj.maxPriority {
+			return gi.maxPriority > gj.maxPriority
+		}
+		return order[i] < order[j]
+	})
+
+	var sb strings.Builder
+	for _, cat := range order {
+		g := groups[cat]
+		sort.Slice(g.items, func(i, j int) bool {
+			return g.items[i].chat.Title < g.items[j].chat.Title
+		})
+		sb.WriteString(fmt.Sprintf("\n%s <b>%s</b>\n", g.emoji, html.EscapeString(cat)))
+		for _, it := range g.items {
+			title := html.EscapeString(it.chat.Title)
+			prefix := "• "
+			if it.isMember {
+				prefix = "• ✅ "
+			}
+			if it.link != "" {
+				sb.WriteString(fmt.Sprintf("%s<a href=\"%s\">%s</a>\n", prefix, it.link, title))
+			} else {
+				sb.WriteString(fmt.Sprintf("%s%s\n", prefix, title))
+			}
+		}
+	}
+	return sb.String()
+}
+
 // sendSubscriptionLinks sends invite links grouped by category as a single HTML message.
 func (b *TelegramBot) sendSubscriptionLinks(chatID int64, result *service.SyncResult) {
-	type entry struct {
-		title string
-		link  string
-	}
-	groups := make(map[string][]entry)
-	groupEmoji := make(map[string]string)
-	var order []string
-
+	items := make([]chatListItem, 0, len(result.Granted))
 	for _, g := range result.Granted {
 		chat, err := b.subscriptionService.GetChat(g.ChatID)
-		title := fmt.Sprintf("Chat %d", g.ChatID)
-		cat := "Прочее"
-		emoji := "💬"
-		if err == nil {
-			title = chat.Title
-			if chat.Category != nil && *chat.Category != "" {
-				cat = *chat.Category
-			}
-			if chat.Emoji != nil && *chat.Emoji != "" {
-				emoji = *chat.Emoji
-			}
+		if err != nil {
+			// Не нашли чат в БД — формируем заглушку, чтобы всё равно отдать ссылку.
+			chat = &models.SubscriptionChat{ID: g.ChatID, Title: fmt.Sprintf("Chat %d", g.ChatID)}
 		}
-		if _, exists := groups[cat]; !exists {
-			order = append(order, cat)
-			groupEmoji[cat] = emoji
-		}
-		groups[cat] = append(groups[cat], entry{title: title, link: g.Link})
+		items = append(items, chatListItem{chat: *chat, link: g.Link})
 	}
 
 	text := fmt.Sprintf("Подписка подтверждена! Доступно чатов: <b>%d</b>\n", len(result.Granted))
-	for _, cat := range order {
-		text += fmt.Sprintf("\n%s <b>%s</b>\n", groupEmoji[cat], cat)
-		for _, e := range groups[cat] {
-			text += fmt.Sprintf("• <a href=\"%s\">%s</a>\n", e.link, e.title)
-		}
-	}
+	text += formatChatsGrouped(items)
 
 	msg := tgbotapi.NewMessage(chatID, text)
 	msg.ParseMode = "HTML"

--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -168,6 +168,23 @@ func (b *TelegramBot) Start() {
 	// Start subscription checker
 	go b.startSubscriptionChecker()
 
+	// Слушаем Redis pub/sub от бэкенда: когда админ через UI привязывает чат
+	// к новому тиру, приходит событие — бот рассылает invite-ссылки всем
+	// пользователям с подходящим тиром (та же логика, что и в /subaddchat).
+	b.subscriptionService.SubscribeNewChatAccess(context.Background(), func(ev service.NewChatAccessEvent) {
+		chat, err := b.subscriptionService.GetChat(ev.ChatID)
+		if err != nil {
+			log.Printf("new-chat-access: chat %d not found: %v", ev.ChatID, err)
+			return
+		}
+		tier, err := b.subscriptionService.GetTier(ev.TierID)
+		if err != nil {
+			log.Printf("new-chat-access: tier %d not found: %v", ev.TierID, err)
+			return
+		}
+		b.notifyNewChatAccess(ev.ChatID, chat.Title, tier.Level, subscriptionAdminID())
+	})
+
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = 60
 	u.AllowedUpdates = []string{"message", "callback_query", "chat_member", "my_chat_member"}

--- a/backend/internal/handler/subscription.go
+++ b/backend/internal/handler/subscription.go
@@ -6,6 +6,7 @@ import (
 	"ithozyeva/config"
 	"ithozyeva/internal/models"
 	"ithozyeva/internal/service"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -115,6 +116,7 @@ func (h *SubscriptionHandler) GetChats(c *fiber.Ctx) error {
 			"activeUsers": accessCounts[ch.ID],
 			"category":    ch.Category,
 			"emoji":       ch.Emoji,
+			"priority":    ch.Priority,
 		}
 		if ch.AnchorForTierID != nil {
 			item["anchorForTierID"] = *ch.AnchorForTierID
@@ -350,6 +352,12 @@ func (h *SubscriptionHandler) CreateChat(c *fiber.Ctx) error {
 		if err := h.svc.SetChatTiers(req.ID, req.TierIDs); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось привязать тиры"})
 		}
+		// Новый чат → все его тиры «новые». Публикуем рассылку по каждому.
+		for _, tid := range req.TierIDs {
+			if err := h.svc.PublishNewChatAccess(c.Context(), req.ID, tid); err != nil {
+				log.Printf("CreateChat: publish new-chat-access chat=%d tier=%d failed: %v", req.ID, tid, err)
+			}
+		}
 	}
 
 	return c.JSON(fiber.Map{"success": true})
@@ -374,6 +382,7 @@ func (h *SubscriptionHandler) UpdateChat(c *fiber.Ctx) error {
 		Category        *string `json:"category"`
 		Emoji           *string `json:"emoji"`
 		ClearCategory   bool    `json:"clearCategory"`
+		Priority        *int    `json:"priority"`
 	}
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный формат запроса"})
@@ -407,13 +416,47 @@ func (h *SubscriptionHandler) UpdateChat(c *fiber.Ctx) error {
 		}
 	}
 
+	var addedTiers []uint
 	if req.TierIDs != nil {
+		// Фиксируем старые привязки до SetChatTiers, чтобы вычислить diff и
+		// опубликовать рассылку только по реально добавленным тирам.
+		oldTierIDs, _ := h.svc.GetTierIDsForChat(chatID)
 		if err := h.svc.SetChatTiers(chatID, *req.TierIDs); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось обновить тиры"})
+		}
+		addedTiers = diffTiers(*req.TierIDs, oldTierIDs)
+	}
+
+	if req.Priority != nil {
+		if err := h.svc.SetChatPriority(chatID, *req.Priority); err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось сохранить приоритет"})
+		}
+	}
+
+	// Публикуем события уже ПОСЛЕ всех БД-изменений, иначе подписчик
+	// может прибежать с invite раньше, чем чат стал доступным тиру.
+	for _, tid := range addedTiers {
+		if err := h.svc.PublishNewChatAccess(c.Context(), chatID, tid); err != nil {
+			log.Printf("UpdateChat: publish new-chat-access chat=%d tier=%d failed: %v", chatID, tid, err)
 		}
 	}
 
 	return c.JSON(fiber.Map{"success": true})
+}
+
+// diffTiers возвращает tierID, которые есть в next, но отсутствуют в prev.
+func diffTiers(next, prev []uint) []uint {
+	prevSet := make(map[uint]struct{}, len(prev))
+	for _, t := range prev {
+		prevSet[t] = struct{}{}
+	}
+	added := make([]uint, 0, len(next))
+	for _, t := range next {
+		if _, ok := prevSet[t]; !ok {
+			added = append(added, t)
+		}
+	}
+	return added
 }
 
 func (h *SubscriptionHandler) DeleteChat(c *fiber.Ctx) error {
@@ -449,6 +492,7 @@ func (h *SubscriptionHandler) GetChatDetail(c *fiber.Ctx) error {
 		"tierIDs":  tierIDs,
 		"category": chat.Category,
 		"emoji":    chat.Emoji,
+		"priority": chat.Priority,
 	}
 	if chat.AnchorForTierID != nil {
 		result["anchorForTierID"] = *chat.AnchorForTierID

--- a/backend/internal/models/subscription.go
+++ b/backend/internal/models/subscription.go
@@ -18,6 +18,7 @@ type SubscriptionChat struct {
 	AnchorForTierID *uint   `json:"anchor_for_tier_id"`
 	Category        *string `json:"category" gorm:"size:100"`
 	Emoji           *string `json:"emoji" gorm:"size:16"`
+	Priority        int     `json:"priority" gorm:"default:0"`
 }
 
 func (SubscriptionChat) TableName() string { return "subscription_chats" }

--- a/backend/internal/repository/subscription.go
+++ b/backend/internal/repository/subscription.go
@@ -111,6 +111,11 @@ func (r *SubscriptionRepository) UpdateChatMeta(chatID int64, category, emoji *s
 		Updates(map[string]interface{}{"category": category, "emoji": emoji}).Error
 }
 
+func (r *SubscriptionRepository) UpdateChatPriority(chatID int64, priority int) error {
+	return r.db.Model(&models.SubscriptionChat{}).Where("id = ?", chatID).
+		Update("priority", priority).Error
+}
+
 func (r *SubscriptionRepository) SetAnchor(chatID int64, tierID *uint) error {
 	return r.db.Model(&models.SubscriptionChat{}).Where("id = ?", chatID).
 		Update("anchor_for_tier_id", tierID).Error

--- a/backend/internal/service/subscription.go
+++ b/backend/internal/service/subscription.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -13,6 +14,17 @@ import (
 )
 
 const membershipCacheTTL = 5 * time.Minute
+
+// NewChatAccessChannel — Redis pub/sub канал для уведомлений о том, что чат
+// стал доступен новому тиру подписки. Publisher — backend-handler (UI),
+// subscriber — бот на NL (он единственный, кто может дойти до Telegram API).
+const NewChatAccessChannel = "subscription:new_chat_access"
+
+// NewChatAccessEvent — payload события «чат привязан к новому тиру».
+type NewChatAccessEvent struct {
+	ChatID int64 `json:"chat_id"`
+	TierID uint  `json:"tier_id"`
+}
 
 type SubscriptionService struct {
 	repo  *repository.SubscriptionRepository
@@ -269,6 +281,10 @@ func (s *SubscriptionService) UpdateChatMeta(chatID int64, category, emoji *stri
 	return s.repo.UpdateChatMeta(chatID, category, emoji)
 }
 
+func (s *SubscriptionService) SetChatPriority(chatID int64, priority int) error {
+	return s.repo.UpdateChatPriority(chatID, priority)
+}
+
 func (s *SubscriptionService) SetAnchor(chatID int64, tierID *uint) error {
 	return s.repo.SetAnchor(chatID, tierID)
 }
@@ -301,6 +317,45 @@ func (s *SubscriptionService) GetEligibleUsersWithoutAccessForChat(
 // Anchor-чаты не включены (членство в них определяет сам тир).
 func (s *SubscriptionService) GetChatsForTierLevel(tierLevel int) ([]models.SubscriptionChat, error) {
 	return s.repo.GetChatsForTierLevel(tierLevel)
+}
+
+// PublishNewChatAccess сигналит боту, что в чат chatID теперь имеют доступ
+// пользователи тира tierID — их надо пригласить. Бэкенд в РФ не может сам
+// пойти в Telegram (i/o timeout), поэтому рассылку делает бот на NL,
+// подписанный на этот канал.
+func (s *SubscriptionService) PublishNewChatAccess(ctx context.Context, chatID int64, tierID uint) error {
+	payload, err := json.Marshal(NewChatAccessEvent{ChatID: chatID, TierID: tierID})
+	if err != nil {
+		return err
+	}
+	return s.redis.Publish(ctx, NewChatAccessChannel, payload).Err()
+}
+
+// SubscribeNewChatAccess запускает горутину, которая читает события pub/sub
+// и для каждого вызывает handler. Вызывается при старте бота.
+func (s *SubscriptionService) SubscribeNewChatAccess(ctx context.Context, handler func(ev NewChatAccessEvent)) {
+	pubsub := s.redis.Subscribe(ctx, NewChatAccessChannel)
+	go func() {
+		defer pubsub.Close()
+		ch := pubsub.Channel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				var ev NewChatAccessEvent
+				if err := json.Unmarshal([]byte(msg.Payload), &ev); err != nil {
+					log.Printf("new-chat-access: bad payload: %v", err)
+					continue
+				}
+				handler(ev)
+			}
+		}
+	}()
+	log.Printf("Subscribed to %s for new-chat-access events", NewChatAccessChannel)
 }
 
 func (s *SubscriptionService) DeleteChat(chatID int64) error {


### PR DESCRIPTION
## Summary

Несколько связанных вещей в одном PR (пришли «пачкой» из отладки):

### 1. /substatus видит все доступные чаты
Раньше показывал только записи из \`subscription_user_chat_access\`. Чат, который добавили недавно (или у юзера заблокирован бот во время рассылки), туда не попадал — и \`/substatus\` не упоминал его, хотя \`/mygroups\` показывал. Теперь объединяем access + чаты по тиру.

### 2. /mygroups показывает полный scope подписки
Убрал фильтр «куда не вступил» — юзер считает, что это урезает список. Теперь показываем все доступные чаты по тиру, рядом с «уже вступил» — ✅. \`IsMember\` кеш-ится в Redis (5 мин TTL), так что вызов не бьёт Telegram API N раз на команду.

### 3. Рассылка invite-ссылок из админки
В фазе 1 (#265) рассылка при привязке чата к тиру шла только через \`/subaddchat\` в боте. Через UI (\`PUT /subscriptions/chats\`) — тишина, потому что API в РФ заблокирован от Telegram.

Мост через Redis pub/sub на канале \`subscription:new_chat_access\`:
- \`SubscriptionHandler.UpdateChat\` сравнивает старые \`tierIDs\` с новыми, публикует \`{chat_id, tier_id}\` для каждого **добавленного** тира.
- \`CreateChat\` публикует для всех \`tierIDs\`.
- Бот (\`APP_MODE=bot\`) при старте подписан на канал и для каждого события дёргает уже существующий \`notifyNewChatAccess\`.

### 4. Группировка списков и priority
Миграция \`20260423000000_add_chat_priority.sql\` добавляет \`priority INTEGER DEFAULT 0\` на \`subscription_chats\`. Единый helper \`formatChatsGrouped\` группирует чаты по \`Category\` (NULL → «Прочее»), категории сортирует по \`MAX(priority)\` DESC, внутри — по title. Используется в \`/sub\` (рассылка invite-ссылок), \`/substatus\`, \`/mygroups\`.

В inline-редакторе админки (Подписки → Чаты → раскрыть) теперь поле «Приоритет» рядом с категорией и emoji. Просто проставить \`priority=100\` Базе и AI-X — они окажутся первой группой в списках бота.

## Test plan

- [ ] Применить миграцию → \`\\d subscription_chats\` показывает \`priority\`.
- [ ] Проставить в админке категорию «Элитные» + priority 100 у \`База Стародубцева\` и \`AI-X\`. Открыть \`/sub\` под Master-юзером → «Элитные» первой группой, внутри — оба чата.
- [ ] Изменить tierIDs чата через UI (прикрепить к новому тиру) → в логах бота \`new-chat-access: ...\`, юзеры тира получают DM с invite.
- [ ] \`/substatus\` включает чат, привязанный к тиру, даже если в \`subscription_user_chat_access\` нет записи.
- [ ] \`/mygroups\` показывает все доступные чаты, у «уже состоит» стоит ✅.