### PR TITLE
fix(dashboard): рекуррентные события со следующей датой

### DIFF
--- a/platform-frontend/src/__tests__/pages/Dashboard.test.ts
+++ b/platform-frontend/src/__tests__/pages/Dashboard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { getNextOccurrenceDate } from '@/composables/useEventOccurrence'
 
 describe('Dashboard logic', () => {
   function pluralizeDays(n: number): string {
@@ -11,9 +12,9 @@ describe('Dashboard logic', () => {
     return Math.min(100, Math.round((quest.currentCount / quest.targetCount) * 100))
   }
 
-  function isEventLive(event: { date: string }) {
+  function isEventLive(event: any) {
     const now = new Date()
-    const eventDate = new Date(event.date)
+    const eventDate = getNextOccurrenceDate(event, now)
     const diffMs = now.getTime() - eventDate.getTime()
     return diffMs >= 0 && diffMs < 2 * 60 * 60 * 1000
   }

--- a/platform-frontend/src/pages/Dashboard.vue
+++ b/platform-frontend/src/pages/Dashboard.vue
@@ -43,6 +43,7 @@ import {
 } from 'lucide-vue-next'
 import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
+import { getNextOccurrenceDate } from '@/composables/useEventOccurrence'
 import { useSSE } from '@/composables/useSSE'
 import { useUser, useUserLevel } from '@/composables/useUser'
 import { dateFormatter, formatShortDate } from '@/lib/utils'
@@ -170,7 +171,7 @@ function formatQuestDeadline(dateStr: string) {
 
 function isEventLive(event: CommunityEvent) {
   const now = new Date()
-  const eventDate = new Date(event.date)
+  const eventDate = getNextOccurrenceDate(event, now)
   const diffMs = now.getTime() - eventDate.getTime()
   return diffMs >= 0 && diffMs < 2 * 60 * 60 * 1000
 }
@@ -186,7 +187,7 @@ function isHostOfEvent(event: CommunityEvent) {
 onMounted(async () => {
   try {
     const results = await Promise.allSettled([
-      eventsService.searchNext(3, 0),
+      eventsService.searchNext(20, 0),
       pointsService.getMyPoints(),
       chatQuestService.getActiveQuests(),
       Promise.all([
@@ -197,8 +198,13 @@ onMounted(async () => {
       highlightsService.getRecent(5),
     ])
 
-    if (results[0].status === 'fulfilled')
-      nearestEvents.value = results[0].value?.items ?? []
+    if (results[0].status === 'fulfilled') {
+      const now = new Date()
+      const items = results[0].value?.items ?? []
+      nearestEvents.value = [...items]
+        .sort((a, b) => getNextOccurrenceDate(a, now).getTime() - getNextOccurrenceDate(b, now).getTime())
+        .slice(0, 3)
+    }
     if (results[1].status === 'fulfilled')
       pointsSummary.value = results[1].value
     if (results[2].status === 'fulfilled')
@@ -451,7 +457,7 @@ onMounted(async () => {
             <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-3 text-sm text-muted-foreground">
               <span class="flex items-center gap-1.5">
                 <Calendar class="h-3.5 w-3.5" />
-                {{ dateFormatter.format(new Date(event.date)) }}
+                {{ dateFormatter.format(getNextOccurrenceDate(event)) }}
               </span>
               <span
                 v-if="event.hosts.length"


### PR DESCRIPTION
## Проблема

На главной в блоке «Ближайшее событие» рекуррентные события показывались с датой первого вхождения (например, 7 марта 2026), хотя сегодня уже 24 апреля. Визуально выглядело как прошедшее событие.

## Причина

`Dashboard.vue` брал `event.date` напрямую — а это всегда исходная дата, не ближайшее будущее вхождение. В `EventCard.vue` для этого уже используется утилита `getNextOccurrenceDate`, а дашборд про неё не знал.

## Что поменялось

- Импортируем `getNextOccurrenceDate` из `useEventOccurrence`.
- Отображение даты в карточке «Ближайшее событие» → через next occurrence.
- `isEventLive` использует next occurrence (иначе LIVE-бейдж не загорался для повторяющихся).
- Бэк сортирует `ORDER BY date DESC` по исходной дате → запрашиваем 20, сортируем по next occurrence ASC на клиенте, берём первые 3.

## Test plan
- [ ] На дашборде пользователя записанного на English Speaking Club / Книжный Клуб даты показываются как ближайшее будущее вхождение, а не март.
- [ ] `npm run type-check`, `npm run lint`, `vitest` зелёные.