### PR TITLE
chore(bot): подсказка 'не обязательно во все сразу' в списках чатов

### DIFF
--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -241,6 +241,8 @@ func (b *TelegramBot) handleSubStatusCommand(message *tgbotapi.Message) {
 			items = append(items, chatListItem{chat: chat, link: link})
 		}
 		text += formatChatsGrouped(items)
+		text += "\n<i>Во все сразу вступать не обязательно — Telegram после нескольких " +
+			"подряд вступлений просит подождать. Заходи, куда хочется.</i>"
 	}
 
 	b.SendDirectMessage(message.Chat.ID, text)
@@ -304,7 +306,9 @@ func (b *TelegramBot) handleMyGroupsCommand(message *tgbotapi.Message) {
 		"<b>Доступные чаты по подписке (%s):</b>\n",
 		html.EscapeString(tier.Name))
 	text += formatChatsGrouped(items)
-	text += "\n<i>✅ — чат, в котором вы уже состоите.</i>"
+	text += "\n<i>✅ — чат, в котором вы уже состоите. Во все сразу вступать " +
+		"не обязательно — Telegram ограничивает подряд идущие вступления, " +
+		"так что выбирай, что тебе интересно.</i>"
 
 	b.SendDirectMessage(message.Chat.ID, text)
 }
@@ -438,6 +442,9 @@ func (b *TelegramBot) sendSubscriptionLinks(chatID int64, result *service.SyncRe
 
 	text := fmt.Sprintf("Подписка подтверждена! Доступно чатов: <b>%d</b>\n", len(result.Granted))
 	text += formatChatsGrouped(items)
+	text += "\n<i>Необязательно вступать во все сразу — Telegram после нескольких подряд " +
+		"вступлений просит подождать. Выбирай чаты, которые тебе интересны; " +
+		"остальные всегда под рукой в /mygroups.</i>"
 
 	msg := tgbotapi.NewMessage(chatID, text)
 	msg.ParseMode = "HTML"


### PR DESCRIPTION
## Summary

Подписчик переслал: при нажатии invite-ссылок подряд Telegram показывает «Too many attempts, please try again later» — это клиентский rate-limit на join по invite-link (~3 чата подряд, потом просят подождать). На стороне Bot API мы это починить не можем — лимит применяется, когда юзер жмёт ссылку в своём клиенте.

Папки (chat folder invite links) решили не делать — поддерживать вручную неудобно.

Минимальный фикс — предупредить в тексте:

- \`/sub\` (sendSubscriptionLinks) — в конце списка.
- \`/substatus\` — в конце списка.
- \`/mygroups\` — рядом с легендой про ✅.

Текст один: «Во все сразу вступать не обязательно — Telegram после нескольких подряд вступлений просит подождать. Выбирай, что интересно».

\`notifyNewChatAccess\` не трогаю — там один чат, лимит не применяется.

## Test plan

- [ ] /sub → в хвосте добавлена строчка про «не обязательно во все сразу».
- [ ] /substatus — то же.
- [ ] /mygroups — то же (плюс осталась подпись про ✅).
- [ ] notifyNewChatAccess (рассылка при привязке нового чата) — без изменений.