### PR TITLE
fix(bot): не постить приветствие в anchor-чат, только в ЛС

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -481,13 +481,12 @@ func (b *TelegramBot) handleChatMemberUpdated(update *tgbotapi.ChatMemberUpdated
 		return
 	}
 
-	// Post welcome in anchor only on join (not on leave/kick).
-	// Telegram не даёт боту писать первым в ЛС: сообщение в anchor с deep-link
-	// — единственный способ заставить юзера один раз стартануть бота.
-	if newActive && !oldActive {
-		b.postAnchorWelcome(update.Chat.ID, tgUser)
-	}
-
+	// Раньше постили персональное "@user, добро пожаловать, нажми кнопку"
+	// прямо в anchor-чат — это видели все участники, и люди жаловались на
+	// спам. Теперь молчим: приветствие/инвайты уходят в ЛС через
+	// notifyUserOfSyncResult (если юзер стартовал бота). Для тех, кто
+	// ещё не нажимал /start, в anchor-чате есть закреплённое сообщение
+	// с deep-link — его ставит pinAnchorWelcome при установке anchor.
 	b.notifyUserOfSyncResult(userID, result)
 }
 


### PR DESCRIPTION
## Summary

Пользователь пожаловался: при входе нового участника в anchor-чат бот постил публичное «@user, добро пожаловать! Нажмите кнопку ниже…» — это видели все участники чата.

Убрал вызов \`postAnchorWelcome\` из \`handleChatMemberUpdated\`. Приветствие и инвайты теперь уходят только в ЛС через уже существующий \`notifyUserOfSyncResult\` (он зовётся следом) — \`sendSubscriptionLinks\` с полным списком доступных чатов, сгруппированно по категориям.

Юзеры, которые не стартовали бота, в ЛС не получат ничего (Telegram запрещает боту писать первым). Для них работает тот же фоллбэк, что и раньше — закреплённое в anchor сообщение с deep-link на \`/start sub\`. Оно ставится автоматически при установке anchor (\`pinAnchorWelcome\`, PR #269).

Функция \`postAnchorWelcome\` в коде не удалена — мёртвая, не вызывается, на случай если понадобится обратно под флагом.

## Test plan

- [ ] Новый юзер вступает в anchor-чат → в anchor-чате **нет** публичного приветствия от бота.
- [ ] У юзера, который стартовал бота, в ЛС приходит список чатов с инвайтами.
- [ ] У юзера, который НЕ стартовал бота, ничего не валится в логах (только «Forbidden: bot was blocked» / аналог — безопасно).
- [ ] Закреплённое welcome в anchor-чате по-прежнему на месте.