### PR TITLE
chore(db): импорт orphan tracked-чатов в subscription_chats

### DIFF
--- a/backend/database/migrations/20260423100000_import_orphan_tracked_chats.sql
+++ b/backend/database/migrations/20260423100000_import_orphan_tracked_chats.sql
@@ -1,0 +1,20 @@
+-- Импортирует в subscription_chats все активные tracked_chats, которых
+-- там ещё нет. Эти чаты когда-то попали в tracked (для учёта активности),
+-- но не были заведены в систему подписок. Их нельзя «перерегистрировать»
+-- через handleMyChatMemberUpdated — Telegram не шлёт my_chat_member при
+-- повторном добавлении бота, если он уже в чате.
+--
+-- После миграции чаты видны в админке «Подписки → Чаты» с фильтром
+-- «Без привязки». Тиры/категории/приоритеты админ проставляет руками.
+--
+-- Фильтр tc.chat_id < -1000000000000 отсекает битые legacy-id basic group
+-- (сейчас такой один: -5203153204), которые не являются supergroup и
+-- не могут работать с invite-link через Bot API.
+
+INSERT INTO subscription_chats (id, title, chat_type, priority)
+SELECT tc.chat_id, tc.title, tc.chat_type, 0
+FROM tracked_chats tc
+LEFT JOIN subscription_chats sc ON sc.id = tc.chat_id
+WHERE tc.is_active
+  AND sc.id IS NULL
+  AND tc.chat_id < -1000000000000;


### PR DESCRIPTION
## Summary

10 чатов есть в \`tracked_chats\` (учёт активности), но отсутствуют в \`subscription_chats\`:

\`\`\`
-1003822754192  IT-X: Вакансии, Работа
-1003340480893  IT-X: Рефералки, поиск работы
-1002889736366  IT-X: Хобби и творчество
-1002615578774  IT-X: Архитектурный
-1002544203048  IT-X: Разбор резюме
-1002492438891  IT-X: Рефералки, поиск работы (оффтоп)
-1002403724947  IT-X: Инвестиции, темки, деньги, крипта
-1002394057716  IT-X: DevOps, Infrastructure
-1002322657217  IT-X: Еда, кулинария, рецепты
-1002264228346  IT-X: VPN
\`\`\`

Перерегистрировать их через добавление бота нельзя — бот там уже сидит, Telegram не шлёт \`my_chat_member\` повторно.

Миграция заносит все 10 одним \`INSERT … WHERE NOT EXISTS\`. Дальше админ через фильтр «Без привязки» в админке выставляет тиры/категории/priority — и для каждого сработает rollout через Redis pub/sub (#272) с одной invite-ссылкой на всю рассылку.

\`chat_id < -1e12\` отсекает один битый legacy basic-group id (\`-5203153204\`, мусор от старой Telegram-миграции) — такой id не работает с invite-link через Bot API.

## Test plan

- [ ] После деплоя в админке «Подписки → Чаты → Без привязки» видны 10 новых чатов.
- [ ] Выставить тир для одного из них → приходит одна сводка рассылки с общим invite-link (проверяем фикс #272).
- [ ] \`SELECT COUNT(*) FROM subscription_chats\` выросло на 10.