### PR TITLE
fix(bot): тихо удалять невалидный /whois в группах

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -411,6 +411,14 @@ func (b *TelegramBot) handleWhoisCommand(message *tgbotapi.Message) {
 		// Способ 2: /whois @username
 		args := strings.TrimSpace(message.CommandArguments())
 		if args == "" {
+			// Невалидный вызов в группе — тихо удаляем команду, не засоряя чат
+			// подсказкой. В личке оставляем подсказку, там удалять нечего.
+			if message.Chat.Type != "private" {
+				if _, delErr := b.bot.Request(tgbotapi.NewDeleteMessage(message.Chat.ID, message.MessageID)); delErr != nil {
+					log.Printf("Failed to delete invalid /whois command %d in chat %d: %v", message.MessageID, message.Chat.ID, delErr)
+				}
+				return
+			}
 			msg := tgbotapi.NewMessage(message.Chat.ID, "Ответьте на сообщение командой /whois или укажите username: /whois @username")
 			msg.ReplyToMessageID = message.MessageID
 			b.bot.Send(msg)


### PR DESCRIPTION
## Проблема

В группах пользователь пишет \`/whois\` без reply и без username, и бот отвечает подсказкой «Ответьте на сообщение командой /whois или укажите username…». Когда это повторяется подряд, подсказки засоряют чат.

## Что поменялось

В `handleWhoisCommand` для невалидного вызова (нет reply и нет args):
- **В группах**: команда пользователя удаляется, бот ничего не пишет.
- **В личке**: подсказка остаётся как была — удалять нечего, и для юзера это обучающий контекст.

Ошибка удаления (нет прав) просто логируется.

## Test plan
- [ ] В группе `/whois` без args и без reply → сообщение юзера исчезает, бот молчит.
- [ ] В группе `/whois @username` и `/whois` в reply — работают как раньше.
- [ ] В личке `/whois` без args — по-прежнему шлёт подсказку.
- [ ] Если у бота нет прав на удаление — в логе Warning, поведение без падений.