### PR TITLE
feat(bot): удалять голые /команды в группах

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -261,6 +261,17 @@ func (b *TelegramBot) Start() {
 			continue
 		}
 
+		// Голое «/слово» в группе (без аргументов и без другого текста):
+		// удаляем, чтобы клик по подсвеченной команде не превращался в цепочку спама.
+		// Наши команды обработаны выше и сюда не падают.
+		if update.Message.Chat.Type != "private" {
+			text := strings.TrimSpace(update.Message.Text)
+			if strings.HasPrefix(text, "/") && !strings.ContainsAny(text, " \t\n") {
+				b.deleteBareCommand(update.Message.Chat.ID, update.Message.MessageID)
+				continue
+			}
+		}
+
 		// Бот отвечает только в личных сообщениях
 		if update.Message.Chat.Type != "private" {
 			continue
@@ -767,6 +778,18 @@ func (b *TelegramBot) deleteServiceMessage(chatID int64, messageID int) {
 	}
 	if _, err := b.bot.Request(tgbotapi.NewDeleteMessage(chatID, messageID)); err != nil {
 		log.Printf("Failed to delete service message %d in chat %d: %v", messageID, chatID, err)
+	}
+}
+
+// deleteBareCommand удаляет сообщение-«голую команду» (только «/слово») в
+// трекаемых чатах. Telegram рендерит такие строки как кликабельные
+// bot-команды — по ним тапают соседи и множат спам.
+func (b *TelegramBot) deleteBareCommand(chatID int64, messageID int) {
+	if !b.chatActivityService.IsTrackedChat(chatID) {
+		return
+	}
+	if _, err := b.bot.Request(tgbotapi.NewDeleteMessage(chatID, messageID)); err != nil {
+		log.Printf("Failed to delete bare command %d in chat %d: %v", messageID, chatID, err)
 	}
 }
 


### PR DESCRIPTION
## Проблема

Когда кто-то пишет в общем чате сообщение из одной \`/команды\` (например \`/b\`), Telegram рендерит её как кликабельную bot-команду. Соседи тапают по ней → отправляется та же команда → получается цикл спама (см. скриншот из тикета).

## Что поменялось

В main update loop (`internal/bot/telegram_bot.go`) после обработчиков наших команд, но до гейта private-only, новая проверка:

- Чат групповой;
- `message.Text` после trim начинается с `/`;
- В тексте нет пробелов/табов/переводов строки.

Если условие сработало — удаляем через `deleteBareCommand` (тот же паттерн, что `deleteServiceMessage`: проверка `IsTrackedChat`, `tgbotapi.NewDeleteMessage`, лог ошибки).

## Что не трогаем

- `/whois`, `/highlight`, `/summarize`, `/chatid` — уже обработаны выше, сюда не доходят.
- `/cmd foo`, \«hi /b\» — не попадают под условие.
- Личка с ботом — гейт `Chat.Type != "private"` не срабатывает.

## Test plan
- [ ] `/b` в трекаемом чате → исчезает.
- [ ] `/лол`, `/123` → исчезают.
- [ ] `/b foo` → остаётся.
- [ ] `/whois @username` → работает как раньше.
- [ ] `/whois` голая → `handleWhoisCommand` удалит как раньше.
- [ ] `/b` в личке → ничего не удаляется.
- [ ] Стикер/фото без текста → ничего не удаляется.