### PR TITLE
feat(profile): уровень по тиру подписки + фикс 'дней с нами'

### DIFF
--- a/backend/database/migrations/20260424150000_add_king_tier.sql
+++ b/backend/database/migrations/20260424150000_add_king_tier.sql
@@ -1,0 +1,3 @@
+INSERT INTO subscription_tiers (slug, name, level) VALUES
+    ('king', 'King', 4)
+ON CONFLICT (slug) DO NOTHING;

--- a/backend/internal/handler/member.go
+++ b/backend/internal/handler/member.go
@@ -190,6 +190,7 @@ func (h *MembersHandler) Delete(c *fiber.Ctx) error {
 
 func (h *MembersHandler) Me(c *fiber.Ctx) error {
 	member := c.Locals("member").(*models.Member)
+	member.SubscriptionTier = h.svc.GetEffectiveTier(member.TelegramID)
 
 	mentor, err := h.svc.GetMentor(member.Id)
 
@@ -197,6 +198,7 @@ func (h *MembersHandler) Me(c *fiber.Ctx) error {
 		return c.JSON(member)
 	}
 
+	mentor.SubscriptionTier = member.SubscriptionTier
 	return c.JSON(mentor)
 }
 
@@ -329,6 +331,8 @@ func (h *MembersHandler) GetPublicProfile(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Участник не найден"})
 	}
 
+	member.SubscriptionTier = h.svc.GetEffectiveTier(member.TelegramID)
+
 	points, _ := h.pointsSvc.GetBalance(member.Id)
 
 	result := fiber.Map{
@@ -339,6 +343,7 @@ func (h *MembersHandler) GetPublicProfile(c *fiber.Ctx) error {
 
 	mentor, err := h.svc.GetMentor(member.Id)
 	if err == nil && mentor != nil {
+		mentor.SubscriptionTier = member.SubscriptionTier
 		result["isMentor"] = true
 		result["mentor"] = mentor
 	}

--- a/backend/internal/models/member.go
+++ b/backend/internal/models/member.go
@@ -35,6 +35,9 @@ type Member struct {
 	Roles       []Role       `json:"roles" gorm:"-:all"`
 	Birthday    *DateOnly    `json:"birthday" gorm:"column:birthday"`
 	CreatedAt   time.Time    `json:"createdAt" gorm:"column:created_at;autoCreateTime"`
+	// SubscriptionTier — эффективный тир подписки (EffectiveTier из subscription_users).
+	// Заполняется хендлерами перед отдачей профиля. В БД не хранится.
+	SubscriptionTier *SubscriptionTier `json:"subscriptionTier,omitempty" gorm:"-:all"`
 }
 
 type ReviewOnCommunity struct {

--- a/backend/internal/models/mentor.go
+++ b/backend/internal/models/mentor.go
@@ -21,22 +21,23 @@ type MentorDbModel struct {
 }
 
 type MentorModel struct {
-	Id         int64     `json:"id"`
-	TelegramID int64     `json:"telegramID"`
-	Username   string    `json:"tg"`
-	FirstName  string    `json:"firstName"`
-	LastName   string    `json:"lastName"`
-	Bio        string    `json:"bio"`
-	AvatarURL  string    `json:"avatarUrl"`
-	Occupation string    `json:"occupation"`
-	Experience string    `json:"experience"`
-	Birthday   *DateOnly `json:"birthday"`
-	Roles      []Role    `json:"roles"`
-	Order      int       `json:"order"`
-	MemberId   int       `json:"memberId"`
-	ProfTags   []ProfTag `json:"profTags"`
-	Contacts   []Contact `json:"contacts"`
-	Services   []Service `json:"services"`
+	Id               int64             `json:"id"`
+	TelegramID       int64             `json:"telegramID"`
+	Username         string            `json:"tg"`
+	FirstName        string            `json:"firstName"`
+	LastName         string            `json:"lastName"`
+	Bio              string            `json:"bio"`
+	AvatarURL        string            `json:"avatarUrl"`
+	Occupation       string            `json:"occupation"`
+	Experience       string            `json:"experience"`
+	Birthday         *DateOnly         `json:"birthday"`
+	Roles            []Role            `json:"roles"`
+	Order            int               `json:"order"`
+	MemberId         int               `json:"memberId"`
+	ProfTags         []ProfTag         `json:"profTags"`
+	Contacts         []Contact         `json:"contacts"`
+	Services         []Service         `json:"services"`
+	SubscriptionTier *SubscriptionTier `json:"subscriptionTier,omitempty"`
 }
 
 type MentorsTag struct {

--- a/backend/internal/repository/member.go
+++ b/backend/internal/repository/member.go
@@ -59,6 +59,7 @@ func (r *MemberRepository) GetById(id int64) (*models.Member, error) {
 		AvatarURL:  member.AvatarURL,
 		Roles:      member.GetRoleStrings(),
 		Birthday:   member.Birthday,
+		CreatedAt:  member.CreatedAt,
 	}
 
 	return result, nil

--- a/backend/internal/service/member.go
+++ b/backend/internal/service/member.go
@@ -14,8 +14,9 @@ type MemberRepoAdapter struct {
 // MemberService представляет сервис для работы с участниками
 type MemberService struct {
 	BaseService[models.Member]
-	repo       *repository.MemberRepository
-	mentorRepo *repository.MentorRepository
+	repo             *repository.MemberRepository
+	mentorRepo       *repository.MentorRepository
+	subscriptionRepo *repository.SubscriptionRepository
 }
 
 // NewMemberService создает новый экземпляр сервиса участников
@@ -24,10 +25,31 @@ func NewMemberService() *MemberService {
 	adapter := &MemberRepoAdapter{repo}
 
 	return &MemberService{
-		BaseService: NewBaseService[models.Member](adapter),
-		repo:        repo,
-		mentorRepo:  repository.NewMentorRepository(),
+		BaseService:      NewBaseService[models.Member](adapter),
+		repo:             repo,
+		mentorRepo:       repository.NewMentorRepository(),
+		subscriptionRepo: repository.NewSubscriptionRepository(),
 	}
+}
+
+// GetEffectiveTier возвращает эффективный тир подписки пользователя
+// (ManualTierID в приоритете, иначе ResolvedTierID). nil если подписки нет.
+// Используется хендлерами профиля, чтобы отдать фронту актуальный уровень
+// без чтения roles, которые с тирами не синхронизируются.
+func (s *MemberService) GetEffectiveTier(telegramID int64) *models.SubscriptionTier {
+	user, err := s.subscriptionRepo.GetUser(telegramID)
+	if err != nil {
+		return nil
+	}
+	tierID := user.EffectiveTierID()
+	if tierID == nil {
+		return nil
+	}
+	tier, err := s.subscriptionRepo.GetTier(*tierID)
+	if err != nil {
+		return nil
+	}
+	return tier
 }
 
 func (s *MemberService) GetTodayBirthdays() ([]string, error) {

--- a/platform-frontend/src/__tests__/composables/useUser.test.ts
+++ b/platform-frontend/src/__tests__/composables/useUser.test.ts
@@ -273,7 +273,7 @@ describe('useUser', () => {
       expect(result.levelIndex.value).toBe(0)
     })
 
-    it('returns Бригадир for SUBSCRIBER', async () => {
+    it('returns Новичок for SUBSCRIBER without tier (beginner or null)', async () => {
       const user: TelegramUser = {
         id: 1,
         telegramID: 1,
@@ -286,6 +286,30 @@ describe('useUser', () => {
         company: '',
         avatarUrl: '',
         roles: ['SUBSCRIBER'],
+        subscriptionTier: { id: 1, slug: 'beginner', name: 'Beginner', level: 1 },
+      }
+      localStorage.setItem('tg_user', JSON.stringify(user))
+
+      const { useUserLevel } = await freshImport()
+      const { result } = withSetup(() => useUserLevel())
+      expect(result.level.value).toBe('Новичок')
+      expect(result.levelIndex.value).toBe(0)
+    })
+
+    it('returns Бригадир for foreman tier', async () => {
+      const user: TelegramUser = {
+        id: 1,
+        telegramID: 1,
+        tg: 'user',
+        birthday: '',
+        firstName: '',
+        lastName: '',
+        bio: '',
+        grade: '',
+        company: '',
+        avatarUrl: '',
+        roles: ['SUBSCRIBER'],
+        subscriptionTier: { id: 2, slug: 'foreman', name: 'Foreman', level: 2 },
       }
       localStorage.setItem('tg_user', JSON.stringify(user))
 
@@ -293,6 +317,74 @@ describe('useUser', () => {
       const { result } = withSetup(() => useUserLevel())
       expect(result.level.value).toBe('Бригадир')
       expect(result.levelIndex.value).toBe(1)
+    })
+
+    it('returns Хозяин for master tier', async () => {
+      const user: TelegramUser = {
+        id: 1,
+        telegramID: 1,
+        tg: 'user',
+        birthday: '',
+        firstName: '',
+        lastName: '',
+        bio: '',
+        grade: '',
+        company: '',
+        avatarUrl: '',
+        roles: ['SUBSCRIBER'],
+        subscriptionTier: { id: 3, slug: 'master', name: 'Master', level: 3 },
+      }
+      localStorage.setItem('tg_user', JSON.stringify(user))
+
+      const { useUserLevel } = await freshImport()
+      const { result } = withSetup(() => useUserLevel())
+      expect(result.level.value).toBe('Хозяин')
+      expect(result.levelIndex.value).toBe(2)
+    })
+
+    it('returns King for king tier', async () => {
+      const user: TelegramUser = {
+        id: 1,
+        telegramID: 1,
+        tg: 'user',
+        birthday: '',
+        firstName: '',
+        lastName: '',
+        bio: '',
+        grade: '',
+        company: '',
+        avatarUrl: '',
+        roles: ['SUBSCRIBER'],
+        subscriptionTier: { id: 4, slug: 'king', name: 'King', level: 4 },
+      }
+      localStorage.setItem('tg_user', JSON.stringify(user))
+
+      const { useUserLevel } = await freshImport()
+      const { result } = withSetup(() => useUserLevel())
+      expect(result.level.value).toBe('King')
+      expect(result.levelIndex.value).toBe(4)
+    })
+
+    it('returns Хозяин for MENTOR even without master tier', async () => {
+      const user: TelegramUser = {
+        id: 1,
+        telegramID: 1,
+        tg: 'user',
+        birthday: '',
+        firstName: '',
+        lastName: '',
+        bio: '',
+        grade: '',
+        company: '',
+        avatarUrl: '',
+        roles: ['MENTOR'],
+      }
+      localStorage.setItem('tg_user', JSON.stringify(user))
+
+      const { useUserLevel } = await freshImport()
+      const { result } = withSetup(() => useUserLevel())
+      expect(result.level.value).toBe('Хозяин')
+      expect(result.levelIndex.value).toBe(2)
     })
 
     it('returns Бизнесмен for ADMIN', async () => {

--- a/platform-frontend/src/composables/useUser.ts
+++ b/platform-frontend/src/composables/useUser.ts
@@ -42,8 +42,8 @@ export function canViewAdminPanel() {
 
 export function useUserLevel() {
   const user = useUser()
-  const level = computed(() => user.value ? getSubscriptionLevel(user.value.roles) : SUBSCRIPTION_LEVELS[0])
-  const levelIndex = computed(() => user.value ? getSubscriptionLevelIndex(user.value.roles) : 0)
+  const level = computed(() => user.value ? getSubscriptionLevel(user.value.roles, user.value.subscriptionTier) : SUBSCRIPTION_LEVELS[0])
+  const levelIndex = computed(() => user.value ? getSubscriptionLevelIndex(user.value.roles, user.value.subscriptionTier) : 0)
   const maxLevel = SUBSCRIPTION_LEVELS.length - 1
 
   return { level, levelIndex, maxLevel }

--- a/platform-frontend/src/models/profile.ts
+++ b/platform-frontend/src/models/profile.ts
@@ -1,5 +1,14 @@
 export type UserRole = 'UNSUBSCRIBER' | 'SUBSCRIBER' | 'MENTOR' | 'ADMIN' | 'EVENT_MAKER'
 
+export type SubscriptionTierSlug = 'beginner' | 'foreman' | 'master' | 'king'
+
+export interface SubscriptionTier {
+  id: number
+  slug: SubscriptionTierSlug | string
+  name: string
+  level: number
+}
+
 export interface TelegramUser {
   id: number
   telegramID: number
@@ -13,6 +22,7 @@ export interface TelegramUser {
   avatarUrl: string
   roles: UserRole[]
   createdAt?: string
+  subscriptionTier?: SubscriptionTier | null
 }
 
 export interface Mentor extends TelegramUser {
@@ -72,18 +82,33 @@ export const SUBSCRIPTION_LEVELS = [
 
 export type SubscriptionLevel = typeof SUBSCRIPTION_LEVELS[number]
 
-export function getSubscriptionLevel(roles: UserRole[]): SubscriptionLevel {
+// Маппинг тиров подписки (из subscription_tiers) на UI-уровни.
+// beginner = "в комьюнити" без повышенного тира → Новичок.
+// MENTOR как отдельная роль — поднимает до Хозяина, если тир ниже.
+// ADMIN всегда побеждает и даёт Бизнесмена.
+export function getSubscriptionLevel(
+  roles: UserRole[],
+  tier?: SubscriptionTier | null,
+): SubscriptionLevel {
   if (roles.includes('ADMIN'))
     return 'Бизнесмен'
+  const slug = tier?.slug
+  if (slug === 'king')
+    return 'King'
+  if (slug === 'master')
+    return 'Хозяин'
   if (roles.includes('MENTOR'))
     return 'Хозяин'
-  if (roles.includes('SUBSCRIBER'))
+  if (slug === 'foreman')
     return 'Бригадир'
   return 'Новичок'
 }
 
-export function getSubscriptionLevelIndex(roles: UserRole[]): number {
-  const level = getSubscriptionLevel(roles)
+export function getSubscriptionLevelIndex(
+  roles: UserRole[],
+  tier?: SubscriptionTier | null,
+): number {
+  const level = getSubscriptionLevel(roles, tier)
   return SUBSCRIPTION_LEVELS.indexOf(level)
 }
 

--- a/platform-frontend/src/pages/MemberProfile.vue
+++ b/platform-frontend/src/pages/MemberProfile.vue
@@ -110,13 +110,13 @@ const daysSinceJoined = computed(() => {
 const subscriptionLevel = computed(() => {
   if (!profile.value)
     return SUBSCRIPTION_LEVELS[0]
-  return getSubscriptionLevel(profile.value.member.roles)
+  return getSubscriptionLevel(profile.value.member.roles, profile.value.member.subscriptionTier)
 })
 
 const subscriptionLevelIndex = computed(() => {
   if (!profile.value)
     return 0
-  return getSubscriptionLevelIndex(profile.value.member.roles)
+  return getSubscriptionLevelIndex(profile.value.member.roles, profile.value.member.subscriptionTier)
 })
 
 function getAvatarSrc(tg: string, avatarUrl?: string) {


### PR DESCRIPTION
## Проблема

На `/community/member-profile` две ошибки (см. скриншот):

1. **«739729 дней с нами»** — `MemberRepository.GetById` собирал ответ вручную и не копировал `CreatedAt`. Фронт получал нулевую дату → огромная дельта.
2. **Неправильный уровень** («Бригадир», хотя `/subcheckall` ставит другой тир) — фронт определял уровень по `member.roles` (`SUBSCRIBER` → Бригадир), а `/subcheckall` обновляет `subscription_users.resolved_tier_id`. Две независимые системы, синхронизации нет.

## Backend
- Миграция `20260424150000_add_king_tier.sql` — новый тир `king` (level=4) в `subscription_tiers`.
- `models.Member`, `models.MentorModel` — transient-поле `SubscriptionTier` (JSON, не в БД).
- `MemberRepository.GetById` — теперь копирует `CreatedAt`.
- `MemberService.GetEffectiveTier(telegramID)` — достаёт EffectiveTierID (manual > resolved) из `subscription_users`.
- `MembersHandler.Me` / `GetPublicProfile` — заполняют `member.SubscriptionTier`.

## Frontend
- `TelegramUser.subscriptionTier?: SubscriptionTier`.
- `getSubscriptionLevel(roles, tier?)`:
  - ADMIN → Бизнесмен
  - king → King
  - master → Хозяин
  - MENTOR → Хозяин (если тир ниже)
  - foreman → Бригадир
  - beginner / null → Новичок
- Тесты `useUserLevel` покрывают все ветки (22 теста).

## Test plan
- [x] `go build`, `go test`, `type-check`, `lint`, `vitest` зелёные.
- [ ] После деплоя `/me` возвращает `subscriptionTier`.
- [ ] «дней с нами» — реальное число.
- [ ] Уровень корректный: beginner=Новичок, foreman=Бригадир, master=Хозяин, king=King.