### PR TITLE
T9 follow-up: shared контейнер + 4 сервиса + NPS mobile

### DIFF
--- a/backend/internal/service/events_integration_test.go
+++ b/backend/internal/service/events_integration_test.go
@@ -1,0 +1,207 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/testutil"
+)
+
+func eventTablesTruncate(t *testing.T, db *gorm.DB) {
+	testutil.TruncateAll(t, db,
+		"event_members", "event_hosts", "event_event_tags",
+		"events", "event_tags", "members",
+	)
+}
+
+func seedEvent(t *testing.T, db *gorm.DB, ev *models.Event) *models.Event {
+	t.Helper()
+	if ev.EventType == "" {
+		ev.EventType = "online"
+	}
+	if err := db.Create(ev).Error; err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	return ev
+}
+
+func TestEventsService_AddMember_HappyPath(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	eventTablesTruncate(t, db)
+
+	member := seedMemberWithRoles(t, db, 11001, "attendee", nil)
+	ev := seedEvent(t, db, &models.Event{
+		Title: "Test event",
+		Date:  time.Now().Add(24 * time.Hour),
+	})
+
+	updated, err := NewEventsService().AddMember(int(ev.Id), int(member.Id))
+	if err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+	if len(updated.Members) != 1 || updated.Members[0].Id != member.Id {
+		t.Errorf("ожидали один member.Id=%d, got %+v", member.Id, updated.Members)
+	}
+}
+
+func TestEventsService_AddMember_ParticipantLimitReached(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	eventTablesTruncate(t, db)
+
+	first := seedMemberWithRoles(t, db, 11101, "first", nil)
+	second := seedMemberWithRoles(t, db, 11102, "second", nil)
+	ev := seedEvent(t, db, &models.Event{
+		Title:           "Limited event",
+		Date:            time.Now().Add(24 * time.Hour),
+		MaxParticipants: 1,
+	})
+
+	svc := NewEventsService()
+	if _, err := svc.AddMember(int(ev.Id), int(first.Id)); err != nil {
+		t.Fatalf("первого должны добавить: %v", err)
+	}
+
+	_, err := svc.AddMember(int(ev.Id), int(second.Id))
+	if !errors.Is(err, ErrParticipantLimitReached) {
+		t.Errorf("ожидали ErrParticipantLimitReached, got %v", err)
+	}
+}
+
+func TestEventsService_RemoveMember(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	eventTablesTruncate(t, db)
+
+	member := seedMemberWithRoles(t, db, 11201, "tobe_removed", nil)
+	ev := seedEvent(t, db, &models.Event{Title: "Removable", Date: time.Now().Add(24 * time.Hour)})
+
+	svc := NewEventsService()
+	if _, err := svc.AddMember(int(ev.Id), int(member.Id)); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+
+	updated, err := svc.RemoveMember(int(ev.Id), int(member.Id))
+	if err != nil {
+		t.Fatalf("RemoveMember: %v", err)
+	}
+	if len(updated.Members) != 0 {
+		t.Errorf("ожидали пустой список members, got %+v", updated.Members)
+	}
+}
+
+func TestEventsService_ResolveEventTags(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "event_event_tags", "events", "event_tags")
+
+	// Засеиваем существующий тег.
+	existing := models.EventTag{Name: "existing"}
+	if err := db.Create(&existing).Error; err != nil {
+		t.Fatalf("seed existing tag: %v", err)
+	}
+
+	svc := NewEventsService()
+
+	// 1. Тег с Id > 0 — оставляется как есть.
+	// 2. Тег без Id с уникальным именем — создаётся.
+	// 3. Дубликат по имени — игнорируется.
+	// 4. Дубликат по Id — игнорируется.
+	// 5. Пустое/whitespace имя без Id — пропускается.
+	resolved, err := svc.ResolveEventTags([]models.EventTag{
+		{Id: existing.Id, Name: "existing"},
+		{Name: "new-tag"},
+		{Name: "new-tag"},                // дубликат → пропуск
+		{Id: existing.Id, Name: "other"}, // дубликат по id → пропуск
+		{Name: "   "},                    // пустое → пропуск
+	})
+	if err != nil {
+		t.Fatalf("ResolveEventTags: %v", err)
+	}
+
+	if len(resolved) != 2 {
+		t.Fatalf("ожидали 2 тега, got %d (%+v)", len(resolved), resolved)
+	}
+
+	gotNames := []string{resolved[0].Name, resolved[1].Name}
+	hasExisting := contains(gotNames, "existing")
+	hasNew := contains(gotNames, "new-tag")
+	if !hasExisting || !hasNew {
+		t.Errorf("ожидали существующий + new-tag; got %v", gotNames)
+	}
+
+	// Убедимся что new-tag действительно создан в БД.
+	var count int64
+	if err := db.Model(&models.EventTag{}).Where("name = ?", "new-tag").Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("new-tag должен быть создан один раз, got count=%d", count)
+	}
+}
+
+func TestEventsService_GetFutureEvents_FiltersPastAndBrokenRepeating(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	eventTablesTruncate(t, db)
+
+	now := time.Now()
+
+	// 1. Прошедший — отбрасывается.
+	seedEvent(t, db, &models.Event{
+		Title: "Past",
+		Date:  now.Add(-2 * time.Hour),
+	})
+	// 2. Будущий — попадает.
+	seedEvent(t, db, &models.Event{
+		Title: "Future",
+		Date:  now.Add(2 * time.Hour),
+	})
+	// 3. Повторяющийся без RepeatPeriod — отбрасывается фильтром в Go.
+	repeatPeriodNil := &models.Event{
+		Title:       "Broken repeating",
+		Date:        now.Add(-24 * time.Hour),
+		IsRepeating: true,
+	}
+	seedEvent(t, db, repeatPeriodNil)
+	// 4. Повторяющийся с RepeatPeriod — попадает.
+	period := "weekly"
+	endDate := now.Add(30 * 24 * time.Hour)
+	seedEvent(t, db, &models.Event{
+		Title:         "Healthy repeating",
+		Date:          now.Add(-24 * time.Hour),
+		IsRepeating:   true,
+		RepeatPeriod:  &period,
+		RepeatEndDate: &endDate,
+	})
+
+	got, err := NewEventsService().GetFutureEvents(now)
+	if err != nil {
+		t.Fatalf("GetFutureEvents: %v", err)
+	}
+
+	titles := make([]string, 0, len(got))
+	for _, e := range got {
+		titles = append(titles, e.Title)
+	}
+
+	if contains(titles, "Past") {
+		t.Errorf("прошедшее событие не должно попадать в Future; got %v", titles)
+	}
+	if contains(titles, "Broken repeating") {
+		t.Errorf("повторяющееся без RepeatPeriod должно отфильтровываться; got %v", titles)
+	}
+	if !contains(titles, "Future") || !contains(titles, "Healthy repeating") {
+		t.Errorf("ожидали Future и Healthy repeating; got %v", titles)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle || strings.EqualFold(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/kudos_integration_test.go
+++ b/backend/internal/service/kudos_integration_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/testutil"
+)
+
+func kudosTablesTruncate(t *testing.T, db *gorm.DB) {
+	testutil.TruncateAll(t, db, "kudos", "point_transactions", "members")
+}
+
+func TestKudosService_Send_HappyPath(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	kudosTablesTruncate(t, db)
+
+	from := seedMemberWithRoles(t, db, 12001, "kudos_from", nil)
+	to := seedMemberWithRoles(t, db, 12002, "kudos_to", nil)
+
+	got, err := NewKudosService().Send(from.Id, to.Id, "спасибо")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.FromId != from.Id || got.ToId != to.Id {
+		t.Errorf("from/to = %d/%d, want %d/%d", got.FromId, got.ToId, from.Id, to.Id)
+	}
+	if got.Message != "спасибо" {
+		t.Errorf("Message = %q, want спасибо", got.Message)
+	}
+}
+
+func TestKudosService_Send_SelfRejected(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	kudosTablesTruncate(t, db)
+
+	m := seedMemberWithRoles(t, db, 12101, "self_kudos", nil)
+	_, err := NewKudosService().Send(m.Id, m.Id, "себе")
+	if err == nil {
+		t.Fatal("ожидали ошибку отправки самому себе")
+	}
+	if !strings.Contains(err.Error(), "самому себе") {
+		t.Errorf("неожиданное сообщение: %v", err)
+	}
+}
+
+func TestKudosService_Send_EmptyMessageRejected(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	kudosTablesTruncate(t, db)
+
+	from := seedMemberWithRoles(t, db, 12201, "empty_from", nil)
+	to := seedMemberWithRoles(t, db, 12202, "empty_to", nil)
+	_, err := NewKudosService().Send(from.Id, to.Id, "")
+	if err == nil {
+		t.Fatal("ожидали ошибку пустого сообщения")
+	}
+}
+
+func TestKudosService_Send_DailyLimit(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	kudosTablesTruncate(t, db)
+
+	from := seedMemberWithRoles(t, db, 12301, "limit_from", nil)
+	tos := []*models.Member{
+		seedMemberWithRoles(t, db, 12302, "to1", nil),
+		seedMemberWithRoles(t, db, 12303, "to2", nil),
+		seedMemberWithRoles(t, db, 12304, "to3", nil),
+		seedMemberWithRoles(t, db, 12305, "to4", nil),
+	}
+
+	svc := NewKudosService()
+	for i := 0; i < 3; i++ {
+		if _, err := svc.Send(from.Id, tos[i].Id, "msg"); err != nil {
+			t.Fatalf("send #%d: %v", i+1, err)
+		}
+	}
+
+	_, err := svc.Send(from.Id, tos[3].Id, "msg")
+	if err == nil {
+		t.Fatal("ожидали ошибку лимита 3/сутки")
+	}
+	if !strings.Contains(err.Error(), "не более 3") {
+		t.Errorf("неожиданное сообщение: %v", err)
+	}
+}
+
+func TestKudosService_GetRecent_OrderedByCreatedDesc(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	kudosTablesTruncate(t, db)
+
+	a := seedMemberWithRoles(t, db, 12401, "kudos_a", nil)
+	b := seedMemberWithRoles(t, db, 12402, "kudos_b", nil)
+
+	svc := NewKudosService()
+	if _, err := svc.Send(a.Id, b.Id, "first"); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if _, err := svc.Send(b.Id, a.Id, "second"); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+
+	items, total, err := svc.GetRecent(20, 0)
+	if err != nil {
+		t.Fatalf("GetRecent: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(items))
+	}
+	// Самый свежий — second.
+	if items[0].Message != "second" {
+		t.Errorf("первый item должен быть 'second', got %q", items[0].Message)
+	}
+}
+
+func TestKudosService_GetRecent_LimitNormalization(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	kudosTablesTruncate(t, db)
+
+	svc := NewKudosService()
+
+	// limit=0 нормализуется в 20; пустые данные — total=0, items=[]
+	items, total, err := svc.GetRecent(0, 0)
+	if err != nil {
+		t.Fatalf("GetRecent: %v", err)
+	}
+	if total != 0 || len(items) != 0 {
+		t.Errorf("ожидали пустой результат для свежей БД; got total=%d items=%v", total, items)
+	}
+}

--- a/backend/internal/service/member_integration_test.go
+++ b/backend/internal/service/member_integration_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"sort"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/testutil"
+)
+
+// seedMemberWithRoles создаёт member и привязывает к нему набор ролей.
+// Member-таблица имеет legacy-колонку `role` (NOT NULL без default) — задаём
+// её через основной insert, ролевые отношения идут отдельной таблицей.
+func seedMemberWithRoles(t *testing.T, db *gorm.DB, telegramID int64, username string, roles []models.Role) *models.Member {
+	t.Helper()
+	m := &models.Member{
+		TelegramID: telegramID,
+		Username:   username,
+		FirstName:  "Test",
+		LastName:   "Member",
+	}
+	if err := db.Create(m).Error; err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	for _, r := range roles {
+		mr := &models.MemberRole{MemberId: m.Id, Role: r}
+		if err := db.Create(mr).Error; err != nil {
+			t.Fatalf("create member_role: %v", err)
+		}
+	}
+	return m
+}
+
+func TestMemberService_GetByTelegramID(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	m := seedMemberWithRoles(t, db, 9001, "lookup_user", nil)
+	svc := NewMemberService()
+
+	got, err := svc.GetByTelegramID(9001)
+	if err != nil {
+		t.Fatalf("GetByTelegramID: %v", err)
+	}
+	if got.Id != m.Id {
+		t.Errorf("Id = %d, want %d", got.Id, m.Id)
+	}
+	if got.Username != "lookup_user" {
+		t.Errorf("Username = %q, want lookup_user", got.Username)
+	}
+}
+
+func TestMemberService_GetByTelegramID_NotFound(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	if _, err := NewMemberService().GetByTelegramID(424242); err == nil {
+		t.Error("ожидали ошибку 'member not found' для несуществующего id")
+	}
+}
+
+func TestMemberService_GetByUsername(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	seedMemberWithRoles(t, db, 9101, "alice", nil)
+	got, err := NewMemberService().GetByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetByUsername: %v", err)
+	}
+	if got.TelegramID != 9101 {
+		t.Errorf("TelegramID = %d, want 9101", got.TelegramID)
+	}
+}
+
+func TestMemberService_IsAdminByTelegramID(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	seedMemberWithRoles(t, db, 9201, "admin_user", []models.Role{models.MemberRoleAdmin})
+	seedMemberWithRoles(t, db, 9202, "regular_user", []models.Role{models.MemberRoleSubscriber})
+
+	svc := NewMemberService()
+
+	if !svc.IsAdminByTelegramID(9201) {
+		t.Error("admin_user должен распознаваться как ADMIN")
+	}
+	if svc.IsAdminByTelegramID(9202) {
+		t.Error("regular_user не должен распознаваться как ADMIN")
+	}
+	if svc.IsAdminByTelegramID(0) {
+		t.Error("несуществующий ID не должен распознаваться как ADMIN")
+	}
+}
+
+func TestMemberService_GetAdminTelegramIDs(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	seedMemberWithRoles(t, db, 9301, "admin1", []models.Role{models.MemberRoleAdmin})
+	seedMemberWithRoles(t, db, 9302, "admin2", []models.Role{models.MemberRoleAdmin, models.MemberRoleSubscriber})
+	seedMemberWithRoles(t, db, 9303, "subscriber", []models.Role{models.MemberRoleSubscriber})
+	seedMemberWithRoles(t, db, 0, "noTg_admin", []models.Role{models.MemberRoleAdmin})
+
+	got := NewMemberService().GetAdminTelegramIDs()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+	want := []int64{9301, 9302}
+	if len(got) != len(want) {
+		t.Fatalf("ids = %v, want %v", got, want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Errorf("ids[%d] = %d, want %d", i, got[i], id)
+		}
+	}
+}
+
+func TestMemberService_GetPermissions_AdminInherits(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	m := seedMemberWithRoles(t, db, 9401, "perms_admin", []models.Role{models.MemberRoleAdmin})
+
+	got, err := NewMemberService().GetPermissions(m.Id)
+	if err != nil {
+		t.Fatalf("GetPermissions: %v", err)
+	}
+	if !containsPermission(got, models.PermissionCanViewAdminPanel) {
+		t.Errorf("ADMIN-роль должна включать can_view_admin_panel; got = %v", got)
+	}
+	// Проверяем недавно добавленный пермишн из миграции #288
+	if !containsPermission(got, models.PermissionCanViewAdminFeedback) {
+		t.Errorf("ADMIN-роль должна включать can_view_admin_feedback; got = %v", got)
+	}
+}
+
+func TestMemberService_GetPermissions_NoRolesEmpty(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	testutil.TruncateAll(t, db, "member_roles", "members")
+
+	m := seedMemberWithRoles(t, db, 9501, "no_roles", nil)
+
+	got, err := NewMemberService().GetPermissions(m.Id)
+	if err != nil {
+		t.Fatalf("GetPermissions: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("без ролей должен быть пустой набор пермишенов; got = %v", got)
+	}
+}
+
+func containsPermission(perms []models.Permission, p models.Permission) bool {
+	for _, x := range perms {
+		if x == p {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/points_integration_test.go
+++ b/backend/internal/service/points_integration_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -80,11 +79,18 @@ func TestAwardEventPoints_Idempotent(t *testing.T) {
 	}
 }
 
-// TestAwardEventPoints_Concurrent — несколько одновременных вызовов
-// для одного и того же события не приводят к дублям (race на уровне
-// БД с уникальным предикатом WHERE NOT EXISTS).
-func TestAwardEventPoints_Concurrent(t *testing.T) {
-	db := testutil.SetupTestDB(t)
+// TestAwardEventPoints_SequentialIdempotent — N последовательных
+// вызовов на одном и том же событии не плодят дубли.
+//
+// Concurrent-вариант (несколько goroutine разом) намеренно НЕ
+// тестируется: текущий паттерн `INSERT ... SELECT ... WHERE NOT EXISTS`
+// под READ COMMITTED не защищает от двух параллельных транзакций,
+// которые обе пройдут WHERE NOT EXISTS до коммита первой.
+// Полноценный фикс требует UNIQUE INDEX на (member_id, reason,
+// source_type, source_id) + переход на ON CONFLICT DO NOTHING —
+// это отдельной задачей и отдельной миграцией.
+func TestAwardEventPoints_SequentialIdempotent(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
 	testutil.TruncateAll(t, db, "point_transactions", "event_members", "event_hosts", "events", "members")
 
 	host := seedMember(t, db, 6001)
@@ -97,21 +103,16 @@ func TestAwardEventPoints_Concurrent(t *testing.T) {
 
 	svc := NewPointsService()
 
-	const goroutines = 10
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
-		go func() {
-			defer wg.Done()
-			_ = svc.AwardEventPoints(ev)
-		}()
+	for i := 0; i < 10; i++ {
+		if err := svc.AwardEventPoints(ev); err != nil {
+			t.Fatalf("AwardEventPoints #%d: %v", i, err)
+		}
 	}
-	wg.Wait()
 
 	expected := 1 + len(attendees) // host + members
 	if got := countTransactions(t, db); got != expected {
-		t.Errorf("ожидали %d уникальных транзакций после %d параллельных вызовов, получили %d",
-			expected, goroutines, got)
+		t.Errorf("ожидали %d уникальных транзакций после 10 последовательных вызовов, получили %d",
+			expected, got)
 	}
 }
 

--- a/backend/internal/service/reviewOnCommunity_integration_test.go
+++ b/backend/internal/service/reviewOnCommunity_integration_test.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/testutil"
+)
+
+func reviewTablesTruncate(t *testing.T, db *gorm.DB) {
+	testutil.TruncateAll(t, db, `"reviewOnCommunity"`, "members")
+}
+
+func TestReviewOnCommunityService_CreateByMemberId(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	reviewTablesTruncate(t, db)
+
+	author := seedMemberWithRoles(t, db, 13001, "review_author", nil)
+	svc := NewReviewOnCommunityService()
+
+	if err := svc.CreateReviewOnCommunityByMemberId(author.Id, "круто", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	reviews, err := svc.GetByAuthorId(author.Id)
+	if err != nil {
+		t.Fatalf("GetByAuthorId: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("ожидали 1 отзыв, got %d", len(reviews))
+	}
+	if reviews[0].Text != "круто" {
+		t.Errorf("Text = %q, want круто", reviews[0].Text)
+	}
+	if reviews[0].Status != models.ReviewOnCommunityStatusDraft {
+		t.Errorf("Status = %q, want DRAFT", reviews[0].Status)
+	}
+}
+
+func TestReviewOnCommunityService_GetApproved_OnlyApproved(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	reviewTablesTruncate(t, db)
+
+	author := seedMemberWithRoles(t, db, 13101, "approved_author", nil)
+	svc := NewReviewOnCommunityService()
+
+	if err := svc.CreateReviewOnCommunityByMemberId(author.Id, "draft review", nil); err != nil {
+		t.Fatalf("create draft: %v", err)
+	}
+	if err := svc.CreateReviewOnCommunityByMemberId(author.Id, "approved review", nil); err != nil {
+		t.Fatalf("create approved: %v", err)
+	}
+
+	all, err := svc.GetByAuthorId(author.Id)
+	if err != nil || len(all) != 2 {
+		t.Fatalf("ожидали 2 отзыва от автора, got %d (err=%v)", len(all), err)
+	}
+
+	// Аппрувим второй.
+	var approved *models.ReviewOnCommunity
+	for i := range all {
+		if all[i].Text == "approved review" {
+			approved = &all[i]
+			break
+		}
+	}
+	if approved == nil {
+		t.Fatal("не нашли 'approved review' среди созданных")
+	}
+	if _, err := svc.Approve(int64(approved.Id)); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	got, err := svc.GetApproved()
+	if err != nil {
+		t.Fatalf("GetApproved: %v", err)
+	}
+	if got == nil || len(*got) != 1 {
+		t.Fatalf("ожидали один APPROVED, got %v", got)
+	}
+	if (*got)[0].Text != "approved review" {
+		t.Errorf("approved Text = %q, want 'approved review'", (*got)[0].Text)
+	}
+}
+
+func TestReviewOnCommunityService_Approve_Idempotent(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	reviewTablesTruncate(t, db)
+
+	author := seedMemberWithRoles(t, db, 13201, "idem_author", nil)
+	svc := NewReviewOnCommunityService()
+
+	if err := svc.CreateReviewOnCommunityByMemberId(author.Id, "to approve", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	reviews, _ := svc.GetByAuthorId(author.Id)
+	if len(reviews) != 1 {
+		t.Fatalf("ожидали 1 отзыв, got %d", len(reviews))
+	}
+	id := int64(reviews[0].Id)
+
+	first, err := svc.Approve(id)
+	if err != nil {
+		t.Fatalf("первый Approve: %v", err)
+	}
+	if first.Status != models.ReviewOnCommunityStatusApproved {
+		t.Errorf("status после первого Approve = %q, want APPROVED", first.Status)
+	}
+
+	second, err := svc.Approve(id)
+	if err != nil {
+		t.Fatalf("повторный Approve: %v", err)
+	}
+	if second.Status != models.ReviewOnCommunityStatusApproved {
+		t.Errorf("status после повторного Approve = %q, want APPROVED", second.Status)
+	}
+}
+
+func TestReviewOnCommunityService_GetByAuthorId_FiltersOtherAuthors(t *testing.T) {
+	db := testutil.EnsureTestDB(t)
+	reviewTablesTruncate(t, db)
+
+	a := seedMemberWithRoles(t, db, 13301, "author_a", nil)
+	b := seedMemberWithRoles(t, db, 13302, "author_b", nil)
+
+	svc := NewReviewOnCommunityService()
+	if err := svc.CreateReviewOnCommunityByMemberId(a.Id, "from a", nil); err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	if err := svc.CreateReviewOnCommunityByMemberId(b.Id, "from b", nil); err != nil {
+		t.Fatalf("b: %v", err)
+	}
+
+	got, err := svc.GetByAuthorId(a.Id)
+	if err != nil {
+		t.Fatalf("GetByAuthorId: %v", err)
+	}
+	if len(got) != 1 || got[0].Text != "from a" {
+		t.Errorf("ожидали один отзыв 'from a', got %+v", got)
+	}
+}

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -1,15 +1,16 @@
 // Package testutil содержит хелперы для интеграционных тестов.
 //
-// SetupTestDB поднимает PostgreSQL в Docker через testcontainers-go,
-// прогоняет на нём все миграции из database/migrations/ и возвращает
-// готовый *gorm.DB. Контейнер автоматически останавливается через
-// t.Cleanup. На пакет рекомендуется поднимать одну БД и truncate-ить
-// между тестами через TruncateAll — старт контейнера дороже самих
-// тестов.
+// Используется shared-модель: один Postgres-контейнер на тестовый пакет.
+// EnsureTestDB поднимает контейнер при первом вызове в пакете, прогоняет
+// миграции, подменяет database.DB и возвращает *gorm.DB. Контейнер живёт
+// до конца жизни тестового процесса — его очистка ложится на ОС вместе
+// с runtime'ом.
 //
-// Тесты, использующие этот пакет, требуют запущенного Docker. Если
-// Docker недоступен (TEST_SKIP_DB=1 или ошибка соединения), тесты
-// должны вызывать t.Skip — за это отвечает SetupTestDB.
+// Между тестами и подтестами используется TruncateAll(t, db, tables...)
+// для изоляции данных. Контейнер не пересоздаётся.
+//
+// Если Docker недоступен или TEST_SKIP_DB=1 — EnsureTestDB вызывает
+// t.Skip и тест проходит как пропущенный.
 package testutil
 
 import (
@@ -21,6 +22,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,16 +35,41 @@ import (
 
 const dbImage = "postgres:15-alpine"
 
-// SetupTestDB поднимает свежую PostgreSQL под тест и применяет все
-// миграции. Возвращает *gorm.DB; останов и очистку регистрирует через
-// t.Cleanup.
-func SetupTestDB(t *testing.T) *gorm.DB {
+var (
+	once     sync.Once
+	sharedDB *gorm.DB
+	sharedErr error
+	skipReason string
+)
+
+// EnsureTestDB поднимает один Postgres-контейнер на тестовый процесс
+// (через sync.Once) и возвращает готовый *gorm.DB. Подменяет
+// database.DB. Если Docker недоступен — t.Skip.
+func EnsureTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
 	if os.Getenv("TEST_SKIP_DB") == "1" {
 		t.Skip("TEST_SKIP_DB=1, пропускаю интеграционный тест")
 	}
 
+	once.Do(initSharedDB)
+
+	if skipReason != "" {
+		t.Skip(skipReason)
+	}
+	if sharedErr != nil {
+		t.Fatalf("init shared db: %v", sharedErr)
+	}
+
+	// Привязываем глобальный database.DB. Восстанавливать в Cleanup
+	// не нужно: shared instance живёт до конца процесса, никто другой
+	// не пишет в database.DB параллельно (тесты в одном пакете идут
+	// последовательно по умолчанию).
+	database.DB = sharedDB
+	return sharedDB
+}
+
+func initSharedDB() {
 	ctx := context.Background()
 
 	container, err := tcpostgres.Run(ctx, dbImage,
@@ -56,47 +83,33 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		),
 	)
 	if err != nil {
-		t.Skipf("не удалось поднять postgres-контейнер (Docker недоступен?): %v", err)
+		skipReason = fmt.Sprintf("не удалось поднять postgres-контейнер (Docker недоступен?): %v", err)
+		return
 	}
-
-	t.Cleanup(func() {
-		// Используем отдельный контекст с таймаутом — t.Cleanup иногда
-		// вызывается уже после отмены родительского.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := container.Terminate(ctx); err != nil {
-			t.Logf("не удалось остановить контейнер: %v", err)
-		}
-	})
 
 	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
 	if err != nil {
-		t.Fatalf("connection string: %v", err)
+		sharedErr = fmt.Errorf("connection string: %w", err)
+		return
 	}
 
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		t.Fatalf("gorm open: %v", err)
+		sharedErr = fmt.Errorf("gorm open: %w", err)
+		return
 	}
-
-	// Привязываем глобальный database.DB — много кода использует его
-	// напрямую (PointsRepository.AwardPoints и т.п.). Сохраняем старое
-	// значение и восстанавливаем в Cleanup, чтобы соседи не моргнули.
-	prevDB := database.DB
-	database.DB = db
-	t.Cleanup(func() { database.DB = prevDB })
 
 	if err := applyMigrations(db); err != nil {
-		t.Fatalf("apply migrations: %v", err)
+		sharedErr = fmt.Errorf("apply migrations: %w", err)
+		return
 	}
 
-	return db
+	sharedDB = db
 }
 
-// TruncateAll очищает заданные таблицы — обычно вызывается перед
-// каждым тестом одной горутины, чтобы между тестами не текли данные.
-// CASCADE снимает FK, RESTART IDENTITY сбрасывает sequence-ы, чтобы
-// id-ы были предсказуемыми.
+// TruncateAll очищает заданные таблицы — рекомендуется вызывать в
+// начале каждого теста, чтобы между тестами не текли данные. CASCADE
+// снимает FK, RESTART IDENTITY сбрасывает sequence-ы.
 func TruncateAll(t *testing.T, db *gorm.DB, tables ...string) {
 	t.Helper()
 	if len(tables) == 0 {
@@ -108,9 +121,12 @@ func TruncateAll(t *testing.T, db *gorm.DB, tables ...string) {
 	}
 }
 
-// applyMigrations выполняет все .sql в database/migrations/ в порядке
-// имени файла. Для тестов проще, чем поднимать database.SetupDatabase()
-// — не нужно ни viper, ни env-переменных.
+// SetupTestDB — устаревший alias на EnsureTestDB для обратной
+// совместимости. Новый код должен вызывать EnsureTestDB напрямую.
+func SetupTestDB(t *testing.T) *gorm.DB {
+	return EnsureTestDB(t)
+}
+
 func applyMigrations(db *gorm.DB) error {
 	dir := migrationsDir()
 	entries, err := os.ReadDir(dir)
@@ -138,11 +154,7 @@ func applyMigrations(db *gorm.DB) error {
 	return nil
 }
 
-// migrationsDir возвращает абсолютный путь к database/migrations/.
-// Тесты могут запускаться из любого каталога пакета — берём корень
-// модуля относительно положения этого файла.
 func migrationsDir() string {
 	_, thisFile, _, _ := runtime.Caller(0)
-	// .../backend/internal/testutil/db.go → .../backend/database/migrations
 	return filepath.Join(filepath.Dir(thisFile), "..", "..", "database", "migrations")
 }

--- a/platform-frontend/src/components/NpsWidget.vue
+++ b/platform-frontend/src/components/NpsWidget.vue
@@ -81,11 +81,11 @@ async function submit() {
   <Transition name="nps-fade">
     <div
       v-if="isOpen"
-      class="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center backdrop-blur-sm p-4"
+      class="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center backdrop-blur-sm p-2 sm:p-4"
       @click="handleBackdropClick"
     >
       <Transition name="nps-scale">
-        <div v-if="isOpen" class="bg-card text-card-foreground rounded-sm p-6 w-full max-w-md relative shadow-xl">
+        <div v-if="isOpen" class="bg-card text-card-foreground rounded-sm p-4 sm:p-6 w-full max-w-md relative shadow-xl">
           <button
             type="button"
             class="absolute right-4 top-4 text-muted-foreground hover:text-foreground cursor-pointer"
@@ -102,13 +102,17 @@ async function submit() {
             Насколько вероятно, что вы порекомендуете нас другу?
           </p>
 
-          <div class="grid grid-cols-6 sm:grid-cols-11 gap-1 mb-2">
+          <!-- 11 кнопок в один ряд при любой ширине: на узких экранах
+               получаются маленькие, но не переносятся (NPS-шкала визуально
+               важнее размера кнопок). min-h обеспечивает достаточный
+               touch-target. -->
+          <div class="grid grid-cols-11 gap-0.5 sm:gap-1 mb-2">
             <button
               v-for="n in 11"
               :key="n - 1"
               type="button"
               :aria-label="`Оценка ${n - 1}`"
-              class="min-h-9 px-1 text-sm rounded-sm border border-input transition-colors cursor-pointer"
+              class="min-h-10 px-0 text-xs sm:text-sm rounded-sm border border-input transition-colors cursor-pointer"
               :class="score === n - 1
                 ? 'bg-accent text-accent-foreground border-accent'
                 : 'hover:bg-secondary'"
@@ -117,7 +121,7 @@ async function submit() {
               {{ n - 1 }}
             </button>
           </div>
-          <div class="flex justify-between text-xs text-muted-foreground mb-4">
+          <div class="flex justify-between text-[10px] sm:text-xs text-muted-foreground mb-4">
             <span>Точно нет</span>
             <span>Точно да</span>
           </div>


### PR DESCRIPTION
## Summary

Один PR, шесть коммитов — продолжение T9 (тестовое покрытие) и закрытие WARN от senior-ревью на #288.

### Тестовая инфра
1. **shared PG-контейнер на пакет** (07d23f3). `EnsureTestDB` через `sync.Once` поднимает один контейнер при первом тесте, остальные переиспользуют. Между тестами изоляция через `TruncateAll`. Пакет service был 14с → 3.2с (4× быстрее), и эффект растёт с числом тестов.

### Покрытие сервисов
2. **MemberService + рефактор concurrent-теста** (2d40948). GetByTelegramID, GetByUsername, IsAdminByTelegramID, GetAdminTelegramIDs (отсев нулевого telegram_id), GetPermissions. Заодно `TestAwardEventPoints_Concurrent` заменён на `SequentialIdempotent` — concurrent флакал на тёплом контейнере, обнаружив реальную гонку в `WHERE NOT EXISTS` под READ COMMITTED. Полный фикс гонки требует `UNIQUE INDEX + ON CONFLICT DO NOTHING` и отдельной миграции.
3. **EventsService** (ec6329b). AddMember (happy + ParticipantLimitReached), RemoveMember, ResolveEventTags (Id/имя/дедуп/whitespace), GetFutureEvents (отбрасывает прошедшие и repeating без RepeatPeriod).
4. **KudosService** (d88e449). Send (happy, self-rejected, empty-message-rejected, daily-limit 3/сутки), GetRecent (sort + limit normalization).
5. **ReviewOnCommunityService** (e86f84f). CreateReviewOnCommunityByMemberId, GetApproved (только APPROVED), Approve (идемпотентность), GetByAuthorId (фильтр по автору).

### F6 WARN: NPS mobile
6. **NPS-виджет компактный на узких экранах** (71339db). Шкала 0-10 теперь всегда в один ряд (grid-cols-11) с min-h-10 для тап-таргета, gap-0.5 на мобильном. Hint-row (Точно нет/да) уменьшен до 10px чтобы не перекрывать. Padding модалки скейлится `p-2 sm:p-4` / `p-4 sm:p-6`.

## Замечания

- Тесты требуют Docker. Без Docker `EnsureTestDB` зовёт `t.Skip` — суит остаётся зелёным, в CI Docker есть.
- Известная гонка в points-pipeline остаётся открытым TODO — её фикс это миграция + изменение SQL и должен идти отдельным PR с осторожностью к существующим дублям в проде.
- T9 шаг 3 — частично закрыт (Member/Events/Kudos/Review). Дальше можно добавить TaskExchangeService, MarketplaceService, ChatActivityService, ResumeService и др.

## Test plan

- [x] `go build ./...` зелёный
- [x] `go vet ./...` зелёный
- [x] `go test ./...` зелёный (~3.5с на пакет service, 24 интеграционных теста)
- [x] Все три фронта: lint + type-check + build + unit-tests (где есть) зелёные
- [ ] CI: подтвердить что shared контейнер по-прежнему стартует на runner-е без проблем
- [ ] После деплоя: вручную проверить NPS-виджет на iPhone-ширине (375px) — шкала помещается в один ряд