### PR TITLE
fix(subs): одна invite-ссылка на рассылку + одно событие на чат

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -77,9 +77,18 @@ func (b *TelegramBot) isChatMember(chatID, userID int64) bool {
 
 // createOneTimeInviteLink creates a single-use invite link for a chat.
 func (b *TelegramBot) createOneTimeInviteLink(chatID int64) (string, error) {
+	return b.createInviteLinkWithLimit(chatID, 1)
+}
+
+// createInviteLinkWithLimit создаёт invite-link с заданным member_limit.
+// memberLimit=1 — эквивалент старой createOneTimeInviteLink.
+// Для массовых рассылок шлём одну ссылку с limit=len(users), чтобы не
+// упираться в Telegram rate-limit на createChatInviteLink (~20/мин на чат).
+// memberLimit=0 означает ссылку без ограничения (до 99999 юзеров).
+func (b *TelegramBot) createInviteLinkWithLimit(chatID int64, memberLimit int) (string, error) {
 	link, err := b.bot.Request(tgbotapi.CreateChatInviteLinkConfig{
-		ChatConfig: tgbotapi.ChatConfig{ChatID: chatID},
-		MemberLimit: 1,
+		ChatConfig:  tgbotapi.ChatConfig{ChatID: chatID},
+		MemberLimit: memberLimit,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create invite link for chat %d: %w", chatID, err)
@@ -691,8 +700,12 @@ func (b *TelegramBot) handleSubAddChatCommand(message *tgbotapi.Message) {
 }
 
 // notifyNewChatAccess выдаёт доступ в chatID всем пользователям с нужным
-// уровнем тира (у кого его ещё нет) и рассылает им одноразовые invite-ссылки
-// в ЛС. В конце отправляет супер-админу сводку по рассылке.
+// уровнем тира (у кого его ещё нет) и рассылает им invite-ссылку в ЛС.
+// В конце отправляет супер-админу сводку по рассылке.
+//
+// Создаём ОДНУ invite-ссылку с member_limit = len(users), а не по штуке
+// на каждого — Telegram лимитирует createChatInviteLink ~20/мин на чат,
+// и раньше рассылка на 50+ юзеров массово падала с «Too Many Requests».
 func (b *TelegramBot) notifyNewChatAccess(chatID int64, chatTitle string, tierLevel int, adminChatID int64) {
 	users, err := b.subscriptionService.GetEligibleUsersWithoutAccessForChat(chatID, tierLevel)
 	if err != nil {
@@ -705,25 +718,27 @@ func (b *TelegramBot) notifyNewChatAccess(chatID int64, chatTitle string, tierLe
 		return
 	}
 
+	link, err := b.createInviteLinkWithLimit(chatID, len(users))
+	if err != nil {
+		log.Printf("notifyNewChatAccess: failed to create shared invite link for chat %d: %v", chatID, err)
+		b.SendDirectMessage(adminChatID, fmt.Sprintf(
+			"Не удалось создать invite-ссылку для чата <code>%d</code>: %v", chatID, err))
+		return
+	}
+
 	titleEscaped := html.EscapeString(chatTitle)
+	text := fmt.Sprintf(
+		"🆕 Вам открыт новый чат по вашей подписке:\n\n<b>%s</b>\n\n<a href=\"%s\">Перейти в чат</a>",
+		titleEscaped, link)
 	delivered, skipped, failed := 0, 0, 0
 
 	for _, user := range users {
-		link, err := b.createOneTimeInviteLink(chatID)
-		if err != nil {
-			log.Printf("notifyNewChatAccess: invite-link failed for chat %d user %d: %v", chatID, user.ID, err)
-			failed++
-			continue
-		}
-		text := fmt.Sprintf(
-			"🆕 Вам открыт новый чат по вашей подписке:\n\n<b>%s</b>\n\n<a href=\"%s\">Перейти в чат</a>",
-			titleEscaped, link)
 		msg := tgbotapi.NewMessage(user.ID, text)
 		msg.ParseMode = "HTML"
 		msg.DisableWebPagePreview = true
 		if _, err := b.bot.Send(msg); err != nil {
 			// Forbidden = пользователь не нажимал /start боту. Не считаем это
-			// ошибкой, просто skip — ссылка «прогорает» без жертв.
+			// ошибкой, просто skip — ссылка shared, новая «не протухает».
 			if strings.Contains(err.Error(), "Forbidden") {
 				skipped++
 			} else {
@@ -738,8 +753,8 @@ func (b *TelegramBot) notifyNewChatAccess(chatID int64, chatTitle string, tierLe
 			continue
 		}
 		delivered++
-		// Небольшая пауза между отправками, чтобы не упереться в Telegram
-		// flood-limit при рассылке на 100+ пользователей.
+		// Небольшая пауза между отправками — Telegram limits ~30 msg/sec
+		// в разные чаты. 50ms с запасом.
 		time.Sleep(50 * time.Millisecond)
 	}
 

--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -177,12 +177,7 @@ func (b *TelegramBot) Start() {
 			log.Printf("new-chat-access: chat %d not found: %v", ev.ChatID, err)
 			return
 		}
-		tier, err := b.subscriptionService.GetTier(ev.TierID)
-		if err != nil {
-			log.Printf("new-chat-access: tier %d not found: %v", ev.TierID, err)
-			return
-		}
-		b.notifyNewChatAccess(ev.ChatID, chat.Title, tier.Level, subscriptionAdminID())
+		b.notifyNewChatAccess(ev.ChatID, chat.Title, ev.MinTierLevel, subscriptionAdminID())
 	})
 
 	u := tgbotapi.NewUpdate(0)

--- a/backend/internal/handler/subscription.go
+++ b/backend/internal/handler/subscription.go
@@ -352,15 +352,33 @@ func (h *SubscriptionHandler) CreateChat(c *fiber.Ctx) error {
 		if err := h.svc.SetChatTiers(req.ID, req.TierIDs); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось привязать тиры"})
 		}
-		// Новый чат → все его тиры «новые». Публикуем рассылку по каждому.
-		for _, tid := range req.TierIDs {
-			if err := h.svc.PublishNewChatAccess(c.Context(), req.ID, tid); err != nil {
-				log.Printf("CreateChat: publish new-chat-access chat=%d tier=%d failed: %v", req.ID, tid, err)
+		// Новый чат → все его тиры «новые». Шлём одно событие с min level.
+		if level, ok := h.minTierLevel(req.TierIDs); ok {
+			if err := h.svc.PublishNewChatAccess(c.Context(), req.ID, level); err != nil {
+				log.Printf("CreateChat: publish new-chat-access chat=%d level=%d failed: %v", req.ID, level, err)
 			}
 		}
 	}
 
 	return c.JSON(fiber.Map{"success": true})
+}
+
+// minTierLevel возвращает минимальный level среди указанных tierID, чтобы
+// publisher мог уведомить всех пользователей, у кого effective tier >= этого
+// значения. Если ни один tier не найден — возвращает (0, false).
+func (h *SubscriptionHandler) minTierLevel(tierIDs []uint) (int, bool) {
+	min, found := 0, false
+	for _, tid := range tierIDs {
+		tier, err := h.svc.GetTier(tid)
+		if err != nil {
+			continue
+		}
+		if !found || tier.Level < min {
+			min = tier.Level
+			found = true
+		}
+	}
+	return min, found
 }
 
 func (h *SubscriptionHandler) UpdateChat(c *fiber.Ctx) error {
@@ -435,9 +453,10 @@ func (h *SubscriptionHandler) UpdateChat(c *fiber.Ctx) error {
 
 	// Публикуем события уже ПОСЛЕ всех БД-изменений, иначе подписчик
 	// может прибежать с invite раньше, чем чат стал доступным тиру.
-	for _, tid := range addedTiers {
-		if err := h.svc.PublishNewChatAccess(c.Context(), chatID, tid); err != nil {
-			log.Printf("UpdateChat: publish new-chat-access chat=%d tier=%d failed: %v", chatID, tid, err)
+	// Одно событие на чат — бот рассылает всем с level >= min(added).
+	if level, ok := h.minTierLevel(addedTiers); ok {
+		if err := h.svc.PublishNewChatAccess(c.Context(), chatID, level); err != nil {
+			log.Printf("UpdateChat: publish new-chat-access chat=%d level=%d failed: %v", chatID, level, err)
 		}
 	}
 

--- a/backend/internal/service/subscription.go
+++ b/backend/internal/service/subscription.go
@@ -20,10 +20,14 @@ const membershipCacheTTL = 5 * time.Minute
 // subscriber — бот на NL (он единственный, кто может дойти до Telegram API).
 const NewChatAccessChannel = "subscription:new_chat_access"
 
-// NewChatAccessEvent — payload события «чат привязан к новому тиру».
+// NewChatAccessEvent — payload события «чат стал доступен новой аудитории».
+// MinTierLevel — минимальный уровень тира среди только что добавленных
+// привязок; подписчик уведомляет всех пользователей с level >= этого
+// значения. Одно событие на чат, чтобы избежать кратных рассылок, когда
+// чат одновременно привязан к нескольким тирам.
 type NewChatAccessEvent struct {
-	ChatID int64 `json:"chat_id"`
-	TierID uint  `json:"tier_id"`
+	ChatID       int64 `json:"chat_id"`
+	MinTierLevel int   `json:"min_tier_level"`
 }
 
 type SubscriptionService struct {
@@ -319,12 +323,14 @@ func (s *SubscriptionService) GetChatsForTierLevel(tierLevel int) ([]models.Subs
 	return s.repo.GetChatsForTierLevel(tierLevel)
 }
 
-// PublishNewChatAccess сигналит боту, что в чат chatID теперь имеют доступ
-// пользователи тира tierID — их надо пригласить. Бэкенд в РФ не может сам
-// пойти в Telegram (i/o timeout), поэтому рассылку делает бот на NL,
-// подписанный на этот канал.
-func (s *SubscriptionService) PublishNewChatAccess(ctx context.Context, chatID int64, tierID uint) error {
-	payload, err := json.Marshal(NewChatAccessEvent{ChatID: chatID, TierID: tierID})
+// PublishNewChatAccess сигналит боту, что чат chatID стал доступен новой
+// аудитории — пользователей с эффективным тиром >= minTierLevel надо
+// пригласить. Бэкенд в РФ не может сам пойти в Telegram (i/o timeout),
+// поэтому рассылку делает бот на NL, подписанный на этот канал.
+// Шлём одно событие на чат, а не на каждый tier — иначе при привязке
+// чата сразу к нескольким тирам рассылка повторялась бы N раз.
+func (s *SubscriptionService) PublishNewChatAccess(ctx context.Context, chatID int64, minTierLevel int) error {
+	payload, err := json.Marshal(NewChatAccessEvent{ChatID: chatID, MinTierLevel: minTierLevel})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Два связанных бага в рассылке инвайтов при привязке чата к тиру.

### 1. Дубли рассылок
Если чат привязан к нескольким тирам (а почти все content-чаты привязаны к Beginner+Foreman+Master), publisher в \`SubscriptionHandler.UpdateChat\`/\`CreateChat\` шёл в цикле \`for _, tid := range addedTiers\` и публиковал событие на каждый. Бот делал столько же независимых рассылок — админу прилетало три сводки подряд по одному чату:
\`\`\`
Рассылка по чату -1002936591048: доставлено 19, … ошибок 37.
Рассылка по чату -1002936591048: доставлено 0,  … ошибок 37.
Рассылка по чату -1002936591048: доставлено 0,  … ошибок 5.
\`\`\`

Теперь handler считает min level среди добавленных тиров и шлёт **одно** событие \`{chat_id, min_tier_level}\`. Бот рассылает один раз. В \`NewChatAccessEvent\` поле \`TierID\` → \`MinTierLevel\` (так же, как уже принимает \`notifyNewChatAccess\`).

### 2. Rate-limit на invite-link
\`notifyNewChatAccess\` в цикле по юзерам звал \`createOneTimeInviteLink\` (MemberLimit=1) **на каждого получателя**. Telegram лимит \`createChatInviteLink\` — ~20/мин на чат. На рассылке в 50+ юзеров каждый второй запрос падал с \`Too Many Requests\` — отсюда 37 ошибок в сводке.

Теперь на всю рассылку один invite-link с \`member_limit = len(users)\`. Все получают общий URL, ссылка закрывается сама после N использований — семантически эквивалентно старым одноразовым.

Для этого добавил \`createInviteLinkWithLimit(chatID, memberLimit)\`; старый \`createOneTimeInviteLink\` теперь тонкий wrapper над ним. Команды \`/sub\`, \`/substatus\`, \`/mygroups\` продолжают выдавать одноразовые персональные ссылки (там и так 1 вызов per user, rate-limit не упирается).

## Test plan

- [ ] Привязать чат к 3 тирам одновременно в админке → админу приходит **одна** сводка рассылки, не три.
- [ ] Рассылка на 50+ пользователей → ошибок ≤ единиц (скорее 0), а не 37.
- [ ] Отдельные юзеры, нажимающие \`/sub\`, получают персональные одноразовые ссылки как раньше (поведение \`CheckAndSyncUser\` не тронуто).