### PR TITLE
feat: F6 NPS-виджет + рефакторинг T1/T3/T4

### DIFF
--- a/admin-frontend/src/__tests__/composables/useSidebar.test.ts
+++ b/admin-frontend/src/__tests__/composables/useSidebar.test.ts
@@ -25,7 +25,7 @@ describe('useSidebar', () => {
 
       const { sidebarItems } = useSidebar()
 
-      expect(sidebarItems.value).toHaveLength(16)
+      expect(sidebarItems.value).toHaveLength(17)
     })
 
     it('shows only items without requiredPermission when user has no permissions', () => {
@@ -77,7 +77,7 @@ describe('useSidebar', () => {
 
       const expectedPaths = [
         '/dashboard', '/mentors', '/members', '/events', '/resumes',
-        '/reviews', '/mentor-reviews', '/points', '/chat-activity',
+        '/reviews', '/mentor-reviews', '/feedback', '/points', '/chat-activity',
         '/chat-quests', '/seasons', '/raffles', '/minigames',
         '/subscriptions', '/referrals', '/audit-logs',
       ]

--- a/admin-frontend/src/__tests__/router/index.test.ts
+++ b/admin-frontend/src/__tests__/router/index.test.ts
@@ -41,8 +41,8 @@ describe('router', () => {
   })
 
   describe('route definitions', () => {
-    it('has 18 routes defined', () => {
-      expect(router.getRoutes()).toHaveLength(18)
+    it('has 19 routes defined', () => {
+      expect(router.getRoutes()).toHaveLength(19)
     })
 
     it('has a login route', () => {
@@ -73,6 +73,7 @@ describe('router', () => {
       ['seasons', '/seasons'],
       ['raffles', '/raffles'],
       ['subscriptions', '/subscriptions'],
+      ['feedback', '/feedback'],
     ])('has route "%s" at path "%s" requiring auth', (name, path) => {
       const route = router.getRoutes().find(r => r.name === name)
       expect(route).toBeDefined()

--- a/admin-frontend/src/composables/useSidebar.ts
+++ b/admin-frontend/src/composables/useSidebar.ts
@@ -92,6 +92,12 @@ export function useSidebar() {
           icon: MessageSquare,
           requiredPermission: 'can_view_admin_mentors_review',
         },
+        {
+          title: 'Обратная связь',
+          path: '/feedback',
+          icon: MessageSquare,
+          requiredPermission: 'can_view_admin_feedback',
+        },
       ],
     },
     {

--- a/admin-frontend/src/models/feedback.ts
+++ b/admin-frontend/src/models/feedback.ts
@@ -1,0 +1,10 @@
+export interface Feedback {
+  id: number
+  userId: number | null
+  userFirstName: string | null
+  userLastName: string | null
+  userUsername: string | null
+  score: number
+  comment: string | null
+  createdAt: string
+}

--- a/admin-frontend/src/router/index.ts
+++ b/admin-frontend/src/router/index.ts
@@ -18,6 +18,7 @@ const SeasonsView = () => import('@/views/SeasonsView.vue')
 const RafflesView = () => import('@/views/RafflesView.vue')
 const CasinoView = () => import('@/views/CasinoView.vue')
 const SubscriptionsView = () => import('@/views/SubscriptionsView.vue')
+const FeedbackView = () => import('@/views/FeedbackView.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -128,6 +129,12 @@ const router = createRouter({
       path: '/subscriptions',
       name: 'subscriptions',
       component: SubscriptionsView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/feedback',
+      name: 'feedback',
+      component: FeedbackView,
       meta: { requiresAuth: true },
     },
   ],

--- a/admin-frontend/src/services/feedbackService.ts
+++ b/admin-frontend/src/services/feedbackService.ts
@@ -1,0 +1,10 @@
+import type { Feedback } from '@/models/feedback'
+import { BaseService } from '@/services/api/baseService'
+
+class FeedbackService extends BaseService<Feedback> {
+  constructor() {
+    super('feedback')
+  }
+}
+
+export const feedbackService = new FeedbackService()

--- a/admin-frontend/src/types/permissions.ts
+++ b/admin-frontend/src/types/permissions.ts
@@ -23,6 +23,7 @@ export type Permission
     | 'can_edit_admin_points'
     | 'can_view_admin_subscriptions'
     | 'can_edit_admin_subscriptions'
+    | 'can_view_admin_feedback'
     | 'is_super_admin'
 
 /**
@@ -49,6 +50,7 @@ export function isPermission(value: string): value is Permission {
     'can_edit_admin_points',
     'can_view_admin_subscriptions',
     'can_edit_admin_subscriptions',
+    'can_view_admin_feedback',
     'is_super_admin',
   ]
 

--- a/admin-frontend/src/views/FeedbackView.vue
+++ b/admin-frontend/src/views/FeedbackView.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+import AdminLayout from '@/components/layout/AdminLayout.vue'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Pagination, PaginationEllipsis, PaginationFirst, PaginationLast, PaginationList, PaginationListItem, PaginationNext, PaginationPrev } from '@/components/ui/pagination'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Typography } from '@/components/ui/typography'
+import { feedbackService } from '@/services/feedbackService'
+
+onMounted(feedbackService.search)
+onUnmounted(feedbackService.clearPagination)
+
+function userName(item: { userFirstName: string | null, userLastName: string | null, userUsername: string | null }): string {
+  const name = [item.userFirstName, item.userLastName].filter(Boolean).join(' ').trim()
+  if (name && item.userUsername)
+    return `${name} (@${item.userUsername})`
+  if (name)
+    return name
+  if (item.userUsername)
+    return `@${item.userUsername}`
+  return 'Аноним'
+}
+
+function scoreColor(score: number): string {
+  if (score >= 9)
+    return 'text-green-600'
+  if (score >= 7)
+    return 'text-yellow-600'
+  return 'text-red-600'
+}
+</script>
+
+<template>
+  <AdminLayout>
+    <div class="space-y-6">
+      <Typography variant="h2" as="h1">
+        Обратная связь
+      </Typography>
+
+      <Card>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Дата</TableHead>
+                <TableHead>Пользователь</TableHead>
+                <TableHead class="w-20 text-center">
+                  Оценка
+                </TableHead>
+                <TableHead>Комментарий</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow v-if="feedbackService.items.value.total === 0" class="h-24">
+                <TableCell colspan="4" class="text-center">
+                  Отзывов пока нет
+                </TableCell>
+              </TableRow>
+              <TableRow v-for="item in feedbackService.items.value.items" :key="item.id">
+                <TableCell class="whitespace-nowrap">
+                  {{ new Date(item.createdAt).toLocaleString() }}
+                </TableCell>
+                <TableCell class="whitespace-nowrap">
+                  {{ userName(item) }}
+                </TableCell>
+                <TableCell class="text-center font-semibold" :class="scoreColor(item.score)">
+                  {{ item.score }}
+                </TableCell>
+                <TableCell class="whitespace-pre-wrap">
+                  {{ item.comment || '—' }}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <div class="mt-4 flex justify-end">
+        <Pagination v-slot="{ page }" :items-per-page="10" :total="feedbackService.items.value.total" :sibling-count="1" show-edges :default-page="1">
+          <PaginationList v-slot="{ items }" class="flex items-center gap-1">
+            <PaginationFirst />
+            <PaginationPrev />
+
+            <template v-for="(item, index) in items">
+              <PaginationListItem v-if="item.type === 'page'" :key="index" :value="item.value" as-child>
+                <Button class="w-10 h-10 p-0" :variant="item.value === page ? 'default' : 'outline'" @click="feedbackService.changePagination(item.value)">
+                  {{ item.value }}
+                </Button>
+              </PaginationListItem>
+              <PaginationEllipsis v-else :key="item.type" :index="index" />
+            </template>
+
+            <PaginationNext />
+            <PaginationLast />
+          </PaginationList>
+        </Pagination>
+      </div>
+    </div>
+  </AdminLayout>
+</template>

--- a/backend/database/migrations/20260425000000_create_feedbacks.sql
+++ b/backend/database/migrations/20260425000000_create_feedbacks.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS feedbacks (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT REFERENCES members(id) ON DELETE SET NULL,
+    score INT NOT NULL CHECK (score >= 0 AND score <= 10),
+    comment TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedbacks_created_at ON feedbacks(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_feedbacks_user_id ON feedbacks(user_id);
+
+INSERT INTO permissions (name)
+SELECT name FROM (VALUES ('can_view_admin_feedback')) AS new_perms(name)
+WHERE NOT EXISTS (SELECT 1 FROM permissions p WHERE p.name = new_perms.name);
+
+INSERT INTO role_permissions (role, permission_id)
+SELECT 'ADMIN', p.id
+FROM permissions p
+WHERE p.name = 'can_view_admin_feedback'
+  AND NOT EXISTS (
+    SELECT 1 FROM role_permissions rp WHERE rp.role = 'ADMIN' AND rp.permission_id = p.id
+  );

--- a/backend/internal/handler/achievement.go
+++ b/backend/internal/handler/achievement.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"ithozyeva/internal/models"
 	"ithozyeva/internal/service"
 	"strconv"
 
@@ -19,7 +18,10 @@ func NewAchievementHandler() *AchievementHandler {
 }
 
 func (h *AchievementHandler) GetMyAchievements(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	resp, err := h.svc.GetUserAchievements(member.Id)
 	if err != nil {

--- a/backend/internal/handler/casino.go
+++ b/backend/internal/handler/casino.go
@@ -35,7 +35,10 @@ func (h *CasinoHandler) checkRateLimit(memberId int64) error {
 }
 
 func (h *CasinoHandler) PlayCoinFlip(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	if err := h.checkRateLimit(member.Id); err != nil {
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": "Подождите секунду между ставками"})
 	}
@@ -56,7 +59,10 @@ func (h *CasinoHandler) PlayCoinFlip(c *fiber.Ctx) error {
 }
 
 func (h *CasinoHandler) PlayDiceRoll(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	if err := h.checkRateLimit(member.Id); err != nil {
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": "Подождите секунду между ставками"})
 	}
@@ -77,7 +83,10 @@ func (h *CasinoHandler) PlayDiceRoll(c *fiber.Ctx) error {
 }
 
 func (h *CasinoHandler) PlayWheel(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	if err := h.checkRateLimit(member.Id); err != nil {
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": "Подождите секунду между ставками"})
 	}
@@ -108,7 +117,10 @@ func (h *CasinoHandler) GetGlobalFeed(c *fiber.Ctx) error {
 }
 
 func (h *CasinoHandler) GetHistory(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	limit, _ := strconv.Atoi(c.Query("limit", "20"))
 	offset, _ := strconv.Atoi(c.Query("offset", "0"))
 
@@ -122,7 +134,10 @@ func (h *CasinoHandler) GetHistory(c *fiber.Ctx) error {
 }
 
 func (h *CasinoHandler) GetStats(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	stats, err := h.svc.GetStats(member.Id)
 	if err != nil {
 		log.Printf("GetStats error (member=%d): %v", member.Id, err)

--- a/backend/internal/handler/events.go
+++ b/backend/internal/handler/events.go
@@ -133,7 +133,10 @@ func (h *EventsHandler) AddMember(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	result, err := h.svc.AddMember(req.EventId, int(member.Id))
 	if err != nil {
@@ -157,7 +160,10 @@ func (h *EventsHandler) RemoveMember(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	result, err := h.svc.RemoveMember(req.EventId, int(member.Id))
 	if err != nil {

--- a/backend/internal/handler/feedback.go
+++ b/backend/internal/handler/feedback.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"log"
+	"strconv"
+
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/service"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type FeedbackHandler struct {
+	svc *service.FeedbackService
+}
+
+func NewFeedbackHandler() *FeedbackHandler {
+	return &FeedbackHandler{
+		svc: service.NewFeedbackService(),
+	}
+}
+
+func (h *FeedbackHandler) Create(c *fiber.Ctx) error {
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
+
+	req := new(models.CreateFeedbackRequest)
+	if err := c.BodyParser(req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
+	}
+
+	feedback, err := h.svc.Create(member, *req)
+	if err != nil {
+		log.Printf("create feedback error (member=%d): %v", member.Id, err)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(feedback)
+}
+
+func (h *FeedbackHandler) AdminList(c *fiber.Ctx) error {
+	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	offset, _ := strconv.Atoi(c.Query("offset", "0"))
+
+	items, total, err := h.svc.List(limit, offset)
+	if err != nil {
+		log.Printf("admin list feedback error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Ошибка загрузки отзывов"})
+	}
+
+	return c.JSON(fiber.Map{
+		"items": items,
+		"total": total,
+	})
+}

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"ithozyeva/internal/models"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// getMember безопасно достаёт *models.Member из c.Locals.
+// Возвращает 401, если member отсутствует или некорректного типа —
+// вместо паники из-за прямого type assertion.
+func getMember(c *fiber.Ctx) (*models.Member, error) {
+	member, ok := c.Locals("member").(*models.Member)
+	if !ok || member == nil {
+		return nil, fiber.NewError(fiber.StatusUnauthorized, "member context not found")
+	}
+	return member, nil
+}

--- a/backend/internal/handler/kudos.go
+++ b/backend/internal/handler/kudos.go
@@ -21,7 +21,10 @@ func NewKudosHandler() *KudosHandler {
 }
 
 func (h *KudosHandler) Send(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	req := new(models.CreateKudosRequest)
 	if err := c.BodyParser(req); err != nil {

--- a/backend/internal/handler/marketplace.go
+++ b/backend/internal/handler/marketplace.go
@@ -62,7 +62,10 @@ func (h *MarketplaceHandler) GetById(c *fiber.Ctx) error {
 }
 
 func (h *MarketplaceHandler) Create(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	req := &models.CreateMarketplaceItemRequest{
 		Title:           c.FormValue("title"),
@@ -118,6 +121,7 @@ func (h *MarketplaceHandler) Create(c *fiber.Ctx) error {
 
 	item, err := h.svc.Create(req, member.Id, imageFileName, imageContent, imageContentType)
 	if err != nil {
+		log.Printf("Marketplace create error (member=%d): %v", member.Id, err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Не удалось создать объявление"})
 	}
 
@@ -128,7 +132,10 @@ func (h *MarketplaceHandler) Create(c *fiber.Ctx) error {
 }
 
 func (h *MarketplaceHandler) Update(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -157,7 +164,10 @@ func (h *MarketplaceHandler) Update(c *fiber.Ctx) error {
 }
 
 func (h *MarketplaceHandler) RequestPurchase(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -180,7 +190,10 @@ func (h *MarketplaceHandler) RequestPurchase(c *fiber.Ctx) error {
 }
 
 func (h *MarketplaceHandler) CancelPurchase(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -204,7 +217,10 @@ func (h *MarketplaceHandler) CancelPurchase(c *fiber.Ctx) error {
 }
 
 func (h *MarketplaceHandler) MarkSold(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -233,7 +249,10 @@ func (h *MarketplaceHandler) MarkSold(c *fiber.Ctx) error {
 }
 
 func (h *MarketplaceHandler) Delete(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})

--- a/backend/internal/handler/member.go
+++ b/backend/internal/handler/member.go
@@ -189,7 +189,10 @@ func (h *MembersHandler) Delete(c *fiber.Ctx) error {
 }
 
 func (h *MembersHandler) Me(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	member.SubscriptionTier = h.svc.GetEffectiveTier(member.TelegramID)
 
 	mentor, err := h.svc.GetMentor(member.Id)
@@ -204,12 +207,14 @@ func (h *MembersHandler) Me(c *fiber.Ctx) error {
 
 func (h *MembersHandler) UpdateProfile(c *fiber.Ctx) error {
 	request := new(UpdateRequest)
-	err := c.BodyParser(request)
-	if err != nil {
+	if err := c.BodyParser(request); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	member.FirstName = request.FirstName
 	member.LastName = request.LastName
 	member.Bio = request.Bio

--- a/backend/internal/handler/mentor.go
+++ b/backend/internal/handler/mentor.go
@@ -74,7 +74,10 @@ func (h *MentorHandler) AddReviewFromPlatform(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	author := member.FirstName + " " + member.LastName
 
 	review := &models.ReviewOnService{
@@ -206,7 +209,11 @@ func (h *MentorHandler) UpdateInfo(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	existedMentor, err := h.svc.GetByMemberID(c.Locals("member").(*models.Member).Id)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
+	existedMentor, err := h.svc.GetByMemberID(member.Id)
 
 	if err != nil {
 		log.Printf("get mentor by member ID error: %v", err)
@@ -235,7 +242,11 @@ func (h *MentorHandler) UpdateProfTags(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	existedMentor, err := h.svc.GetByMemberID(c.Locals("member").(*models.Member).Id)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
+	existedMentor, err := h.svc.GetByMemberID(member.Id)
 
 	if err != nil {
 		log.Printf("get mentor by member ID error: %v", err)
@@ -263,7 +274,11 @@ func (h *MentorHandler) UpdateContacts(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	existedMentor, err := h.svc.GetByMemberID(c.Locals("member").(*models.Member).Id)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
+	existedMentor, err := h.svc.GetByMemberID(member.Id)
 
 	if err != nil {
 		log.Printf("get mentor by member ID error: %v", err)
@@ -316,7 +331,11 @@ func (h *MentorHandler) UpdateServices(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	existedMentor, err := h.svc.GetByMemberID(c.Locals("member").(*models.Member).Id)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
+	existedMentor, err := h.svc.GetByMemberID(member.Id)
 
 	if err != nil {
 		log.Printf("get mentor by member ID error: %v", err)

--- a/backend/internal/handler/notification.go
+++ b/backend/internal/handler/notification.go
@@ -17,7 +17,10 @@ func NewNotificationHandler() *NotificationHandler {
 }
 
 func (h *NotificationHandler) GetMy(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	var notifications []models.Notification
 	if err := database.DB.Where("member_id = ?", member.Id).
@@ -32,7 +35,10 @@ func (h *NotificationHandler) GetMy(c *fiber.Ctx) error {
 }
 
 func (h *NotificationHandler) GetUnreadCount(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	var count int64
 	if err := database.DB.Model(&models.Notification{}).
@@ -46,7 +52,10 @@ func (h *NotificationHandler) GetUnreadCount(c *fiber.Ctx) error {
 }
 
 func (h *NotificationHandler) MarkAsRead(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -69,7 +78,10 @@ func (h *NotificationHandler) MarkAsRead(c *fiber.Ctx) error {
 }
 
 func (h *NotificationHandler) MarkAllAsRead(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	if err := database.DB.Model(&models.Notification{}).
 		Where("member_id = ? AND read = false", member.Id).

--- a/backend/internal/handler/points.go
+++ b/backend/internal/handler/points.go
@@ -19,7 +19,10 @@ func NewPointsHandler() *PointsHandler {
 }
 
 func (h *PointsHandler) GetMyPoints(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	summary, err := h.svc.GetMyPoints(member.Id)
 	if err != nil {

--- a/backend/internal/handler/profile_stats.go
+++ b/backend/internal/handler/profile_stats.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"ithozyeva/internal/models"
 	"ithozyeva/internal/repository"
 	"ithozyeva/internal/service"
 	"log"
@@ -33,7 +32,10 @@ func (h *ProfileStatsHandler) enrichAchievements(stats *repository.ProfileStats,
 }
 
 func (h *ProfileStatsHandler) GetMyStats(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	stats, err := h.repo.GetStats(member.Id)
 	if err != nil {
 		log.Printf("get my profile stats error (member=%d): %v", member.Id, err)

--- a/backend/internal/handler/raffle.go
+++ b/backend/internal/handler/raffle.go
@@ -21,7 +21,10 @@ func NewRaffleHandler() *RaffleHandler {
 }
 
 func (h *RaffleHandler) GetAll(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	items, err := h.svc.GetAll(member.Id)
 	if err != nil {
 		log.Printf("get raffles error (member=%d): %v", member.Id, err)
@@ -40,7 +43,10 @@ func (h *RaffleHandler) GetAllAdmin(c *fiber.Ctx) error {
 }
 
 func (h *RaffleHandler) BuyTickets(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})

--- a/backend/internal/handler/referal_link.go
+++ b/backend/internal/handler/referal_link.go
@@ -74,10 +74,9 @@ func (h *ReferalLinkHandler) AddLink(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
-
-	if member == nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Произошла ошибка при получении пользователя"})
+	member, err := getMember(c)
+	if err != nil {
+		return err
 	}
 
 	result, err := h.svc.AddLink(req, member)
@@ -99,7 +98,10 @@ func (h *ReferalLinkHandler) UpdateLink(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	existedLink, err := h.service.GetById(req.Id)
 	if err != nil {
@@ -132,9 +134,12 @@ func (h *ReferalLinkHandler) TrackConversion(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
-	err := h.svc.TrackConversion(req.ReferralLinkId, member.Id)
+	err = h.svc.TrackConversion(req.ReferralLinkId, member.Id)
 	if err != nil {
 		// Handle unique constraint violation (duplicate conversion) as idempotent success
 		errMsg := err.Error()
@@ -222,7 +227,10 @@ func (h *ReferalLinkHandler) DeleteLink(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	existedLink, err := h.service.GetById(req.Id)
 	if err != nil {

--- a/backend/internal/handler/reviewOnCommunity.go
+++ b/backend/internal/handler/reviewOnCommunity.go
@@ -48,9 +48,12 @@ func (h *ReviewOnCommunityHandler) AddReview(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный запрос"})
 	}
 
-	author := c.Locals("member").(*models.Member)
+	author, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
-	err := h.svc.CreateReviewOnCommunityByMemberId(author.Id, review.Text, nil)
+	err = h.svc.CreateReviewOnCommunityByMemberId(author.Id, review.Text, nil)
 
 	if err != nil {
 		log.Printf("add review error (member=%d): %v", author.Id, err)
@@ -79,7 +82,10 @@ func (h *ReviewOnCommunityHandler) CreateReview(c *fiber.Ctx) error {
 }
 
 func (h *ReviewOnCommunityHandler) GetMyReviews(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	reviews, err := h.svc.GetByAuthorId(member.Id)
 	if err != nil {
 		log.Printf("get my reviews error (member=%d): %v", member.Id, err)
@@ -89,7 +95,10 @@ func (h *ReviewOnCommunityHandler) GetMyReviews(c *fiber.Ctx) error {
 }
 
 func (h *ReviewOnCommunityHandler) UpdateMyReview(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -119,7 +128,10 @@ func (h *ReviewOnCommunityHandler) UpdateMyReview(c *fiber.Ctx) error {
 }
 
 func (h *ReviewOnCommunityHandler) DeleteMyReview(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})

--- a/backend/internal/handler/sse.go
+++ b/backend/internal/handler/sse.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"bufio"
 	"fmt"
-	"ithozyeva/internal/models"
 	"ithozyeva/internal/service"
 	"log"
 
@@ -17,7 +16,10 @@ func NewSSEHandler() *SSEHandler {
 }
 
 func (h *SSEHandler) Stream(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")

--- a/backend/internal/handler/task_exchange.go
+++ b/backend/internal/handler/task_exchange.go
@@ -59,7 +59,10 @@ func (h *TaskExchangeHandler) GetById(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) Create(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 
 	var req models.CreateTaskExchangeRequest
 	if err := c.BodyParser(&req); err != nil {
@@ -92,7 +95,10 @@ func (h *TaskExchangeHandler) Create(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) Update(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -122,7 +128,10 @@ func (h *TaskExchangeHandler) Update(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) Assign(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -139,7 +148,10 @@ func (h *TaskExchangeHandler) Assign(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) Unassign(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -155,7 +167,10 @@ func (h *TaskExchangeHandler) Unassign(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) RemoveAssignee(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -184,7 +199,10 @@ func (h *TaskExchangeHandler) RemoveAssignee(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) MarkDone(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})
@@ -288,7 +306,10 @@ func (h *TaskExchangeHandler) Reject(c *fiber.Ctx) error {
 }
 
 func (h *TaskExchangeHandler) Delete(c *fiber.Ctx) error {
-	member := c.Locals("member").(*models.Member)
+	member, err := getMember(c)
+	if err != nil {
+		return err
+	}
 	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Неверный ID"})

--- a/backend/internal/models/feedback.go
+++ b/backend/internal/models/feedback.go
@@ -1,0 +1,31 @@
+package models
+
+import "time"
+
+type Feedback struct {
+	Id        int64     `json:"id" gorm:"primaryKey"`
+	UserId    *int64    `json:"userId" gorm:"column:user_id"`
+	Score     int       `json:"score" gorm:"column:score"`
+	Comment   *string   `json:"comment" gorm:"column:comment"`
+	CreatedAt time.Time `json:"createdAt" gorm:"column:created_at;autoCreateTime"`
+}
+
+func (Feedback) TableName() string {
+	return "feedbacks"
+}
+
+type CreateFeedbackRequest struct {
+	Score   int     `json:"score"`
+	Comment *string `json:"comment"`
+}
+
+type FeedbackPublic struct {
+	Id            int64     `json:"id"`
+	UserId        *int64    `json:"userId"`
+	UserFirstName *string   `json:"userFirstName"`
+	UserLastName  *string   `json:"userLastName"`
+	UserUsername  *string   `json:"userUsername"`
+	Score         int       `json:"score"`
+	Comment       *string   `json:"comment"`
+	CreatedAt     time.Time `json:"createdAt"`
+}

--- a/backend/internal/models/roles.go
+++ b/backend/internal/models/roles.go
@@ -34,6 +34,7 @@ const (
 	PermissionCanApprovePlatformTasks      Permission = "can_approve_platform_tasks"
 	PermissionCanViewAdminSubscriptions    Permission = "can_view_admin_subscriptions"
 	PermissionCanEditAdminSubscriptions    Permission = "can_edit_admin_subscriptions"
+	PermissionCanViewAdminFeedback         Permission = "can_view_admin_feedback"
 )
 
 type PermissionModel struct {

--- a/backend/internal/repository/feedback.go
+++ b/backend/internal/repository/feedback.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"ithozyeva/database"
+	"ithozyeva/internal/models"
+)
+
+type FeedbackRepository struct{}
+
+func NewFeedbackRepository() *FeedbackRepository {
+	return &FeedbackRepository{}
+}
+
+func (r *FeedbackRepository) Create(feedback *models.Feedback) error {
+	return database.DB.Create(feedback).Error
+}
+
+func (r *FeedbackRepository) CountTodayByMember(memberId int64) (int64, error) {
+	var count int64
+	err := database.DB.Model(&models.Feedback{}).
+		Where("user_id = ? AND created_at >= CURRENT_DATE", memberId).
+		Count(&count).Error
+	return count, err
+}
+
+func (r *FeedbackRepository) List(limit, offset int) ([]models.FeedbackPublic, int64, error) {
+	var total int64
+	if err := database.DB.Model(&models.Feedback{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]models.FeedbackPublic, 0)
+	err := database.DB.Raw(`
+		SELECT f.id, f.user_id, f.score, f.comment, f.created_at,
+			m.first_name AS user_first_name, m.last_name AS user_last_name, m.username AS user_username
+		FROM feedbacks f
+		LEFT JOIN members m ON m.id = f.user_id
+		ORDER BY f.created_at DESC
+		LIMIT ? OFFSET ?
+	`, limit, offset).Scan(&items).Error
+
+	return items, total, err
+}

--- a/backend/internal/repository/points.go
+++ b/backend/internal/repository/points.go
@@ -4,6 +4,8 @@ import (
 	"ithozyeva/database"
 	"ithozyeva/internal/models"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type PointsRepository struct{}
@@ -12,8 +14,9 @@ func NewPointsRepository() *PointsRepository {
 	return &PointsRepository{}
 }
 
-func (r *PointsRepository) AwardPoints(tx *models.PointTransaction) error {
-	result := database.DB.Exec(
+// AwardPointsTx идемпотентно начисляет баллы внутри переданного tx (или DB).
+func (r *PointsRepository) AwardPointsTx(db *gorm.DB, tx *models.PointTransaction) error {
+	result := db.Exec(
 		`INSERT INTO point_transactions (member_id, amount, reason, source_type, source_id, description)
 		 SELECT ?, ?, ?, ?, ?, ?
 		 WHERE NOT EXISTS (
@@ -24,6 +27,10 @@ func (r *PointsRepository) AwardPoints(tx *models.PointTransaction) error {
 		tx.MemberId, tx.Reason, tx.SourceType, tx.SourceId,
 	)
 	return result.Error
+}
+
+func (r *PointsRepository) AwardPoints(tx *models.PointTransaction) error {
+	return r.AwardPointsTx(database.DB, tx)
 }
 
 func (r *PointsRepository) GetBalance(memberId int64) (int, error) {

--- a/backend/internal/service/feedback.go
+++ b/backend/internal/service/feedback.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"fmt"
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/repository"
+	"strings"
+)
+
+type FeedbackService struct {
+	repo *repository.FeedbackRepository
+}
+
+func NewFeedbackService() *FeedbackService {
+	return &FeedbackService{
+		repo: repository.NewFeedbackRepository(),
+	}
+}
+
+const maxFeedbackCommentLen = 2000
+
+func (s *FeedbackService) Create(member *models.Member, req models.CreateFeedbackRequest) (*models.Feedback, error) {
+	if req.Score < 0 || req.Score > 10 {
+		return nil, fmt.Errorf("score must be between 0 and 10")
+	}
+
+	if member != nil {
+		count, err := s.repo.CountTodayByMember(member.Id)
+		if err != nil {
+			return nil, err
+		}
+		if count >= 1 {
+			return nil, fmt.Errorf("можно отправить не более одного отзыва в сутки")
+		}
+	}
+
+	feedback := &models.Feedback{
+		Score: req.Score,
+	}
+
+	if req.Comment != nil {
+		trimmed := strings.TrimSpace(*req.Comment)
+		if len(trimmed) > maxFeedbackCommentLen {
+			return nil, fmt.Errorf("комментарий слишком длинный (макс. %d символов)", maxFeedbackCommentLen)
+		}
+		if trimmed != "" {
+			feedback.Comment = &trimmed
+		}
+	}
+
+	if member != nil {
+		feedback.UserId = &member.Id
+	}
+
+	if err := s.repo.Create(feedback); err != nil {
+		return nil, err
+	}
+
+	return feedback, nil
+}
+
+func (s *FeedbackService) List(limit, offset int) ([]models.FeedbackPublic, int64, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return s.repo.List(limit, offset)
+}

--- a/backend/internal/service/points.go
+++ b/backend/internal/service/points.go
@@ -2,10 +2,13 @@ package service
 
 import (
 	"fmt"
+	"ithozyeva/database"
 	"ithozyeva/internal/models"
 	"ithozyeva/internal/repository"
 	"log"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type PointsService struct {
@@ -65,18 +68,37 @@ func (s *PointsService) GiveCustomPoints(memberId int64, amount int, reason mode
 	}
 }
 
+// awardIdempotentTx — внутренний помощник для атомарного начисления внутри транзакции.
+func (s *PointsService) awardIdempotentTx(db *gorm.DB, memberId int64, reason models.PointReason, sourceType string, sourceId int64, description string) error {
+	tx := &models.PointTransaction{
+		MemberId:    memberId,
+		Amount:      models.PointValues[reason],
+		Reason:      reason,
+		SourceType:  sourceType,
+		SourceId:    sourceId,
+		Description: description,
+	}
+	return s.repo.AwardPointsTx(db, tx)
+}
+
 func (s *PointsService) AwardEventPoints(event *models.Event) error {
-	for _, host := range event.Hosts {
-		s.AwardIdempotent(host.Id, models.PointReasonEventHost, "event", event.Id,
-			fmt.Sprintf("Проведение события: %s", event.Title))
-	}
+	return database.DB.Transaction(func(tx *gorm.DB) error {
+		for _, host := range event.Hosts {
+			if err := s.awardIdempotentTx(tx, host.Id, models.PointReasonEventHost, "event", event.Id,
+				fmt.Sprintf("Проведение события: %s", event.Title)); err != nil {
+				return err
+			}
+		}
 
-	for _, member := range event.Members {
-		s.AwardIdempotent(member.Id, models.PointReasonEventAttend, "event", event.Id,
-			fmt.Sprintf("Участие в событии: %s", event.Title))
-	}
+		for _, member := range event.Members {
+			if err := s.awardIdempotentTx(tx, member.Id, models.PointReasonEventAttend, "event", event.Id,
+				fmt.Sprintf("Участие в событии: %s", event.Title)); err != nil {
+				return err
+			}
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // CheckProfileComplete проверяет заполненность профиля и начисляет одноразовый бонус.
@@ -188,6 +210,8 @@ func (s *PointsService) AwardWeeklyChatter() {
 }
 
 // AwardActivityBonuses начисляет бонусы за активность: еженедельная активность, 3+ события в месяц, серия 4 недели.
+// Каждый бонус-блок выполняется в собственной транзакции, чтобы сбой одного типа
+// не откатывал успешные начисления другого.
 func (s *PointsService) AwardActivityBonuses() {
 	now := time.Now()
 	year, week := now.ISOWeek()
@@ -196,14 +220,21 @@ func (s *PointsService) AwardActivityBonuses() {
 	prevWeekTime := now.AddDate(0, 0, -7)
 	prevYear, prevWeek := prevWeekTime.ISOWeek()
 
-	weeklyMembers, err := s.repo.GetMembersWithEventsInWeek(prevYear, prevWeek)
-	if err != nil {
+	if weeklyMembers, err := s.repo.GetMembersWithEventsInWeek(prevYear, prevWeek); err != nil {
 		log.Printf("Error getting weekly active members: %v", err)
 	} else {
 		sourceId := int64(prevYear*100 + prevWeek)
-		for _, memberId := range weeklyMembers {
-			s.AwardIdempotent(memberId, models.PointReasonWeeklyActivity, "weekly", sourceId,
-				fmt.Sprintf("Активность на неделе %d/%d", prevWeek, prevYear))
+		err := database.DB.Transaction(func(tx *gorm.DB) error {
+			for _, memberId := range weeklyMembers {
+				if err := s.awardIdempotentTx(tx, memberId, models.PointReasonWeeklyActivity, "weekly", sourceId,
+					fmt.Sprintf("Активность на неделе %d/%d", prevWeek, prevYear)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			log.Printf("AwardActivityBonuses weekly tx error: %v", err)
 		}
 	}
 
@@ -212,26 +243,40 @@ func (s *PointsService) AwardActivityBonuses() {
 	monthYear := prevMonthTime.Year()
 	prevMonth := int(prevMonthTime.Month())
 
-	monthlyMembers, err := s.repo.GetMembersWithMonthlyEvents(monthYear, prevMonth, 3)
-	if err != nil {
+	if monthlyMembers, err := s.repo.GetMembersWithMonthlyEvents(monthYear, prevMonth, 3); err != nil {
 		log.Printf("Error getting monthly active members: %v", err)
 	} else {
 		sourceId := int64(monthYear*100 + prevMonth)
-		for _, memberId := range monthlyMembers {
-			s.AwardIdempotent(memberId, models.PointReasonMonthlyActive, "monthly", sourceId,
-				fmt.Sprintf("3+ событий за %d/%d", prevMonth, monthYear))
+		err := database.DB.Transaction(func(tx *gorm.DB) error {
+			for _, memberId := range monthlyMembers {
+				if err := s.awardIdempotentTx(tx, memberId, models.PointReasonMonthlyActive, "monthly", sourceId,
+					fmt.Sprintf("3+ событий за %d/%d", prevMonth, monthYear)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			log.Printf("AwardActivityBonuses monthly tx error: %v", err)
 		}
 	}
 
 	// Серия 4 недели подряд
-	streakMembers, err := s.repo.GetMembersWithStreak(4)
-	if err != nil {
+	if streakMembers, err := s.repo.GetMembersWithStreak(4); err != nil {
 		log.Printf("Error getting streak members: %v", err)
 	} else {
 		sourceId := int64(year*100 + week)
-		for _, memberId := range streakMembers {
-			s.AwardIdempotent(memberId, models.PointReasonStreak4Weeks, "streak", sourceId,
-				"Серия: 4 недели подряд с событиями")
+		err := database.DB.Transaction(func(tx *gorm.DB) error {
+			for _, memberId := range streakMembers {
+				if err := s.awardIdempotentTx(tx, memberId, models.PointReasonStreak4Weeks, "streak", sourceId,
+					"Серия: 4 недели подряд с событиями"); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			log.Printf("AwardActivityBonuses streak tx error: %v", err)
 		}
 	}
 }

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -232,6 +232,11 @@ func SetupAdminRoutes(app *fiber.App, db *gorm.DB, redisClient *redis.Client) {
 		subs.Delete("/users/:id/override", authMiddleware.RequirePermission(models.PermissionCanEditAdminSubscriptions), subscriptionHandler.ClearOverride)
 		subs.Delete("/users/:id/access/:chatId", authMiddleware.RequirePermission(models.PermissionCanEditAdminSubscriptions), subscriptionHandler.RevokeAccess)
 	}
+
+	// Маршруты для обратной связи (NPS)
+	feedbackHandler := handler.NewFeedbackHandler()
+	feedback := protected.Group("/feedback", authMiddleware.RequirePermission(models.PermissionCanViewAdminFeedback))
+	feedback.Get("/", feedbackHandler.AdminList)
 }
 
 func SetupPlatformRoutes(app *fiber.App, db *gorm.DB) {
@@ -396,4 +401,8 @@ func SetupPlatformRoutes(app *fiber.App, db *gorm.DB) {
 	// SSE (Server-Sent Events) для real-time обновлений
 	sseHandler := handler.NewSSEHandler()
 	protected.Get("/sse", sseHandler.Stream)
+
+	// Маршруты для обратной связи (NPS)
+	feedbackHandler := handler.NewFeedbackHandler()
+	protected.Post("/feedback", feedbackHandler.Create)
 }

--- a/platform-frontend/src/App.vue
+++ b/platform-frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onBeforeMount, ref } from 'vue'
 import OnboardingOverlay from '@/components/common/OnboardingOverlay.vue'
+import NpsWidget from '@/components/NpsWidget.vue'
 import { Toaster } from '@/components/ui/toast'
 import { useOnboarding } from '@/composables/useOnboarding'
 import { startSSE, stopSSE } from '@/composables/useSSE'
@@ -83,6 +84,7 @@ onBeforeMount(() => {
         </Transition>
       </router-view>
     </Layout>
+    <NpsWidget v-if="tg_user" />
   </div>
 </template>
 

--- a/platform-frontend/src/__tests__/composables/useUser.test.ts
+++ b/platform-frontend/src/__tests__/composables/useUser.test.ts
@@ -8,6 +8,12 @@ async function freshImport() {
   return mod
 }
 
+// useUser хранит данные обёрнутыми в {data, savedAt} под версионированным
+// ключом — пишем через хелпер, чтобы тесты не дублировали логику сериализации.
+function setStoredUser(user: TelegramUser | null) {
+  localStorage.setItem('tg_user:v2', JSON.stringify({ data: user, savedAt: Date.now() }))
+}
+
 describe('useUser', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -36,7 +42,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['SUBSCRIBER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(mockUser))
+      setStoredUser(mockUser)
 
       const { useUser } = await freshImport()
       const { result } = withSetup(() => useUser())
@@ -71,7 +77,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['SUBSCRIBER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { isUserSubscribed } = await freshImport()
       const { result } = withSetup(() => isUserSubscribed())
@@ -92,7 +98,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['UNSUBSCRIBER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { isUserSubscribed } = await freshImport()
       const { result } = withSetup(() => isUserSubscribed())
@@ -115,7 +121,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['MENTOR'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { isUserMentor } = await freshImport()
       const { result } = withSetup(() => isUserMentor())
@@ -136,7 +142,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['SUBSCRIBER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { isUserMentor } = await freshImport()
       const { result } = withSetup(() => isUserMentor())
@@ -159,7 +165,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['ADMIN'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { isUserAdmin } = await freshImport()
       const { result } = withSetup(() => isUserAdmin())
@@ -180,7 +186,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['SUBSCRIBER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { isUserAdmin } = await freshImport()
       const { result } = withSetup(() => isUserAdmin())
@@ -209,7 +215,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['ADMIN'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { canViewAdminPanel } = await freshImport()
       const { result } = withSetup(() => canViewAdminPanel())
@@ -230,7 +236,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['EVENT_MAKER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { canViewAdminPanel } = await freshImport()
       const { result } = withSetup(() => canViewAdminPanel())
@@ -251,7 +257,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['SUBSCRIBER'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { canViewAdminPanel } = await freshImport()
       const { result } = withSetup(() => canViewAdminPanel())
@@ -288,7 +294,7 @@ describe('useUser', () => {
         roles: ['SUBSCRIBER'],
         subscriptionTier: { id: 1, slug: 'beginner', name: 'Beginner', level: 1 },
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
@@ -311,7 +317,7 @@ describe('useUser', () => {
         roles: ['SUBSCRIBER'],
         subscriptionTier: { id: 2, slug: 'foreman', name: 'Foreman', level: 2 },
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
@@ -334,7 +340,7 @@ describe('useUser', () => {
         roles: ['SUBSCRIBER'],
         subscriptionTier: { id: 3, slug: 'master', name: 'Master', level: 3 },
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
@@ -357,7 +363,7 @@ describe('useUser', () => {
         roles: ['SUBSCRIBER'],
         subscriptionTier: { id: 4, slug: 'king', name: 'King', level: 4 },
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
@@ -379,7 +385,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['MENTOR'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())
@@ -401,7 +407,7 @@ describe('useUser', () => {
         avatarUrl: '',
         roles: ['ADMIN'],
       }
-      localStorage.setItem('tg_user', JSON.stringify(user))
+      setStoredUser(user)
 
       const { useUserLevel } = await freshImport()
       const { result } = withSetup(() => useUserLevel())

--- a/platform-frontend/src/components/NpsWidget.vue
+++ b/platform-frontend/src/components/NpsWidget.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+import { useLocalStorage } from '@vueuse/core'
+import { Smile, X } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+import { useToast } from '@/components/ui/toast'
+import { Typography } from '@/components/ui/typography'
+import { feedbackService } from '@/services/feedbackService'
+
+const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000 // 30 дней
+
+const dismissedAt = useLocalStorage<number | null>('nps_dismissed_at', null)
+const isOpen = ref(false)
+const score = ref<number | null>(null)
+const comment = ref('')
+const isSubmitting = ref(false)
+
+const { toast } = useToast()
+
+const isHidden = computed(() => {
+  if (!dismissedAt.value)
+    return false
+  return Date.now() - dismissedAt.value < COOLDOWN_MS
+})
+
+function open() {
+  if (isHidden.value)
+    return
+  isOpen.value = true
+  score.value = null
+  comment.value = ''
+}
+
+// dismiss — пользователь явно отказался (кнопка «Отменить») → 30 дней не дёргаем.
+function dismiss() {
+  isOpen.value = false
+  dismissedAt.value = Date.now()
+}
+
+// closeSoft — закрытие по крестику или фону, без long-cooldown'а;
+// чтобы случайный клик не выключал виджет на месяц.
+function closeSoft() {
+  isOpen.value = false
+}
+
+function handleBackdropClick(event: MouseEvent) {
+  if (event.target === event.currentTarget) {
+    closeSoft()
+  }
+}
+
+async function submit() {
+  if (score.value === null || isSubmitting.value)
+    return
+  isSubmitting.value = true
+  try {
+    await feedbackService.submit(score.value, comment.value)
+    toast({ title: 'Спасибо за отзыв' })
+    dismissedAt.value = Date.now()
+    isOpen.value = false
+  }
+  catch {
+    // handleError в сервисе уже показал ошибку
+  }
+  finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <button
+    v-if="!isHidden"
+    type="button"
+    aria-label="Оставить отзыв"
+    class="fixed bottom-6 right-6 z-40 size-12 rounded-full bg-accent text-accent-foreground shadow-lg flex items-center justify-center hover:scale-105 transition-transform cursor-pointer"
+    @click="open"
+  >
+    <Smile class="size-6" />
+  </button>
+
+  <Transition name="nps-fade">
+    <div
+      v-if="isOpen"
+      class="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center backdrop-blur-sm p-4"
+      @click="handleBackdropClick"
+    >
+      <Transition name="nps-scale">
+        <div v-if="isOpen" class="bg-card text-card-foreground rounded-sm p-6 w-full max-w-md relative shadow-xl">
+          <button
+            type="button"
+            class="absolute right-4 top-4 text-muted-foreground hover:text-foreground cursor-pointer"
+            aria-label="Закрыть"
+            @click="closeSoft"
+          >
+            <X class="size-6" />
+          </button>
+
+          <Typography variant="h3" as="h2" class="mb-1">
+            Оцените платформу
+          </Typography>
+          <p class="text-sm text-muted-foreground mb-4">
+            Насколько вероятно, что вы порекомендуете нас другу?
+          </p>
+
+          <div class="grid grid-cols-6 sm:grid-cols-11 gap-1 mb-2">
+            <button
+              v-for="n in 11"
+              :key="n - 1"
+              type="button"
+              :aria-label="`Оценка ${n - 1}`"
+              class="min-h-9 px-1 text-sm rounded-sm border border-input transition-colors cursor-pointer"
+              :class="score === n - 1
+                ? 'bg-accent text-accent-foreground border-accent'
+                : 'hover:bg-secondary'"
+              @click="score = n - 1"
+            >
+              {{ n - 1 }}
+            </button>
+          </div>
+          <div class="flex justify-between text-xs text-muted-foreground mb-4">
+            <span>Точно нет</span>
+            <span>Точно да</span>
+          </div>
+
+          <div class="mb-4">
+            <label for="nps-comment" class="block text-sm font-medium text-muted-foreground mb-2">
+              Комментарий (необязательно)
+            </label>
+            <textarea
+              id="nps-comment"
+              v-model="comment"
+              rows="3"
+              class="w-full px-3 py-2 border border-input rounded-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-ring"
+              placeholder="Что можно улучшить?"
+            />
+          </div>
+
+          <div class="flex justify-end gap-3">
+            <button
+              type="button"
+              class="px-4 py-2 border border-input rounded-full hover:bg-secondary transition duration-300 cursor-pointer"
+              @click="dismiss"
+            >
+              Отменить
+            </button>
+            <button
+              type="button"
+              class="px-4 py-2 bg-accent text-accent-foreground rounded-full hover:bg-accent/90 transition duration-300 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              :disabled="score === null || isSubmitting"
+              @click="submit"
+            >
+              Отправить
+            </button>
+          </div>
+        </div>
+      </Transition>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.nps-fade-enter-active,
+.nps-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.nps-fade-enter-from,
+.nps-fade-leave-to {
+  opacity: 0;
+}
+
+.nps-scale-enter-active {
+  transition: all 0.3s ease-out;
+}
+
+.nps-scale-leave-active {
+  transition: all 0.2s ease-in;
+}
+
+.nps-scale-enter-from,
+.nps-scale-leave-to {
+  transform: scale(0.95);
+  opacity: 0;
+}
+</style>

--- a/platform-frontend/src/composables/useUser.ts
+++ b/platform-frontend/src/composables/useUser.ts
@@ -4,12 +4,35 @@ import { useLocalStorage } from '@vueuse/core'
 import { computed } from 'vue'
 import { getSubscriptionLevel, getSubscriptionLevelIndex, SUBSCRIPTION_LEVELS } from '@/models/profile'
 
+// Версионируем ключ, чтобы при добавлении новых полей в TelegramUser/Mentor
+// (например subscriptionTier) старый кэш не блокировал свежие данные.
+const TG_USER_KEY = 'tg_user:v2'
+// TTL делаем равным интервалу рефреша токена с запасом — после часа простоя
+// клиент в любом случае дёргает /me и обновит кэш.
+const TG_USER_TTL_MS = 60 * 60 * 1000
+
 let userRef: RemovableRef<null | TelegramUser> | null = null
 
 export function useUser<TUser extends TelegramUser | Mentor = TelegramUser>(): RemovableRef<null | TUser> {
   if (!userRef) {
-    userRef = useLocalStorage<TUser>('tg_user', null, {
-      serializer: { read: JSON.parse, write: JSON.stringify },
+    userRef = useLocalStorage<TUser>(TG_USER_KEY, null, {
+      serializer: {
+        read: (raw: string) => {
+          try {
+            const parsed = JSON.parse(raw)
+            if (!parsed || typeof parsed !== 'object')
+              return null
+            const { data, savedAt } = parsed as { data: unknown, savedAt: number }
+            if (typeof savedAt !== 'number' || Date.now() - savedAt > TG_USER_TTL_MS)
+              return null
+            return data as TUser
+          }
+          catch {
+            return null
+          }
+        },
+        write: value => JSON.stringify({ data: value, savedAt: Date.now() }),
+      },
     })
   }
   return userRef as RemovableRef<null | TUser>

--- a/platform-frontend/src/services/feedbackService.ts
+++ b/platform-frontend/src/services/feedbackService.ts
@@ -1,0 +1,19 @@
+import { apiClient } from './api'
+import { handleError } from './errorService'
+
+export const feedbackService = {
+  async submit(score: number, comment?: string) {
+    try {
+      await apiClient.post('feedback', {
+        json: {
+          score,
+          comment: comment?.trim() || undefined,
+        },
+      })
+    }
+    catch (error) {
+      handleError(error)
+      throw error
+    }
+  },
+}


### PR DESCRIPTION
## Summary

Объединённый PR с фичей и тремя независимыми рефакторингами (по явному решению заказчика — обычно делятся, см. комментарий в плане). Прошло senior-review до пуша; найденные BLOCK/WARN исправлены.

### F6 — NPS / feedback widget
- Платформа: плавающая кнопка-смайл → модалка с шкалой 0–10 + опц. комментарий → 30-дневный cooldown после явного отказа/отправки.
- Бэкенд: миграция `feedbacks`, `POST /api/platform/feedback` (1 отзыв в сутки, comment ≤ 2000 chars), `GET /api/admin/feedback` под новым `can_view_admin_feedback` (выдан роли ADMIN).
- Админка: `FeedbackView` со списком (дата/пользователь/оценка с цветовой индикацией/коммент), пункт сайдбара в группе reviews.

### T1 — `getMember` helper
Все 49 unsafe `c.Locals("member").(*models.Member)` без `, ok` в 16 файлах handler заменены на helper, возвращающий 401 вместо паники → HTTP 500.

### T3 — TTL + version для `useUser`
Старый `useLocalStorage('tg_user')` не инвалидировался — недавно поймали с `subscriptionTier`. Теперь хранится `{data, savedAt}` под ключом `tg_user:v2` с TTL 1 ч.

### T4 — транзакции в points-пайплайне
`AwardEventPoints` и `AwardActivityBonuses` (3 раздельные транзакции под weekly/monthly/streak) обёрнуты в `database.DB.Transaction`. Repo получил `AwardPointsTx(db, tx)`. Сбой посреди цикла теперь откатывает частичные начисления.

### Что не делаем
- T2 (индексы chat_messages) — разведка показала, что предпосылка устарела: композитный `(chat_id, sent_at)` и `sent_at` уже существуют с миграции `20260303100000_create_chat_activity.sql`, cleanup-cron корректно работает в `APP_MODE=api`. Возвращаемся, если slow query log реально покажет проблему.

## Test plan

- [x] `go build ./...` чисто
- [x] `go vet ./...` чисто
- [x] grep-постусловие T1: `c.Locals("member").(*Member)` без `, ok` в `internal/handler/` → пусто
- [x] platform-frontend: `npm run lint && npm run type-check && npm run build` чисто
- [x] admin-frontend: `npm run lint && npm run type-check && npm run build` чисто
- [ ] После деплоя: открыть платформу → клик по смайлу → отправить отзыв → toast → запись видна в админке `/feedback`
- [ ] Smoke 401: запрос без токена в `POST /api/platform/feedback` отдаёт 401, не 500
- [ ] Smoke rate-limit: повторный фидбек в течение суток отдаёт 400 с понятным текстом
- [ ] T3: после деплоя ключ `tg_user` в DevTools заменяется на `tg_user:v2`, через час в idle — данные обновляются после `getMe`
- [ ] T4: вручную проверить, что AwardEventPoints не оставляет частичные начисления при искусственной ошибке

## Деплой

- `backend/**` правки → запустит `deploy-bot` на NL. Memory `feedback_serial_backend_deploys`: не мержить параллельно с другими backend PR.
- Миграция применится автоматически на старте; нового конфига не требуется.