### PR TITLE
feat(levels): убрать Меценат/Бизнесмен, King — максимум

### DIFF
--- a/platform-frontend/src/App.vue
+++ b/platform-frontend/src/App.vue
@@ -9,6 +9,7 @@ import { useUser } from '@/composables/useUser'
 import { startProactiveRefresh, stopProactiveRefresh } from '@/services/api'
 import { authService } from '@/services/auth'
 import { handleError } from '@/services/errorService'
+import { profileService } from '@/services/profile'
 import Layout from './components/layout/Layout.vue'
 
 const { start: startOnboarding } = useOnboarding()
@@ -39,6 +40,9 @@ onBeforeMount(() => {
         window.history.replaceState({}, document.title, window.location.pathname)
         startSSE()
         startProactiveRefresh()
+        // Авторизация возвращает не все поля профиля (нет subscriptionTier и т.п.)
+        // — дёргаем /me чтобы перетереть tg_user актуальной версией.
+        profileService.getMe().catch(() => {})
         // Запускаем онбординг с задержкой, чтобы дать DOM срендериться
         // (особенно важно для Safari/Telegram WebView)
         setTimeout(startOnboarding, 1500)
@@ -57,6 +61,10 @@ onBeforeMount(() => {
   else if (tg_user.value) {
     startSSE()
     startProactiveRefresh()
+    // Освежаем tg_user при каждом открытии: бэкенд со временем добавляет
+    // поля (subscriptionTier, роли после /subcheckall и т.п.), локалсторейдж
+    // сам по себе не инвалидируется.
+    profileService.getMe().catch(() => {})
   }
   else if (!tg_user.value && !import.meta.env.DEV) {
     window.location.pathname = '/'

--- a/platform-frontend/src/__tests__/composables/useUser.test.ts
+++ b/platform-frontend/src/__tests__/composables/useUser.test.ts
@@ -362,7 +362,7 @@ describe('useUser', () => {
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
       expect(result.level.value).toBe('King')
-      expect(result.levelIndex.value).toBe(4)
+      expect(result.levelIndex.value).toBe(3)
     })
 
     it('returns Хозяин for MENTOR even without master tier', async () => {
@@ -387,7 +387,7 @@ describe('useUser', () => {
       expect(result.levelIndex.value).toBe(2)
     })
 
-    it('returns Бизнесмен for ADMIN', async () => {
+    it('returns King for ADMIN', async () => {
       const user: TelegramUser = {
         id: 1,
         telegramID: 1,
@@ -405,14 +405,14 @@ describe('useUser', () => {
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
-      expect(result.level.value).toBe('Бизнесмен')
-      expect(result.levelIndex.value).toBe(5)
+      expect(result.level.value).toBe('King')
+      expect(result.levelIndex.value).toBe(3)
     })
 
     it('exposes maxLevel', async () => {
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
-      expect(result.maxLevel).toBe(5)
+      expect(result.maxLevel).toBe(3)
     })
   })
 })

--- a/platform-frontend/src/models/profile.ts
+++ b/platform-frontend/src/models/profile.ts
@@ -75,9 +75,7 @@ export const SUBSCRIPTION_LEVELS = [
   'Новичок',
   'Бригадир',
   'Хозяин',
-  'Меценат',
   'King',
-  'Бизнесмен',
 ] as const
 
 export type SubscriptionLevel = typeof SUBSCRIPTION_LEVELS[number]
@@ -85,13 +83,13 @@ export type SubscriptionLevel = typeof SUBSCRIPTION_LEVELS[number]
 // Маппинг тиров подписки (из subscription_tiers) на UI-уровни.
 // beginner = "в комьюнити" без повышенного тира → Новичок.
 // MENTOR как отдельная роль — поднимает до Хозяина, если тир ниже.
-// ADMIN всегда побеждает и даёт Бизнесмена.
+// ADMIN даёт максимальный уровень (King).
 export function getSubscriptionLevel(
   roles: UserRole[],
   tier?: SubscriptionTier | null,
 ): SubscriptionLevel {
   if (roles.includes('ADMIN'))
-    return 'Бизнесмен'
+    return 'King'
   const slug = tier?.slug
   if (slug === 'king')
     return 'King'


### PR DESCRIPTION
Новая иерархия уровней: Новичок → Бригадир → Хозяин → King (4 уровня). ADMIN → King (раньше Бизнесмен), Меценат/Бизнесмен больше не используются. Тесты обновлены.