### PR TITLE
fix(platform): обработка ошибок в Quests/Casino + console.error под DEV

### DIFF
--- a/platform-frontend/src/pages/Casino.vue
+++ b/platform-frontend/src/pages/Casino.vue
@@ -10,6 +10,7 @@ import { handleError } from '@/services/errorService'
 const stats = ref<CasinoStats | null>(null)
 const feed = ref<CasinoFeedItem[]>([])
 const isLoading = ref(true)
+const loadError = ref<string | null>(null)
 const isPlaying = ref(false)
 const lastResult = ref<CasinoBetResult | null>(null)
 const showResult = ref(false)
@@ -74,6 +75,7 @@ let wheelTimer: ReturnType<typeof setTimeout> | null = null
 
 async function fetchData() {
   isLoading.value = true
+  loadError.value = null
   try {
     const [s, f] = await Promise.all([
       casinoService.getStats(),
@@ -83,7 +85,7 @@ async function fetchData() {
     feed.value = f ?? []
   }
   catch (error) {
-    handleError(error)
+    loadError.value = (await handleError(error)).message
   }
   finally {
     isLoading.value = false
@@ -109,7 +111,7 @@ async function playGame(action: () => Promise<CasinoBetResult>, delayMs = 1500) 
     if (stats.value) {
       stats.value.balance = result.balance
     }
-    casinoService.getFeed().then(f => feed.value = f ?? []).catch(() => {})
+    casinoService.getFeed().then(f => feed.value = f ?? []).catch(handleError)
   }
   catch (error) {
     handleError(error)
@@ -337,6 +339,21 @@ onBeforeUnmount(() => {
         class="flex justify-center py-20"
       >
         <Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+
+      <div
+        v-else-if="loadError"
+        class="text-center py-20"
+      >
+        <p class="text-sm text-destructive mb-3">
+          {{ loadError }}
+        </p>
+        <button
+          class="inline-flex items-center gap-1.5 rounded-sm border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted/50 transition-colors"
+          @click="fetchData"
+        >
+          Повторить
+        </button>
       </div>
 
       <template v-else>

--- a/platform-frontend/src/pages/Quests.vue
+++ b/platform-frontend/src/pages/Quests.vue
@@ -17,6 +17,7 @@ import { handleError } from '@/services/errorService'
 
 const quests = ref<ChatQuestWithProgress[]>([])
 const isLoading = ref(true)
+const loadError = ref<string | null>(null)
 const activeFilter = ref<'all' | 'active' | 'completed'>('all')
 
 const filters: { key: 'all' | 'active' | 'completed', label: string }[] = [
@@ -64,11 +65,12 @@ function questTypeLabel(quest: ChatQuestWithProgress) {
 
 async function fetchQuests() {
   isLoading.value = true
+  loadError.value = null
   try {
     quests.value = await chatQuestService.getAllQuests() ?? []
   }
   catch (error) {
-    handleError(error)
+    loadError.value = (await handleError(error)).message
   }
   finally {
     isLoading.value = false
@@ -109,6 +111,21 @@ onMounted(() => {
       class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
     >
       <QuestCardSkeleton v-for="i in 3" :key="i" />
+    </div>
+
+    <div
+      v-else-if="loadError"
+      class="text-center py-12"
+    >
+      <p class="text-sm text-destructive mb-3">
+        {{ loadError }}
+      </p>
+      <button
+        class="inline-flex items-center gap-1.5 rounded-sm border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted/50 transition-colors"
+        @click="fetchQuests"
+      >
+        Повторить
+      </button>
     </div>
 
     <template v-else>

--- a/platform-frontend/src/services/errorService.ts
+++ b/platform-frontend/src/services/errorService.ts
@@ -89,7 +89,9 @@ export async function handleError(error: unknown): Promise<AppError> {
     variant: 'destructive',
   })
 
-  console.error('[App Error]', appError)
+  if (import.meta.env.DEV) {
+    console.error('[App Error]', appError)
+  }
 
   return appError
 }


### PR DESCRIPTION
## Найденные проблемы (из аудита репо)

| Место | Было | Стало |
|---|---|---|
| `Quests.vue` | При ошибке API скелетон снимается, список пуст, пользователь не понимает почему | `loadError` + error-state с кнопкой «Повторить» |
| `Casino.vue` (первая загрузка) | При ошибке `stats=null`, страница пустая без индикации | `loadError` + error-state с «Повторить» |
| `Casino.vue:112` | `.catch(() => {})` глотал ошибку обновления фида после ставки | `.catch(handleError)` — toast об ошибке |
| `errorService.ts:92` | `console.error('[App Error]', …)` светился в проде | Обёрнут в `if (import.meta.env.DEV)` |

## Test plan
- [x] `npm run type-check`, `npm run lint`, `vitest` (686 тестов) зелёные
- [ ] `/quests` с отключённым бэком → видим «Повторить», а не пустоту
- [ ] `/minigames` с отключённым бэком → то же
- [ ] Игра → после ставки фид падает → тост об ошибке вместо тишины
- [ ] В DevTools прода нет `[App Error]` логов