### PR TITLE
fix(bot): удалять /whois в группе после ответа бота

### DIFF
--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -570,7 +570,18 @@ func (b *TelegramBot) handleWhoisCommand(message *tgbotapi.Message) {
 	msg.ParseMode = "HTML"
 	msg.ReplyToMessageID = message.MessageID
 	msg.DisableWebPagePreview = true
-	b.bot.Send(msg)
+	if _, sendErr := b.bot.Send(msg); sendErr != nil {
+		log.Printf("Failed to send /whois reply in chat %d: %v", message.Chat.ID, sendErr)
+		return
+	}
+
+	// В группе чистим команду, чтобы в чате оставалась только карточка бота
+	// и не плодились кликабельные /whois, по которым тапают соседи.
+	if message.Chat.Type != "private" {
+		if _, delErr := b.bot.Request(tgbotapi.NewDeleteMessage(message.Chat.ID, message.MessageID)); delErr != nil {
+			log.Printf("Failed to delete /whois command %d in chat %d: %v", message.MessageID, message.Chat.ID, delErr)
+		}
+	}
 }
 
 // handleChatIDCommand отправляет ID чата владельцу в ЛС и удаляет команду


### PR DESCRIPTION
## Проблема

Юзеры в группе пишут \`/whois @username\` цепочками — бот отвечает карточкой, но команда остаётся в чате синим кликабельным текстом. Соседи тапают, отправляется та же команда, чат захлёбывается (см. скриншот из сессии).

## Почему не удалялось раньше

PR #278 и #280 удаляли bare-вызов и not-found. Успешный путь (member найден → карточка отправлена) оставлял команду в чате.

## Что поменялось

`handleWhoisCommand` — после `b.bot.Send(msg)` в групповом чате удаляет исходную команду. В личке оставляем как было. Заодно логирую ошибку Send (раньше тихо игнорировалась).

## Про SubscriptionTier в других endpoint'ах

Ревью показало 4 endpoint'а (member.Search, member.GetById, mentor.GetById/GetAllWithRelations, guild.GetMembers), которые не заполняют `SubscriptionTier`. Проверил платформенный фронт — **уровень нигде из этих ответов не рендерится** (только в MemberProfile через GetPublicProfile и в Sidebar/Dashboard через /me). Не трогаю — YAGNI, лишних SQL не делаем.

## Test plan
- [ ] В группе `/whois @realuser` → карточка приходит, команда юзера удаляется.
- [ ] В личке `/whois @realuser` → карточка приходит, команда остаётся.
- [ ] Если бот без прав на удаление — карточка всё равно отправляется, ошибка только в логах.