### PR TITLE
feat(events): сортировать предстоящие по ближайшему вхождению

### DIFF
--- a/backend/internal/handler/events.go
+++ b/backend/internal/handler/events.go
@@ -72,6 +72,18 @@ func (h *EventsHandler) Search(c *fiber.Ctx) error {
 		filter["place_type = ?"] = *req.PlaceType
 	}
 
+	// Для предстоящих — сортируем по ближайшему будущему вхождению
+	// (учитывая repeat_period), а не по исходному date. Для архива
+	// оставляем обычный DESC по date.
+	if req.DateFrom != nil {
+		result, err := h.svc.SearchUpcoming(req.Limit, req.Offset, &filter)
+		if err != nil {
+			log.Printf("events upcoming search error: %v", err)
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Ошибка поиска событий"})
+		}
+		return c.JSON(result)
+	}
+
 	result, err := h.service.Search(req.Limit, req.Offset, &filter, &repository.Order{
 		ColumnBy: "date",
 		Order:    "DESC",

--- a/backend/internal/repository/events.go
+++ b/backend/internal/repository/events.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"ithozyeva/database"
 	"ithozyeva/internal/models"
+	"ithozyeva/internal/utils"
+	"sort"
 	"time"
 )
 
@@ -65,6 +67,54 @@ func (r *EventRepository) Search(limit *int, offset *int, filter *SearchFilter, 
 	}
 
 	return events, count, nil
+}
+
+// SearchUpcoming отдаёт предстоящие события, отсортированные по ближайшему
+// будущему вхождению. Для рекуррентных событий поле date хранит исходное
+// вхождение, поэтому отсортировать в SQL без вычислений нельзя без потери
+// точности для MONTHLY/YEARLY — считаем в Go.
+//
+// Ожидается, что filter уже содержит условие «date >= now OR
+// (is_repeating AND repeat_end_date >= now / NULL)».
+func (r *EventRepository) SearchUpcoming(limit *int, offset *int, filter *SearchFilter) ([]models.Event, int64, error) {
+	var events []models.Event
+
+	query := database.DB.Model(&models.Event{}).Preload("Hosts").Preload("Members").Preload("EventTags")
+	if filter != nil {
+		for key, value := range *filter {
+			if args, ok := value.([]interface{}); ok {
+				query = query.Where(key, args...)
+			} else {
+				query = query.Where(key, value)
+			}
+		}
+	}
+
+	if err := query.Find(&events).Error; err != nil {
+		return nil, 0, err
+	}
+
+	now := time.Now()
+	sort.SliceStable(events, func(i, j int) bool {
+		return utils.NextOccurrence(&events[i], now).Before(utils.NextOccurrence(&events[j], now))
+	})
+
+	total := int64(len(events))
+
+	start := 0
+	if offset != nil && *offset > 0 {
+		start = *offset
+	}
+	if start > len(events) {
+		start = len(events)
+	}
+	events = events[start:]
+
+	if limit != nil && *limit >= 0 && *limit < len(events) {
+		events = events[:*limit]
+	}
+
+	return events, total, nil
 }
 
 func (r *EventRepository) Update(entity *models.Event) (*models.Event, error) {

--- a/backend/internal/service/events.go
+++ b/backend/internal/service/events.go
@@ -45,6 +45,17 @@ func (s *EventsService) GetUpcomingEvents(limit int) ([]models.Event, error) {
 	return s.repo.GetUpcoming(limit)
 }
 
+// SearchUpcoming делегирует в репозиторий поиск предстоящих событий,
+// отсортированных по ближайшему будущему вхождению (а не по исходному date).
+// Возвращает тот же формат, что и Search.
+func (s *EventsService) SearchUpcoming(limit *int, offset *int, filter *repository.SearchFilter) (*models.RegistrySearch[models.Event], error) {
+	items, total, err := s.repo.SearchUpcoming(limit, offset, filter)
+	if err != nil {
+		return nil, err
+	}
+	return &models.RegistrySearch[models.Event]{Items: items, Total: int(total)}, nil
+}
+
 // ResolveEventTags нормализует список тегов события: теги с Id > 0 оставляются как есть,
 // а теги без Id (приходят с фронта, когда админ вводит новое имя вручную) ищутся по имени
 // или создаются. Возвращает список тегов с корректными Id, пригодный для GORM many2many.

--- a/backend/internal/utils/events.go
+++ b/backend/internal/utils/events.go
@@ -64,3 +64,49 @@ func escapeICS(s string) string {
 	)
 	return replacer.Replace(s)
 }
+
+// NextOccurrence возвращает дату ближайшего будущего вхождения события.
+// Для обычных событий и для рекуррентных с датой в будущем — исходная дата.
+// Для рекуррентных с прошедшей исходной датой вычисляет следующее вхождение
+// исходя из repeat_period и repeat_interval.
+//
+// Логика дублирует фронтенд (platform-frontend/src/composables/useEventOccurrence.ts)
+// — любая правка должна идти синхронно в обе стороны.
+func NextOccurrence(event *models.Event, now time.Time) time.Time {
+	if !event.IsRepeating || event.RepeatPeriod == nil {
+		return event.Date
+	}
+	if !event.Date.Before(now) {
+		return event.Date
+	}
+
+	interval := 1
+	if event.RepeatInterval != nil && *event.RepeatInterval > 0 {
+		interval = *event.RepeatInterval
+	}
+
+	switch models.RepeatPeriod(*event.RepeatPeriod) {
+	case models.RepeatDaily:
+		diffDays := int(now.Sub(event.Date) / (24 * time.Hour))
+		next := (diffDays/interval + 1) * interval
+		return event.Date.AddDate(0, 0, next)
+	case models.RepeatWeekly:
+		diffWeeks := int(now.Sub(event.Date) / (7 * 24 * time.Hour))
+		next := (diffWeeks/interval + 1) * interval
+		return event.Date.AddDate(0, 0, next*7)
+	case models.RepeatMonthly:
+		current := event.Date
+		for current.Before(now) {
+			current = current.AddDate(0, interval, 0)
+		}
+		return current
+	case models.RepeatYearly:
+		current := event.Date
+		for current.Before(now) {
+			current = current.AddDate(interval, 0, 0)
+		}
+		return current
+	default:
+		return event.Date
+	}
+}

--- a/backend/internal/utils/events_test.go
+++ b/backend/internal/utils/events_test.go
@@ -1,0 +1,94 @@
+package utils
+
+import (
+	"ithozyeva/internal/models"
+	"testing"
+	"time"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestNextOccurrence_NonRepeating(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	past := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	event := &models.Event{Date: past, IsRepeating: false}
+	if got := NextOccurrence(event, now); !got.Equal(past) {
+		t.Errorf("non-repeating: got %v, want %v", got, past)
+	}
+}
+
+func TestNextOccurrence_RepeatingButFutureStart(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	future := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	weekly := string(models.RepeatWeekly)
+	event := &models.Event{Date: future, IsRepeating: true, RepeatPeriod: &weekly}
+	if got := NextOccurrence(event, now); !got.Equal(future) {
+		t.Errorf("future start: got %v, want %v", got, future)
+	}
+}
+
+func TestNextOccurrence_Weekly(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 3, 15, 11, 0, 0, 0, time.UTC) // воскресенье
+	weekly := string(models.RepeatWeekly)
+	event := &models.Event{Date: start, IsRepeating: true, RepeatPeriod: &weekly, RepeatInterval: ptr(1)}
+	want := time.Date(2026, 4, 26, 11, 0, 0, 0, time.UTC) // ближайшее воскресенье после 24 апр
+	if got := NextOccurrence(event, now); !got.Equal(want) {
+		t.Errorf("weekly: got %v, want %v", got, want)
+	}
+}
+
+func TestNextOccurrence_WeeklyWithInterval(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	weekly := string(models.RepeatWeekly)
+	event := &models.Event{Date: start, IsRepeating: true, RepeatPeriod: &weekly, RepeatInterval: ptr(2)}
+	// каждые 2 недели от 1 марта: 15 мар, 29 мар, 12 апр, 26 апр...
+	want := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+	if got := NextOccurrence(event, now); !got.Equal(want) {
+		t.Errorf("weekly interval=2: got %v, want %v", got, want)
+	}
+}
+
+func TestNextOccurrence_Daily(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	daily := string(models.RepeatDaily)
+	event := &models.Event{Date: start, IsRepeating: true, RepeatPeriod: &daily, RepeatInterval: ptr(1)}
+	want := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	if got := NextOccurrence(event, now); !got.Equal(want) {
+		t.Errorf("daily: got %v, want %v", got, want)
+	}
+}
+
+func TestNextOccurrence_Monthly(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 3, 7, 11, 0, 0, 0, time.UTC)
+	monthly := string(models.RepeatMonthly)
+	event := &models.Event{Date: start, IsRepeating: true, RepeatPeriod: &monthly, RepeatInterval: ptr(1)}
+	// 7 мар → 7 апр (прошёл) → 7 мая
+	want := time.Date(2026, 5, 7, 11, 0, 0, 0, time.UTC)
+	if got := NextOccurrence(event, now); !got.Equal(want) {
+		t.Errorf("monthly: got %v, want %v", got, want)
+	}
+}
+
+func TestNextOccurrence_Yearly(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	start := time.Date(2023, 6, 10, 10, 0, 0, 0, time.UTC)
+	yearly := string(models.RepeatYearly)
+	event := &models.Event{Date: start, IsRepeating: true, RepeatPeriod: &yearly, RepeatInterval: ptr(1)}
+	want := time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC)
+	if got := NextOccurrence(event, now); !got.Equal(want) {
+		t.Errorf("yearly: got %v, want %v", got, want)
+	}
+}
+
+func TestNextOccurrence_NilPeriod(t *testing.T) {
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	event := &models.Event{Date: start, IsRepeating: true, RepeatPeriod: nil}
+	if got := NextOccurrence(event, now); !got.Equal(start) {
+		t.Errorf("nil period: got %v, want %v", got, start)
+	}
+}


### PR DESCRIPTION
## Проблема

`/events` (вкладка «Предстоящие») и dashboard запрашивали события через `Search` с фильтром `dateFrom`. Бэк сортировал `ORDER BY date DESC` по исходной дате первого вхождения. Для рекуррентных событий (English Speaking Club c `date=2026-03-15`, `repeat_end_date` в будущем) это ставило их в топ по старой дате, а не по ближайшему будущему вхождению.

На дашборде это обходилось запросом 20 + клиентской сортировкой. На `/events` — нет, там порядок всегда был «по исходной дате DESC».

## Что поменялось

- `internal/utils/events.go`: добавлена `NextOccurrence(event, now)` — логика дублирует фронт `platform-frontend/src/composables/useEventOccurrence.ts` (любая правка в обе стороны).
- `internal/repository/events.go`: новый `SearchUpcoming(limit, offset, filter)` — загружает всё по фильтру, сортирует в Go по `NextOccurrence` ASC, режет по offset+limit. В SQL MONTHLY/YEARLY считать корректно тяжело (месяцы разной длины) — проще на уровне Go.
- `internal/service/events.go`: тонкий `SearchUpcoming`-шим над репозиторием, отдаёт `models.RegistrySearch[Event]`.
- `internal/handler/events.go`: если `DateFrom != nil` — идём через `SearchUpcoming`; архив (`DateTo`) остаётся на старом `ORDER BY date DESC`.
- `internal/utils/events_test.go`: unit-тесты на `NextOccurrence` — daily/weekly/monthly/yearly, интервалы, nil-период, future-start.

## Что сейчас в продакшене

Дашборд уже показывает правильные даты через клиентский `getNextOccurrenceDate` и клиентскую сортировку — этот PR не ломает его, а делает клиентский sort избыточным. Клиентский sort оставляю как есть, уберём отдельным косметическим PR если захочется — он сейчас корректный no-op (бэк уже отдаёт отсортированное).

## Test plan
- [ ] `go test ./internal/utils/` — 8 тестов зелёных.
- [ ] После деплоя: на `/events` таб «Предстоящие» рекуррентные события показываются в порядке ближайшего вхождения, а не по исходному март-месяцу.
- [ ] Архив (`/events` → «Архив») без изменений.
- [ ] Dashboard — без регрессии (порядок всё ещё правильный).