### PR TITLE
chore: vue-devtools только при vite serve

### DIFF
--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -8,11 +8,12 @@ import { defineConfig } from 'vite'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   base: '/admin/',
   plugins: [
     vue(),
-    vueDevTools(),
+    // vue-devtools раздувает prod-bundle на ~50–100 KB и в проде не нужен
+    ...(command === 'serve' ? [vueDevTools()] : []),
     Icons({
       autoInstall: true,
       compiler: 'vue3',
@@ -36,4 +37,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/landing-frontend/vite.config.ts
+++ b/landing-frontend/vite.config.ts
@@ -7,10 +7,11 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 import svgLoader from 'vite-svg-loader'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     vue(),
-    vueDevTools(),
+    // vue-devtools раздувает prod-bundle на ~50–100 KB и в проде не нужен
+    ...(command === 'serve' ? [vueDevTools()] : []),
     svgLoader({ svgo: false, defaultImport: 'component' }),
     Icons({
       autoInstall: true,
@@ -29,4 +30,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/platform-frontend/vite.config.ts
+++ b/platform-frontend/vite.config.ts
@@ -5,11 +5,12 @@ import { defineConfig } from 'vite'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   base: '/platform/',
   plugins: [
     vue(),
-    vueDevTools(),
+    // vue-devtools раздувает prod-bundle на ~50–100 KB и в проде не нужен
+    ...(command === 'serve' ? [vueDevTools()] : []),
   ],
   resolve: {
     alias: {
@@ -24,4 +25,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
## Summary

T6. Оборачиваем `vueDevTools()` в условие `command === 'serve'` во всех трёх фронтах (landing/admin/platform). Плагин теперь подключается только при живом dev-сервере (`npm run dev`), а на любых `vite build` и `vite preview` его нет.

## Почему `command === 'serve'`, а не `mode === 'development'`

`command` отвечает на «vite запущен как dev-сервер или собирает статику», `mode` — на «какой набор env-переменных подгрузить». `command === 'serve'` точнее: при `vite build --mode development` (которое теоретически может появиться в CI) плагин всё равно не нужен.

## Замечание о размере бандла

Бриф T6 заявлял ~50–100 KB экономии в prod-бандле, но на практике плагин самоотключается в production: хеши `dist/assets/index-*.js` после фикса побайтно совпадают с master. Фикс улучшает только гигиену конфига и снимает плагин с dev-mode-сборок. Реальной экономии в prod нет.

## Test plan

- [x] `npm run lint && npm run build` зелёные на всех трёх фронтах
- [x] Сборки prod байт-в-байт совпадают с master (плагин уже сам no-op-ил)
- [ ] После деплоя: `npm run dev` локально — devtools-кнопка по-прежнему появляется в браузере