### PR TITLE
fix(bot): /sub показывает полный список доступных чатов

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -169,13 +169,12 @@ func (b *TelegramBot) handleSubCommand(message *tgbotapi.Message) {
 		return
 	}
 
-	if len(result.Granted) > 0 {
-		b.sendSubscriptionLinks(message.Chat.ID, result)
-	} else {
-		b.sendMessage(message.Chat.ID,
-			"Ваша подписка активна! У вас уже есть доступ ко всем чатам.\n"+
-				"Используйте /substatus для просмотра.")
-	}
+	// Раньше /sub показывал только что granted. Если у юзера уже есть
+	// access на часть чатов (например, они были добавлены в тир раньше),
+	// эти чаты пропускались — казалось, что /sub «не видит» ИИ-чат или
+	// ещё что-то, хотя на деле он просто не в списке «новых». Теперь
+	// показываем полный актуальный список — как в /substatus.
+	b.handleSubStatusCommand(message)
 }
 
 // handleSubStatusCommand shows current subscription status.


### PR DESCRIPTION
## Summary

Юзер жаловался: «ИИ чат не вижу, для него другая подписка нужна?». На деле access есть, чат привязан к его тиру — но \`/sub\` его не упоминает.

Причина: \`sendSubscriptionLinks\` получает \`result.Granted\` от \`CheckAndSyncUser\`, а там только **delta** — чаты, доступ к которым юзер получил прямо сейчас. Если access у него уже был (прошлый \`/sub\` их выдал) — эти чаты не в \`Granted\`, и \`/sub\` их не показывает. Юзер видит «Доступно чатов: 19» и думает, что это весь список; про оставшиеся 3 чата даже не подозревает.

Теперь \`/sub\` после \`OnboardUser\` (он всё ещё делает свою работу: grant missing, revoke extra, sync tier) делегирует на \`handleSubStatusCommand\`, которое выводит полный список entitled + access чатов со свежими invite-ссылками, сгруппированный по категориям.

\`notifyUserOfSyncResult\` из периодического шедулера не тронут — там по смыслу именно delta «что появилось, что отозвали», иначе на каждого юзера раз в несколько часов будет полотнище списка.

Бонус: уходит разнобой между \`/sub\`, \`/substatus\` и \`/mygroups\` — все три теперь показывают одно и то же с одним форматтером.

## Test plan

- [ ] Юзер, у которого access на все чаты уже был → \`/sub\` выводит полный список (вместо «Ваша подписка активна! У вас уже есть доступ…»).
- [ ] Новый юзер → \`/sub\` корректно выдаёт все инвайты (Grant всё ещё работает внутри OnboardUser).
- [ ] \`/sub\` при \`EffectiveTierID == nil\` показывает «У вас нет активной подписки» — без изменений.