### PR TITLE
perf(events): фильтрация будущих событий в SQL, а не в Go

### DIFF
--- a/backend/internal/repository/events.go
+++ b/backend/internal/repository/events.go
@@ -98,6 +98,23 @@ func (r *EventRepository) Update(entity *models.Event) (*models.Event, error) {
 	return updatedEntity, nil
 }
 
+// GetFutureEvents возвращает события, которые ещё не прошли к моменту now.
+// Условие двойное: повторяющиеся с открытой или будущей датой окончания,
+// либо обычные с датой >= now. Preload-ы те же, что в Search — вызывающий
+// шедулер тут же читает Members/Hosts/EventTags.
+func (r *EventRepository) GetFutureEvents(now time.Time) ([]models.Event, error) {
+	var events []models.Event
+	err := database.DB.
+		Preload("Hosts").Preload("Members").Preload("EventTags").
+		Where(
+			"(is_repeating = ? AND (repeat_end_date IS NULL OR repeat_end_date > ?)) OR "+
+				"(is_repeating = ? AND date >= ?)",
+			true, now, false, now,
+		).
+		Find(&events).Error
+	return events, err
+}
+
 // GetById получает отзыв по ID с информацией о услуге
 func (r *EventRepository) GetById(id int64) (*models.Event, error) {
 	var event models.Event

--- a/backend/internal/service/events.go
+++ b/backend/internal/service/events.go
@@ -83,24 +83,22 @@ func (s *EventsService) ResolveEventTags(tags []models.EventTag) ([]models.Event
 }
 
 func (s *EventsService) GetFutureEvents(now time.Time) ([]models.Event, error) {
-	allEvents, _, err := s.repo.Search(nil, nil, nil, nil)
+	// Отсекаем прошлое на уровне БД, а не в Go. Шедулер алертов зовёт это
+	// раз в минуту, и раньше каждый вызов делал SELECT * FROM events
+	// (~200–400ms на 29 строках) — отсюда постоянный SLOW SQL в логах.
+	events, err := s.repo.GetFutureEvents(now)
 	if err != nil {
 		return nil, err
 	}
 
-	var futureEvents []models.Event
-	for _, event := range allEvents {
-		if event.IsRepeating && event.RepeatPeriod != nil {
-			if event.RepeatEndDate != nil && now.After(*event.RepeatEndDate) {
-				continue
-			}
-			futureEvents = append(futureEvents, event)
-		} else {
-			if event.Date.After(now) || event.Date.Equal(now) {
-				futureEvents = append(futureEvents, event)
-			}
+	// Для повторяющихся дополнительно проверяем RepeatPeriod != NULL — БД
+	// этого условия не знает (в схеме period хранится как *string).
+	filtered := events[:0]
+	for _, ev := range events {
+		if ev.IsRepeating && ev.RepeatPeriod == nil {
+			continue
 		}
+		filtered = append(filtered, ev)
 	}
-
-	return futureEvents, nil
+	return filtered, nil
 }


### PR DESCRIPTION
## Summary

Шедулер алертов бота звал \`GetFutureEvents\` раз в минуту. Он делал \`SELECT * FROM events\` (через \`repo.Search(nil,nil,nil,nil)\`), тянул все 29 строк и фильтровал в Go. 200–400 ms SLOW SQL каждый прогон — заметные кучи warning в логах.

Теперь фильтр — в \`WHERE\`. Новый метод \`repo.GetFutureEvents(now)\`:

\`\`\`sql
(is_repeating = true  AND (repeat_end_date IS NULL OR repeat_end_date > now))
OR
(is_repeating = false AND date >= now)
\`\`\`

\`service.GetFutureEvents\` тонкая обёртка + одна дополнительная проверка в Go: отсеять \`is_repeating=true\` без \`RepeatPeriod\` (в БД period хранится как nullable string — отражать это в SQL через \`repeat_period IS NOT NULL\` можно, но это лишняя точка сопряжения; safety net в Go проще).

Preload-ы те же что в \`Search\` (\`Hosts\`, \`Members\`, \`EventTags\`) — шедулер сразу использует эти relations в \`checkReminderAlert\` / \`SendInitialEventAlerts\`.

## Test plan

- [ ] Существующий юнит \`TestGetFutureEventsFiltering\` зелёный (проверено локально).
- [ ] После деплоя в логах бота больше нет \`SLOW SQL >= 200ms SELECT * FROM "events"\`.
- [ ] Алерты о событиях продолжают уходить (прежнее поведение).