### PR TITLE
fix(bot): тихо удалять /whois с несуществующим username в группах

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -440,6 +440,15 @@ func (b *TelegramBot) handleWhoisCommand(message *tgbotapi.Message) {
 	}
 
 	if err != nil || member == nil {
+		// В группе не найденного участника не озвучиваем, иначе начинается
+		// цепочка «а меня найдёшь?» и чат захлёбывается. Просто удаляем вызов.
+		// В личке — оставляем ответ, там это полезный feedback юзеру.
+		if message.Chat.Type != "private" {
+			if _, delErr := b.bot.Request(tgbotapi.NewDeleteMessage(message.Chat.ID, message.MessageID)); delErr != nil {
+				log.Printf("Failed to delete /whois not-found command %d in chat %d: %v", message.MessageID, message.Chat.ID, delErr)
+			}
+			return
+		}
 		msg := tgbotapi.NewMessage(message.Chat.ID, "Участник не найден на платформе.")
 		msg.ReplyToMessageID = message.MessageID
 		b.bot.Send(msg)


### PR DESCRIPTION
## Проблема

В группе юзеры пишут \`/whois @somebot\` / \`/whois @monk\`, бот отвечает «Участник не найден на платформе» — и это провоцирует цепочку «а меня найдёшь?» (см. скриншот), чат снова заваливается whois-ами.

## Что поменялось

В `handleWhoisCommand` ветка «участник не найден»:
- **В группе**: удаляем команду юзера, бот молчит.
- **В личке**: оставляем ответ как раньше (там это полезный feedback).

## Test plan
- [ ] В группе `/whois @несуществующий` → сообщение юзера исчезает, бот молчит.
- [ ] В группе `/whois @реальный_участник` → карточка приходит как раньше.
- [ ] В личке `/whois @несуществующий` → по-прежнему «Участник не найден…».