### PR TITLE
feat(bot): админ-модерация (/ban /unban /mute /cleanup) и /voteban

### DIFF
--- a/backend/database/migrations/20260426160000_create_moderation_tables.sql
+++ b/backend/database/migrations/20260426160000_create_moderation_tables.sql
@@ -1,0 +1,63 @@
+-- Сохраняем telegram message_id у трекаемых сообщений, чтобы /cleanup мог
+-- их удалять через Telegram API. Старые записи останутся с NULL — их удалить
+-- невозможно (Telegram API требует message_id).
+ALTER TABLE chat_messages
+    ADD COLUMN IF NOT EXISTS telegram_message_id INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_user_sent
+    ON chat_messages (chat_id, telegram_user_id, sent_at);
+
+-- Аудит модерационных действий: ban, unban, mute, unmute, cleanup, voteban_mute.
+CREATE TABLE IF NOT EXISTS bot_moderation_actions (
+    id BIGSERIAL PRIMARY KEY,
+    chat_id BIGINT NOT NULL,
+    target_user_id BIGINT NOT NULL,
+    actor_user_id BIGINT NOT NULL,
+    action VARCHAR(32) NOT NULL,
+    reason TEXT,
+    duration_seconds INTEGER,
+    expires_at TIMESTAMPTZ,
+    meta JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bot_moderation_actions_chat_user
+    ON bot_moderation_actions (chat_id, target_user_id);
+CREATE INDEX IF NOT EXISTS idx_bot_moderation_actions_created_at
+    ON bot_moderation_actions (created_at);
+
+-- Голосования за бан (voteban) — по одному открытому на (chat_id, target).
+CREATE TABLE IF NOT EXISTS bot_votebans (
+    id BIGSERIAL PRIMARY KEY,
+    chat_id BIGINT NOT NULL,
+    chat_title VARCHAR(255) NOT NULL DEFAULT '',
+    target_user_id BIGINT NOT NULL,
+    target_username VARCHAR(255) NOT NULL DEFAULT '',
+    target_first_name VARCHAR(255) NOT NULL DEFAULT '',
+    initiator_user_id BIGINT NOT NULL,
+    trigger_message_id INTEGER,
+    poll_message_id INTEGER NOT NULL,
+    required_votes INTEGER NOT NULL DEFAULT 5,
+    mute_seconds INTEGER NOT NULL DEFAULT 3600,
+    expires_at TIMESTAMPTZ NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'open',
+    finalized_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_bot_votebans_open
+    ON bot_votebans (chat_id, target_user_id)
+    WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_bot_votebans_open_expires
+    ON bot_votebans (expires_at)
+    WHERE status = 'open';
+
+-- Голоса по voteban: уникальные на (voteban_id, voter).
+CREATE TABLE IF NOT EXISTS bot_voteban_votes (
+    voteban_id BIGINT NOT NULL REFERENCES bot_votebans(id) ON DELETE CASCADE,
+    voter_user_id BIGINT NOT NULL,
+    vote SMALLINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (voteban_id, voter_user_id)
+);

--- a/backend/internal/bot/moderation.go
+++ b/backend/internal/bot/moderation.go
@@ -1,0 +1,783 @@
+package bot
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/service"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// Параметры голосования по умолчанию.
+const (
+	votebanRequiredVotes = 5
+	votebanWindowSeconds = 30 * 60 // 30 минут
+	votebanMuteSeconds   = 60 * 60 // 1 час
+
+	cleanupDefaultPeriod = 24 * time.Hour
+	cleanupMaxPeriod     = 7 * 24 * time.Hour
+	cleanupBatchSleep    = 35 * time.Millisecond // Telegram ~30 удалений/сек
+
+	moderationWatcherTick = time.Minute
+)
+
+// --- Permissions ---
+
+// isChatAdmin checks via Telegram API whether userID is creator/admin in chatID.
+func (b *TelegramBot) isChatAdmin(chatID, userID int64) bool {
+	member, err := b.bot.GetChatMember(tgbotapi.GetChatMemberConfig{
+		ChatConfigWithUser: tgbotapi.ChatConfigWithUser{
+			ChatID: chatID,
+			UserID: userID,
+		},
+	})
+	if err != nil {
+		log.Printf("isChatAdmin: GetChatMember failed chat=%d user=%d: %v", chatID, userID, err)
+		return false
+	}
+	return member.Status == "creator" || member.Status == "administrator"
+}
+
+// canModerate true для super-admin платформы, любого ADMIN в БД и админов конкретного чата.
+func (b *TelegramBot) canModerate(chatID, userID int64) bool {
+	if b.isSubscriptionAdmin(userID) {
+		return true
+	}
+	if b.isAdmin(userID) {
+		return true
+	}
+	return b.isChatAdmin(chatID, userID)
+}
+
+// --- Argument parsing ---
+
+// commandArgs возвращает аргументы команды без самой команды (с поддержкой @bot_name).
+func commandArgs(message *tgbotapi.Message) []string {
+	return strings.Fields(message.CommandArguments())
+}
+
+// parseTargetFromArg достаёт telegram user id из строки: либо число, либо @username
+// (находим в chat_messages для текущего чата). Возвращает (id, displayName, ok).
+func (b *TelegramBot) parseTargetFromArg(chatID int64, arg string) (int64, string, bool) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return 0, "", false
+	}
+	if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
+		return id, fmt.Sprintf("id=%d", id), true
+	}
+	username := strings.TrimPrefix(arg, "@")
+	if username == "" {
+		return 0, "", false
+	}
+	id, err := b.chatActivityService.LookupUserIDByUsername(chatID, username)
+	if err != nil || id == 0 {
+		return 0, "", false
+	}
+	return id, "@" + username, true
+}
+
+// targetDisplay — html-имя для упоминания в служебных сообщениях.
+func targetDisplay(user *tgbotapi.User) string {
+	if user == nil {
+		return "пользователь"
+	}
+	if user.UserName != "" {
+		return "@" + html.EscapeString(user.UserName)
+	}
+	name := strings.TrimSpace(user.FirstName + " " + user.LastName)
+	if name == "" {
+		name = fmt.Sprintf("id=%d", user.ID)
+	}
+	return fmt.Sprintf("<a href=\"tg://user?id=%d\">%s</a>", user.ID, html.EscapeString(name))
+}
+
+// --- /ban ---
+
+func (b *TelegramBot) handleBanCommand(message *tgbotapi.Message) {
+	if message.Chat.Type != "group" && message.Chat.Type != "supergroup" {
+		return
+	}
+	if !b.canModerate(message.Chat.ID, message.From.ID) {
+		return
+	}
+	if message.ReplyToMessage == nil {
+		b.replyAndAutoDelete(message, "Используйте /ban в ответ на сообщение нарушителя. Опционально: /ban 1h, /ban 1d.")
+		return
+	}
+	target := message.ReplyToMessage.From
+	if target == nil || target.IsBot {
+		return
+	}
+	if b.canModerate(message.Chat.ID, target.ID) {
+		b.replyAndAutoDelete(message, "Нельзя забанить администратора.")
+		return
+	}
+
+	args := commandArgs(message)
+	var duration time.Duration
+	if len(args) > 0 {
+		d, err := service.ParseHumanDuration(args[0])
+		if err != nil {
+			b.replyAndAutoDelete(message, fmt.Sprintf("Не понял длительность: %v. Примеры: 30m, 1h, 1d.", err))
+			return
+		}
+		duration = d
+	}
+
+	until := int64(0)
+	var expiresAt *time.Time
+	if duration > 0 {
+		t := time.Now().Add(duration)
+		until = t.Unix()
+		expiresAt = &t
+	}
+
+	if _, err := b.bot.Request(tgbotapi.BanChatMemberConfig{
+		ChatMemberConfig: tgbotapi.ChatMemberConfig{
+			ChatID: message.Chat.ID,
+			UserID: target.ID,
+		},
+		UntilDate: until,
+	}); err != nil {
+		log.Printf("/ban: BanChatMember failed chat=%d user=%d: %v", message.Chat.ID, target.ID, err)
+		b.replyAndAutoDelete(message, "Telegram отказался банить (нужны права администратора с правом блокировки).")
+		return
+	}
+
+	durSec := int(duration.Seconds())
+	durPtr := &durSec
+	if duration == 0 {
+		durPtr = nil
+	}
+	if err := b.moderationService.LogAction(&models.ModerationAction{
+		ChatID:          message.Chat.ID,
+		TargetUserID:    target.ID,
+		ActorUserID:     message.From.ID,
+		Action:          models.ModerationActionBan,
+		DurationSeconds: durPtr,
+		ExpiresAt:       expiresAt,
+	}); err != nil {
+		log.Printf("/ban: log failed: %v", err)
+	}
+
+	durStr := service.FormatDurationHuman(duration)
+	b.sendChatHTML(message.Chat.ID, fmt.Sprintf("⛔ %s забанен (%s).", targetDisplay(target), durStr))
+	b.tryDelete(message.Chat.ID, message.MessageID)
+}
+
+// --- /unban ---
+
+func (b *TelegramBot) handleUnbanCommand(message *tgbotapi.Message) {
+	if message.Chat.Type != "group" && message.Chat.Type != "supergroup" {
+		return
+	}
+	if !b.canModerate(message.Chat.ID, message.From.ID) {
+		return
+	}
+
+	var targetID int64
+	display := ""
+	if message.ReplyToMessage != nil && message.ReplyToMessage.From != nil {
+		targetID = message.ReplyToMessage.From.ID
+		display = targetDisplay(message.ReplyToMessage.From)
+	} else {
+		args := commandArgs(message)
+		if len(args) == 0 {
+			b.replyAndAutoDelete(message, "Использование: /unban в ответ на сообщение, или /unban @username, или /unban <user_id>.")
+			return
+		}
+		id, d, ok := b.parseTargetFromArg(message.Chat.ID, args[0])
+		if !ok {
+			b.replyAndAutoDelete(message, "Не нашёл пользователя. Передайте user_id или @username из этого чата.")
+			return
+		}
+		targetID = id
+		display = html.EscapeString(d)
+	}
+
+	if _, err := b.bot.Request(tgbotapi.UnbanChatMemberConfig{
+		ChatMemberConfig: tgbotapi.ChatMemberConfig{
+			ChatID: message.Chat.ID,
+			UserID: targetID,
+		},
+		OnlyIfBanned: true,
+	}); err != nil {
+		log.Printf("/unban: UnbanChatMember failed chat=%d user=%d: %v", message.Chat.ID, targetID, err)
+		b.replyAndAutoDelete(message, "Telegram отказался разбанить.")
+		return
+	}
+
+	if err := b.moderationService.LogAction(&models.ModerationAction{
+		ChatID:       message.Chat.ID,
+		TargetUserID: targetID,
+		ActorUserID:  message.From.ID,
+		Action:       models.ModerationActionUnban,
+	}); err != nil {
+		log.Printf("/unban: log failed: %v", err)
+	}
+
+	b.sendChatHTML(message.Chat.ID, fmt.Sprintf("✅ %s разбанен.", display))
+	b.tryDelete(message.Chat.ID, message.MessageID)
+}
+
+// --- /mute ---
+
+// restrictPermissionsMuted — запрет писать/слать медиа на время мута.
+// Все CanXxx=false; RestrictChatMember в Telegram трактует «не указано»
+// как «отнять» — поэтому дополнительные права тоже всё равно убираются.
+func restrictPermissionsMuted() *tgbotapi.ChatPermissions {
+	return &tgbotapi.ChatPermissions{}
+}
+
+// restrictPermissionsAllow — обратно «всё можно» (для unmute).
+func restrictPermissionsAllow() *tgbotapi.ChatPermissions {
+	return &tgbotapi.ChatPermissions{
+		CanSendMessages:       true,
+		CanSendMediaMessages:  true,
+		CanSendPolls:          true,
+		CanSendOtherMessages:  true,
+		CanAddWebPagePreviews: true,
+		CanInviteUsers:        true,
+	}
+}
+
+func (b *TelegramBot) handleMuteCommand(message *tgbotapi.Message) {
+	if message.Chat.Type != "group" && message.Chat.Type != "supergroup" {
+		return
+	}
+	if !b.canModerate(message.Chat.ID, message.From.ID) {
+		return
+	}
+	if message.ReplyToMessage == nil {
+		b.replyAndAutoDelete(message, "Используйте /mute в ответ на сообщение. Опционально: /mute 30m, /mute 1h.")
+		return
+	}
+	target := message.ReplyToMessage.From
+	if target == nil || target.IsBot {
+		return
+	}
+	if b.canModerate(message.Chat.ID, target.ID) {
+		b.replyAndAutoDelete(message, "Нельзя замутить администратора.")
+		return
+	}
+
+	args := commandArgs(message)
+	var duration time.Duration
+	if len(args) > 0 {
+		d, err := service.ParseHumanDuration(args[0])
+		if err != nil {
+			b.replyAndAutoDelete(message, fmt.Sprintf("Не понял длительность: %v.", err))
+			return
+		}
+		duration = d
+	}
+
+	until := int64(0)
+	var expiresAt *time.Time
+	if duration > 0 {
+		t := time.Now().Add(duration)
+		until = t.Unix()
+		expiresAt = &t
+	}
+
+	if err := b.muteUserInChat(message.Chat.ID, target.ID, until); err != nil {
+		log.Printf("/mute: failed chat=%d user=%d: %v", message.Chat.ID, target.ID, err)
+		b.replyAndAutoDelete(message, "Не удалось замутить.")
+		return
+	}
+
+	durSec := int(duration.Seconds())
+	durPtr := &durSec
+	if duration == 0 {
+		durPtr = nil
+	}
+	if err := b.moderationService.LogAction(&models.ModerationAction{
+		ChatID:          message.Chat.ID,
+		TargetUserID:    target.ID,
+		ActorUserID:     message.From.ID,
+		Action:          models.ModerationActionMute,
+		DurationSeconds: durPtr,
+		ExpiresAt:       expiresAt,
+	}); err != nil {
+		log.Printf("/mute: log failed: %v", err)
+	}
+
+	b.sendChatHTML(message.Chat.ID, fmt.Sprintf("🔇 %s замучен (%s).", targetDisplay(target), service.FormatDurationHuman(duration)))
+	b.tryDelete(message.Chat.ID, message.MessageID)
+}
+
+func (b *TelegramBot) muteUserInChat(chatID, userID int64, untilUnix int64) error {
+	_, err := b.bot.Request(tgbotapi.RestrictChatMemberConfig{
+		ChatMemberConfig: tgbotapi.ChatMemberConfig{
+			ChatID: chatID,
+			UserID: userID,
+		},
+		Permissions: restrictPermissionsMuted(),
+		UntilDate:   untilUnix,
+	})
+	return err
+}
+
+// --- /cleanup ---
+
+func (b *TelegramBot) handleCleanupCommand(message *tgbotapi.Message) {
+	if message.Chat.Type != "group" && message.Chat.Type != "supergroup" {
+		return
+	}
+	if !b.canModerate(message.Chat.ID, message.From.ID) {
+		return
+	}
+
+	var targetID int64
+	var display string
+	if message.ReplyToMessage != nil && message.ReplyToMessage.From != nil {
+		targetID = message.ReplyToMessage.From.ID
+		display = targetDisplay(message.ReplyToMessage.From)
+	} else {
+		args := commandArgs(message)
+		if len(args) == 0 {
+			b.replyAndAutoDelete(message, "Использование: /cleanup в ответ на сообщение [период], или /cleanup @username [период]. Период по умолчанию — 24h.")
+			return
+		}
+		id, d, ok := b.parseTargetFromArg(message.Chat.ID, args[0])
+		if !ok {
+			b.replyAndAutoDelete(message, "Не нашёл пользователя в этом чате.")
+			return
+		}
+		targetID = id
+		display = html.EscapeString(d)
+	}
+
+	period := cleanupDefaultPeriod
+	args := commandArgs(message)
+	// Если в reply, period — args[0]. Если без reply, period — args[1].
+	periodArg := ""
+	if message.ReplyToMessage != nil {
+		if len(args) > 0 {
+			periodArg = args[0]
+		}
+	} else {
+		if len(args) > 1 {
+			periodArg = args[1]
+		}
+	}
+	if periodArg != "" {
+		d, err := service.ParseHumanDuration(periodArg)
+		if err != nil {
+			b.replyAndAutoDelete(message, fmt.Sprintf("Не понял период: %v.", err))
+			return
+		}
+		if d <= 0 {
+			b.replyAndAutoDelete(message, "Период должен быть больше нуля.")
+			return
+		}
+		if d > cleanupMaxPeriod {
+			b.replyAndAutoDelete(message, "Период не больше 7 дней.")
+			return
+		}
+		period = d
+	}
+
+	since := time.Now().Add(-period)
+	ids, err := b.moderationService.MessagesForCleanup(message.Chat.ID, targetID, since)
+	if err != nil {
+		log.Printf("/cleanup: query failed: %v", err)
+		b.replyAndAutoDelete(message, "Ошибка при поиске сообщений.")
+		return
+	}
+
+	// Ack — чтобы команда не висела молча; финальную сводку шлём по завершении.
+	b.tryDelete(message.Chat.ID, message.MessageID)
+
+	if len(ids) == 0 {
+		b.sendChatHTML(message.Chat.ID, fmt.Sprintf("🧹 У %s нет сообщений за %s.", display, service.FormatDurationHuman(period)))
+		return
+	}
+
+	go b.runCleanup(message.Chat.ID, targetID, message.From.ID, display, period, ids)
+}
+
+func (b *TelegramBot) runCleanup(chatID, targetID, actorID int64, display string, period time.Duration, ids []int) {
+	deleted := 0
+	failed := 0
+	successIDs := make([]int, 0, len(ids))
+	for _, mid := range ids {
+		if _, err := b.bot.Request(tgbotapi.NewDeleteMessage(chatID, mid)); err != nil {
+			// Сообщение могло быть уже удалено вручную — это не ошибка для нас.
+			if !strings.Contains(err.Error(), "message to delete not found") {
+				failed++
+				log.Printf("cleanup: delete msg=%d in chat=%d failed: %v", mid, chatID, err)
+			}
+			continue
+		}
+		deleted++
+		successIDs = append(successIDs, mid)
+		time.Sleep(cleanupBatchSleep)
+	}
+	if _, err := b.moderationService.DeleteCleanedMessages(chatID, successIDs); err != nil {
+		log.Printf("cleanup: drop chat_messages rows failed: %v", err)
+	}
+
+	if err := b.moderationService.LogActionWithMeta(&models.ModerationAction{
+		ChatID:       chatID,
+		TargetUserID: targetID,
+		ActorUserID:  actorID,
+		Action:       models.ModerationActionCleanup,
+	}, map[string]interface{}{
+		"period":  service.FormatDurationHuman(period),
+		"deleted": deleted,
+		"failed":  failed,
+		"matched": len(ids),
+	}); err != nil {
+		log.Printf("cleanup: log failed: %v", err)
+	}
+
+	skipped := len(ids) - deleted - failed
+	summary := fmt.Sprintf("🧹 У %s удалено %d/%d сообщений за %s.",
+		display, deleted, len(ids), service.FormatDurationHuman(period))
+	if failed > 0 {
+		summary += fmt.Sprintf(" Не удалось: %d.", failed)
+	}
+	if skipped > 0 {
+		summary += fmt.Sprintf(" Пропущено: %d.", skipped)
+	}
+	summary += "\n<i>Сообщения, отправленные до включения этой функции, удалить нельзя — у бота нет их Telegram-id.</i>"
+	b.sendChatHTML(chatID, summary)
+}
+
+// --- /voteban ---
+
+func (b *TelegramBot) handleVotebanCommand(message *tgbotapi.Message) {
+	if message.Chat.Type != "group" && message.Chat.Type != "supergroup" {
+		return
+	}
+	// Любой участник чата может запустить голосование. Не пускаем только в
+	// тех чатах, которые мы не отслеживаем (бот не админ или соседний чат).
+	if !b.chatActivityService.IsTrackedChat(message.Chat.ID) {
+		return
+	}
+	if message.ReplyToMessage == nil {
+		b.replyAndAutoDelete(message, "Используйте /voteban в ответ на сообщение нарушителя.")
+		return
+	}
+	target := message.ReplyToMessage.From
+	if target == nil || target.IsBot {
+		return
+	}
+	if target.ID == message.From.ID {
+		b.replyAndAutoDelete(message, "Самому на себя голосование не нужно.")
+		return
+	}
+	if b.canModerate(message.Chat.ID, target.ID) {
+		b.replyAndAutoDelete(message, "Нельзя начать голосование на администратора.")
+		return
+	}
+	if !b.isChatMember(message.Chat.ID, message.From.ID) {
+		// На случай, когда юзер вышел/был удалён, но успел отправить команду.
+		return
+	}
+
+	triggerID := message.ReplyToMessage.MessageID
+	triggerPtr := &triggerID
+	chatTitle := message.Chat.Title
+
+	// Сначала отправляем poll-сообщение — нам нужен его MessageID для записи.
+	pollText := b.formatVotebanPoll(target, message.From, models.VotebanTally{}, votebanRequiredVotes, time.Duration(votebanWindowSeconds)*time.Second)
+	pollMsg := tgbotapi.NewMessage(message.Chat.ID, pollText)
+	pollMsg.ParseMode = "HTML"
+	pollMsg.DisableWebPagePreview = true
+	pollMsg.ReplyToMessageID = triggerID
+	// Кнопки добавим после получения id записи (они содержат voteban_id).
+	sent, err := b.bot.Send(pollMsg)
+	if err != nil {
+		log.Printf("voteban: send poll failed: %v", err)
+		return
+	}
+
+	vb, err := b.moderationService.StartVoteban(service.VotebanStartParams{
+		ChatID:           message.Chat.ID,
+		ChatTitle:        chatTitle,
+		TargetUserID:     target.ID,
+		TargetUsername:   target.UserName,
+		TargetFirstName:  target.FirstName,
+		InitiatorUserID:  message.From.ID,
+		TriggerMessageID: triggerPtr,
+		PollMessageID:    sent.MessageID,
+		RequiredVotes:    votebanRequiredVotes,
+		MuteSeconds:      votebanMuteSeconds,
+		WindowSeconds:    votebanWindowSeconds,
+	})
+	if err != nil {
+		// Уже идёт голосование — удаляем только что отправленный poll, оставляем существующий.
+		if err == service.ErrVotebanAlreadyOpen {
+			b.tryDelete(message.Chat.ID, sent.MessageID)
+			b.replyAndAutoDelete(message, "На этого участника уже идёт голосование.")
+			return
+		}
+		log.Printf("voteban: start failed: %v", err)
+		b.tryDelete(message.Chat.ID, sent.MessageID)
+		return
+	}
+
+	// Обновляем poll-сообщение, добавив кнопки с реальным id.
+	editMarkup := tgbotapi.NewEditMessageReplyMarkup(message.Chat.ID, sent.MessageID, b.votebanKeyboard(vb.Id, models.VotebanTally{}))
+	if _, err := b.bot.Send(editMarkup); err != nil {
+		log.Printf("voteban: edit markup failed: %v", err)
+	}
+
+	// Инициатор автоматически голосует «за» — один клик меньше.
+	if res, err := b.moderationService.CastVote(vb.Id, message.From.ID, models.VotebanVoteFor); err == nil {
+		b.refreshVotebanMessage(vb, res.Tally)
+		if res.Threshold {
+			b.finalizeVotebanPassed(vb)
+		}
+	}
+
+	b.tryDelete(message.Chat.ID, message.MessageID)
+}
+
+func (b *TelegramBot) formatVotebanPoll(target, initiator *tgbotapi.User, tally models.VotebanTally, required int, window time.Duration) string {
+	return fmt.Sprintf(
+		"⚖️ <b>Голосование за бан</b>\n\n"+
+			"Кого: %s\n"+
+			"Кто запустил: %s\n"+
+			"Окно: %s · нужно «за»: %d\n\n"+
+			"Голосуют участники чата. Цель не голосует. Через %s — мут на час, иначе — закрываем.",
+		targetDisplay(target),
+		targetDisplay(initiator),
+		service.FormatDurationHuman(window),
+		required,
+		service.FormatDurationHuman(window),
+	) + b.formatVotebanTally(tally, required)
+}
+
+func (b *TelegramBot) formatVotebanTally(tally models.VotebanTally, required int) string {
+	return fmt.Sprintf("\n\n✅ За: %d/%d   ❌ Против: %d", tally.For, required, tally.Against)
+}
+
+func (b *TelegramBot) votebanKeyboard(votebanID int64, tally models.VotebanTally) tgbotapi.InlineKeyboardMarkup {
+	return tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(fmt.Sprintf("✅ За (%d)", tally.For), fmt.Sprintf("vb:%d:up", votebanID)),
+			tgbotapi.NewInlineKeyboardButtonData(fmt.Sprintf("❌ Против (%d)", tally.Against), fmt.Sprintf("vb:%d:down", votebanID)),
+		),
+	)
+}
+
+// refreshVotebanMessage обновляет текст и кнопки poll-сообщения с актуальной раскладкой.
+func (b *TelegramBot) refreshVotebanMessage(vb *models.Voteban, tally models.VotebanTally) {
+	target := &tgbotapi.User{
+		ID:        vb.TargetUserID,
+		UserName:  vb.TargetUsername,
+		FirstName: vb.TargetFirstName,
+	}
+	initiator := &tgbotapi.User{ID: vb.InitiatorUserID}
+	window := time.Until(vb.ExpiresAt)
+	if window < 0 {
+		window = 0
+	}
+	text := b.formatVotebanPoll(target, initiator, tally, vb.RequiredVotes, window)
+
+	edit := tgbotapi.NewEditMessageTextAndMarkup(vb.ChatID, vb.PollMessageID, text, b.votebanKeyboard(vb.Id, tally))
+	edit.ParseMode = "HTML"
+	edit.DisableWebPagePreview = true
+	if _, err := b.bot.Send(edit); err != nil {
+		log.Printf("voteban: refresh poll failed: %v", err)
+	}
+}
+
+// handleVotebanCallback обрабатывает нажатие на ✅/❌ под голосованием.
+func (b *TelegramBot) handleVotebanCallback(callback *tgbotapi.CallbackQuery) {
+	parts := strings.Split(callback.Data, ":")
+	if len(parts) != 3 {
+		return
+	}
+	votebanID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return
+	}
+	var vote int16
+	switch parts[2] {
+	case "up":
+		vote = models.VotebanVoteFor
+	case "down":
+		vote = models.VotebanVoteAgainst
+	default:
+		return
+	}
+
+	vb, err := b.moderationService.GetVoteban(votebanID)
+	if err != nil || vb == nil {
+		b.answerCallbackQuery(callback.ID, "Голосование не найдено.")
+		return
+	}
+	if vb.Status != models.VotebanStatusOpen {
+		b.answerCallbackQuery(callback.ID, "Голосование уже закрыто.")
+		return
+	}
+	if !b.isChatMember(vb.ChatID, callback.From.ID) {
+		b.answerCallbackQuery(callback.ID, "Голосовать могут только участники чата.")
+		return
+	}
+
+	res, err := b.moderationService.CastVote(votebanID, callback.From.ID, vote)
+	if err != nil {
+		switch err {
+		case service.ErrVoteSelfTarget:
+			b.answerCallbackQuery(callback.ID, "Цель голосования не может голосовать.")
+		case service.ErrVotebanClosed:
+			b.answerCallbackQuery(callback.ID, "Голосование уже закрыто.")
+		default:
+			log.Printf("voteban: cast failed: %v", err)
+			b.answerCallbackQuery(callback.ID, "Ошибка.")
+		}
+		return
+	}
+
+	if !res.Changed {
+		b.answerCallbackQuery(callback.ID, "Ваш голос уже учтён.")
+	} else {
+		b.answerCallbackQuery(callback.ID, "Голос принят.")
+	}
+	b.refreshVotebanMessage(vb, res.Tally)
+
+	if res.Threshold {
+		b.finalizeVotebanPassed(vb)
+	}
+}
+
+// finalizeVotebanPassed применяет санкцию: мут на vb.MuteSeconds + удаление trigger.
+// Идемпотентно: если запись уже не open, ничего не делает.
+func (b *TelegramBot) finalizeVotebanPassed(vb *models.Voteban) {
+	ok, err := b.moderationService.FinalizeVoteban(vb.Id, models.VotebanStatusPassed)
+	if err != nil {
+		log.Printf("voteban: finalize-passed failed: %v", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	until := time.Now().Add(time.Duration(vb.MuteSeconds) * time.Second)
+	if err := b.muteUserInChat(vb.ChatID, vb.TargetUserID, until.Unix()); err != nil {
+		log.Printf("voteban: mute failed chat=%d user=%d: %v", vb.ChatID, vb.TargetUserID, err)
+	}
+	if vb.TriggerMessageID != nil {
+		b.tryDelete(vb.ChatID, *vb.TriggerMessageID)
+	}
+
+	dur := time.Duration(vb.MuteSeconds) * time.Second
+	durSec := vb.MuteSeconds
+	expiresAt := until
+	_ = b.moderationService.LogActionWithMeta(&models.ModerationAction{
+		ChatID:          vb.ChatID,
+		TargetUserID:    vb.TargetUserID,
+		ActorUserID:     0,
+		Action:          models.ModerationActionVotebanMute,
+		DurationSeconds: &durSec,
+		ExpiresAt:       &expiresAt,
+	}, map[string]interface{}{
+		"voteban_id": vb.Id,
+		"initiator":  vb.InitiatorUserID,
+	})
+
+	tally, _ := b.moderationService.CountVotes(vb.Id)
+	target := &tgbotapi.User{ID: vb.TargetUserID, UserName: vb.TargetUsername, FirstName: vb.TargetFirstName}
+	text := fmt.Sprintf("⚖️ Голосование завершено: %s замучен на %s (✅ %d / ❌ %d).",
+		targetDisplay(target), service.FormatDurationHuman(dur), tally.For, tally.Against)
+	edit := tgbotapi.NewEditMessageText(vb.ChatID, vb.PollMessageID, text)
+	edit.ParseMode = "HTML"
+	if _, err := b.bot.Send(edit); err != nil {
+		log.Printf("voteban: edit final passed failed: %v", err)
+	}
+}
+
+// finalizeVotebanFailed закрывает голосование без санкций (истечение окна).
+func (b *TelegramBot) finalizeVotebanFailed(vb *models.Voteban) {
+	ok, err := b.moderationService.FinalizeVoteban(vb.Id, models.VotebanStatusFailed)
+	if err != nil {
+		log.Printf("voteban: finalize-failed failed: %v", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	tally, _ := b.moderationService.CountVotes(vb.Id)
+	target := &tgbotapi.User{ID: vb.TargetUserID, UserName: vb.TargetUsername, FirstName: vb.TargetFirstName}
+	text := fmt.Sprintf("⚖️ Голосование закрыто: голосов недостаточно (✅ %d / ❌ %d). %s остаётся в чате.",
+		tally.For, tally.Against, targetDisplay(target))
+	edit := tgbotapi.NewEditMessageText(vb.ChatID, vb.PollMessageID, text)
+	edit.ParseMode = "HTML"
+	if _, err := b.bot.Send(edit); err != nil {
+		log.Printf("voteban: edit final failed: %v", err)
+	}
+}
+
+// startVotebanWatcher финализирует протёкшие открытые голосования.
+func (b *TelegramBot) startVotebanWatcher() {
+	ticker := time.NewTicker(moderationWatcherTick)
+	defer ticker.Stop()
+	for range ticker.C {
+		expired, err := b.moderationService.ListExpiredOpenVotebans(time.Now())
+		if err != nil {
+			log.Printf("voteban-watcher: list failed: %v", err)
+			continue
+		}
+		for i := range expired {
+			vb := expired[i]
+			tally, _ := b.moderationService.CountVotes(vb.Id)
+			if tally.For >= vb.RequiredVotes {
+				b.finalizeVotebanPassed(&vb)
+			} else {
+				b.finalizeVotebanFailed(&vb)
+			}
+		}
+	}
+}
+
+// --- helpers ---
+
+// sendChatHTML отправляет HTML-сообщение в чат, без preview.
+func (b *TelegramBot) sendChatHTML(chatID int64, text string) {
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ParseMode = "HTML"
+	msg.DisableWebPagePreview = true
+	if _, err := b.bot.Send(msg); err != nil {
+		log.Printf("sendChatHTML failed chat=%d: %v", chatID, err)
+	}
+}
+
+// tryDelete удаляет сообщение, ошибки только логирует.
+func (b *TelegramBot) tryDelete(chatID int64, messageID int) {
+	if _, err := b.bot.Request(tgbotapi.NewDeleteMessage(chatID, messageID)); err != nil {
+		// «message to delete not found» — нормальный исход (уже удалено).
+		if !strings.Contains(err.Error(), "message to delete not found") {
+			log.Printf("tryDelete chat=%d msg=%d: %v", chatID, messageID, err)
+		}
+	}
+}
+
+// replyAndAutoDelete отвечает на команду подсказкой и через 15 сек удаляет
+// и подсказку, и саму команду — чтобы не засорять чат.
+func (b *TelegramBot) replyAndAutoDelete(message *tgbotapi.Message, text string) {
+	reply := tgbotapi.NewMessage(message.Chat.ID, text)
+	reply.ReplyToMessageID = message.MessageID
+	sent, err := b.bot.Send(reply)
+	if err != nil {
+		log.Printf("replyAndAutoDelete send failed: %v", err)
+		return
+	}
+	go func() {
+		time.Sleep(15 * time.Second)
+		b.tryDelete(message.Chat.ID, sent.MessageID)
+		b.tryDelete(message.Chat.ID, message.MessageID)
+	}()
+}

--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -115,6 +115,7 @@ type TelegramBot struct {
 	chatHighlightService        *service.ChatHighlightService
 	subscriptionService         *service.SubscriptionService
 	supportService              *service.SupportService
+	moderationService           *service.ModerationService
 }
 
 func NewTelegramBot(redisClient *redis.Client) (*TelegramBot, error) {
@@ -143,6 +144,7 @@ func NewTelegramBot(redisClient *redis.Client) (*TelegramBot, error) {
 	chatHighlightService := service.NewChatHighlightService()
 	subscriptionService := service.NewSubscriptionService(redisClient)
 	supportService := service.NewSupportService(redisClient)
+	moderationService := service.NewModerationService()
 
 	return &TelegramBot{
 		bot:                         bot,
@@ -155,6 +157,7 @@ func NewTelegramBot(redisClient *redis.Client) (*TelegramBot, error) {
 		chatHighlightService:        chatHighlightService,
 		subscriptionService:         subscriptionService,
 		supportService:              supportService,
+		moderationService:           moderationService,
 	}, nil
 }
 
@@ -170,6 +173,9 @@ func (b *TelegramBot) Start() {
 
 	// Start subscription checker
 	go b.startSubscriptionChecker()
+
+	// Финализация протёкших voteban-голосований.
+	go b.startVotebanWatcher()
 
 	// Слушаем Redis pub/sub от бэкенда: когда админ через UI привязывает чат
 	// к новому тиру, приходит событие — бот рассылает invite-ссылки всем
@@ -259,6 +265,27 @@ func (b *TelegramBot) Start() {
 		if update.Message.IsCommand() && update.Message.Command() == "whois" {
 			b.handleWhoisCommand(update.Message)
 			continue
+		}
+
+		// Модерационные команды (работают в групповых чатах).
+		if update.Message.IsCommand() {
+			switch update.Message.Command() {
+			case "ban":
+				b.handleBanCommand(update.Message)
+				continue
+			case "unban":
+				b.handleUnbanCommand(update.Message)
+				continue
+			case "mute":
+				b.handleMuteCommand(update.Message)
+				continue
+			case "cleanup":
+				b.handleCleanupCommand(update.Message)
+				continue
+			case "voteban":
+				b.handleVotebanCommand(update.Message)
+				continue
+			}
 		}
 
 		// Голое «/слово» в группе (без аргументов и без другого текста):
@@ -390,7 +417,13 @@ func (b *TelegramBot) handleHelpCommand(message *tgbotapi.Message) {
 	text := "Подписка, чаты, баллы, события, связь с админом — всё через /start с кнопками.\n\n" +
 		"Вспомогательное в группах:\n" +
 		"/summarize [day|week|3d|N] — AI-саммари чата (5/день на юзера)\n" +
-		"/whois — кто участник (reply или /whois @username)"
+		"/whois — кто участник (reply или /whois @username)\n" +
+		"/voteban (reply) — запустить голосование за временный мут (5 голосов «за» за 30 мин → мут на час)\n\n" +
+		"Модерация (админам чата и платформы):\n" +
+		"/ban [duration] — бан в этом чате (reply). Пример: /ban 1h, /ban 1d. Без аргумента — навсегда\n" +
+		"/unban — разбан (reply, /unban @user или /unban <id>)\n" +
+		"/mute [duration] — мут (reply). Пример: /mute 30m\n" +
+		"/cleanup [period] — удалить сообщения юзера в этом чате за период (reply, по умолчанию 24h)"
 
 	if b.isAdmin(message.From.ID) {
 		text += "\n\nАдмин-команды подписок:\n" +
@@ -960,6 +993,12 @@ func (b *TelegramBot) handleCallbackQuery(callback *tgbotapi.CallbackQuery) {
 	// Welcome-wizard (/start) — короткие колбэки wiz:*.
 	if strings.HasPrefix(data, "wiz:") {
 		b.handleWizardCallback(callback)
+		return
+	}
+
+	// Voteban-голосование — vb:{voteban_id}:up|down.
+	if strings.HasPrefix(data, "vb:") {
+		b.handleVotebanCallback(callback)
 		return
 	}
 

--- a/backend/internal/models/chat_message.go
+++ b/backend/internal/models/chat_message.go
@@ -23,6 +23,7 @@ type ChatMessage struct {
 	TelegramFirstName string    `json:"telegramFirstName" gorm:"column:telegram_first_name"`
 	MemberID          *int64    `json:"memberId" gorm:"column:member_id"`
 	MessageText       string    `json:"messageText" gorm:"column:message_text"`
+	TelegramMessageID *int      `json:"telegramMessageId" gorm:"column:telegram_message_id"`
 	SentAt            time.Time `json:"sentAt" gorm:"column:sent_at"`
 	CreatedAt         time.Time `json:"createdAt" gorm:"column:created_at"`
 }

--- a/backend/internal/models/moderation.go
+++ b/backend/internal/models/moderation.go
@@ -1,0 +1,84 @@
+package models
+
+import "time"
+
+const (
+	ModerationActionBan         = "ban"
+	ModerationActionUnban       = "unban"
+	ModerationActionMute        = "mute"
+	ModerationActionUnmute      = "unmute"
+	ModerationActionCleanup     = "cleanup"
+	ModerationActionVotebanMute = "voteban_mute"
+)
+
+// ModerationAction — журнал модерационных действий бота.
+type ModerationAction struct {
+	Id              int64      `json:"id" gorm:"primaryKey"`
+	ChatID          int64      `json:"chatId" gorm:"column:chat_id"`
+	TargetUserID    int64      `json:"targetUserId" gorm:"column:target_user_id"`
+	ActorUserID     int64      `json:"actorUserId" gorm:"column:actor_user_id"`
+	Action          string     `json:"action" gorm:"column:action"`
+	Reason          *string    `json:"reason" gorm:"column:reason"`
+	DurationSeconds *int       `json:"durationSeconds" gorm:"column:duration_seconds"`
+	ExpiresAt       *time.Time `json:"expiresAt" gorm:"column:expires_at"`
+	Meta            string     `json:"meta" gorm:"column:meta;type:jsonb;default:'{}'"`
+	CreatedAt       time.Time  `json:"createdAt" gorm:"column:created_at"`
+}
+
+func (ModerationAction) TableName() string {
+	return "bot_moderation_actions"
+}
+
+const (
+	VotebanStatusOpen      = "open"
+	VotebanStatusPassed    = "passed"
+	VotebanStatusFailed    = "failed"
+	VotebanStatusCancelled = "cancelled"
+)
+
+const (
+	VotebanVoteFor     int16 = 1
+	VotebanVoteAgainst int16 = -1
+)
+
+// Voteban — голосование за временный мут пользователя в групповом чате.
+type Voteban struct {
+	Id               int64      `json:"id" gorm:"primaryKey"`
+	ChatID           int64      `json:"chatId" gorm:"column:chat_id"`
+	ChatTitle        string     `json:"chatTitle" gorm:"column:chat_title"`
+	TargetUserID     int64      `json:"targetUserId" gorm:"column:target_user_id"`
+	TargetUsername   string     `json:"targetUsername" gorm:"column:target_username"`
+	TargetFirstName  string     `json:"targetFirstName" gorm:"column:target_first_name"`
+	InitiatorUserID  int64      `json:"initiatorUserId" gorm:"column:initiator_user_id"`
+	TriggerMessageID *int       `json:"triggerMessageId" gorm:"column:trigger_message_id"`
+	PollMessageID    int        `json:"pollMessageId" gorm:"column:poll_message_id"`
+	RequiredVotes    int        `json:"requiredVotes" gorm:"column:required_votes"`
+	MuteSeconds      int        `json:"muteSeconds" gorm:"column:mute_seconds"`
+	ExpiresAt        time.Time  `json:"expiresAt" gorm:"column:expires_at"`
+	Status           string     `json:"status" gorm:"column:status"`
+	FinalizedAt      *time.Time `json:"finalizedAt" gorm:"column:finalized_at"`
+	CreatedAt        time.Time  `json:"createdAt" gorm:"column:created_at"`
+}
+
+func (Voteban) TableName() string {
+	return "bot_votebans"
+}
+
+// VotebanVote — голос конкретного юзера в рамках одного voteban.
+type VotebanVote struct {
+	VotebanID   int64     `json:"votebanId" gorm:"column:voteban_id;primaryKey"`
+	VoterUserID int64     `json:"voterUserId" gorm:"column:voter_user_id;primaryKey"`
+	Vote        int16     `json:"vote" gorm:"column:vote"`
+	CreatedAt   time.Time `json:"createdAt" gorm:"column:created_at"`
+	UpdatedAt   time.Time `json:"updatedAt" gorm:"column:updated_at"`
+}
+
+func (VotebanVote) TableName() string {
+	return "bot_voteban_votes"
+}
+
+// VotebanTally — агрегированные счётчики голосов.
+type VotebanTally struct {
+	For     int `json:"for"`
+	Against int `json:"against"`
+}

--- a/backend/internal/repository/chat_activity.go
+++ b/backend/internal/repository/chat_activity.go
@@ -278,3 +278,15 @@ func (r *ChatActivityRepository) DeleteOldMessages(beforeDate time.Time) (int64,
 	result := database.DB.Where("sent_at < ?", beforeDate).Delete(&models.ChatMessage{})
 	return result.RowsAffected, result.Error
 }
+
+// LookupUserIDByUsername ищет telegram_user_id по последнему совпадению
+// telegram_username в указанном чате. Регистронезависимо. 0 = не найдено.
+func (r *ChatActivityRepository) LookupUserIDByUsername(chatID int64, username string) (int64, error) {
+	var userID int64
+	err := database.DB.Model(&models.ChatMessage{}).
+		Where("chat_id = ? AND LOWER(telegram_username) = LOWER(?)", chatID, username).
+		Order("sent_at DESC").
+		Limit(1).
+		Pluck("telegram_user_id", &userID).Error
+	return userID, err
+}

--- a/backend/internal/repository/moderation.go
+++ b/backend/internal/repository/moderation.go
@@ -1,0 +1,158 @@
+package repository
+
+import (
+	"errors"
+	"ithozyeva/database"
+	"ithozyeva/internal/models"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type ModerationRepository struct{}
+
+func NewModerationRepository() *ModerationRepository {
+	return &ModerationRepository{}
+}
+
+// LogAction записывает модерационное действие.
+func (r *ModerationRepository) LogAction(action *models.ModerationAction) error {
+	if action.Meta == "" {
+		action.Meta = "{}"
+	}
+	return database.DB.Create(action).Error
+}
+
+// MessagesForCleanup возвращает telegram_message_id сообщений пользователя в
+// чате за период since (>=). Только записи с непустым telegram_message_id —
+// старые сообщения без него Telegram API удалить не позволит.
+func (r *ModerationRepository) MessagesForCleanup(chatID, userID int64, since time.Time) ([]int, error) {
+	var ids []int
+	err := database.DB.Model(&models.ChatMessage{}).
+		Where("chat_id = ? AND telegram_user_id = ? AND sent_at >= ? AND telegram_message_id IS NOT NULL",
+			chatID, userID, since).
+		Order("sent_at ASC").
+		Pluck("telegram_message_id", &ids).Error
+	return ids, err
+}
+
+// DeleteCleanedMessages удаляет записи из chat_messages по списку telegram_message_id
+// (после успешного удаления в Telegram). Возвращает кол-во удалённых строк.
+func (r *ModerationRepository) DeleteCleanedMessages(chatID int64, messageIDs []int) (int64, error) {
+	if len(messageIDs) == 0 {
+		return 0, nil
+	}
+	res := database.DB.Where("chat_id = ? AND telegram_message_id IN ?", chatID, messageIDs).
+		Delete(&models.ChatMessage{})
+	return res.RowsAffected, res.Error
+}
+
+// FindOpenVoteban — открытое голосование на (chat_id, target_user_id), если есть.
+func (r *ModerationRepository) FindOpenVoteban(chatID, targetUserID int64) (*models.Voteban, error) {
+	var v models.Voteban
+	err := database.DB.Where("chat_id = ? AND target_user_id = ? AND status = ?",
+		chatID, targetUserID, models.VotebanStatusOpen).
+		First(&v).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &v, nil
+}
+
+// CreateVoteban сохраняет новое голосование.
+func (r *ModerationRepository) CreateVoteban(v *models.Voteban) error {
+	return database.DB.Create(v).Error
+}
+
+// GetVoteban читает запись по id.
+func (r *ModerationRepository) GetVoteban(id int64) (*models.Voteban, error) {
+	var v models.Voteban
+	if err := database.DB.First(&v, id).Error; err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// UpsertVote ставит/обновляет голос. Возвращает true, если запись создалась
+// впервые (для логов / UX), и финальное значение голоса.
+func (r *ModerationRepository) UpsertVote(votebanID, voterID int64, vote int16) error {
+	now := time.Now()
+	v := models.VotebanVote{
+		VotebanID:   votebanID,
+		VoterUserID: voterID,
+		Vote:        vote,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	return database.DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "voteban_id"}, {Name: "voter_user_id"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"vote":       vote,
+			"updated_at": now,
+		}),
+	}).Create(&v).Error
+}
+
+// GetVote возвращает текущий голос пользователя или nil, если не голосовал.
+func (r *ModerationRepository) GetVote(votebanID, voterID int64) (*int16, error) {
+	var v models.VotebanVote
+	err := database.DB.Where("voteban_id = ? AND voter_user_id = ?", votebanID, voterID).
+		First(&v).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &v.Vote, nil
+}
+
+// CountVotes считает «за» и «против» по voteban_id.
+func (r *ModerationRepository) CountVotes(votebanID int64) (models.VotebanTally, error) {
+	var tally models.VotebanTally
+	type row struct {
+		Vote  int16
+		Count int
+	}
+	var rows []row
+	err := database.DB.Model(&models.VotebanVote{}).
+		Select("vote, COUNT(*) as count").
+		Where("voteban_id = ?", votebanID).
+		Group("vote").
+		Scan(&rows).Error
+	if err != nil {
+		return tally, err
+	}
+	for _, r := range rows {
+		switch r.Vote {
+		case models.VotebanVoteFor:
+			tally.For = r.Count
+		case models.VotebanVoteAgainst:
+			tally.Against = r.Count
+		}
+	}
+	return tally, nil
+}
+
+// FinalizeVoteban переводит голосование в финальный статус.
+func (r *ModerationRepository) FinalizeVoteban(id int64, status string) error {
+	now := time.Now()
+	return database.DB.Model(&models.Voteban{}).
+		Where("id = ? AND status = ?", id, models.VotebanStatusOpen).
+		Updates(map[string]interface{}{
+			"status":       status,
+			"finalized_at": now,
+		}).Error
+}
+
+// ListExpiredOpenVotebans возвращает голосования с истёкшим окном для finalize.
+func (r *ModerationRepository) ListExpiredOpenVotebans(now time.Time) ([]models.Voteban, error) {
+	var list []models.Voteban
+	err := database.DB.Where("status = ? AND expires_at <= ?", models.VotebanStatusOpen, now).
+		Find(&list).Error
+	return list, err
+}

--- a/backend/internal/service/chat_activity.go
+++ b/backend/internal/service/chat_activity.go
@@ -96,6 +96,7 @@ func (s *ChatActivityService) TrackMessage(message *tgbotapi.Message) {
 	// Определяем member_id
 	memberID := s.resolveMemberID(message.From.ID)
 
+	tgMessageID := message.MessageID
 	msg := &models.ChatMessage{
 		ChatID:            message.Chat.ID,
 		TelegramUserID:    message.From.ID,
@@ -103,6 +104,7 @@ func (s *ChatActivityService) TrackMessage(message *tgbotapi.Message) {
 		TelegramFirstName: message.From.FirstName,
 		MemberID:          memberID,
 		MessageText:       message.Text,
+		TelegramMessageID: &tgMessageID,
 		SentAt:            time.Unix(int64(message.Date), 0),
 	}
 
@@ -226,6 +228,13 @@ func (s *ChatActivityService) GetDailyActivityByUser(userID int64, days int) ([]
 // GetMessagesForExport возвращает данные для CSV экспорта
 func (s *ChatActivityService) GetMessagesForExport(chatID *int64, days int) ([]models.ExportRow, error) {
 	return s.repo.GetMessagesForExport(chatID, days)
+}
+
+// LookupUserIDByUsername ищет telegram_user_id по @username среди сообщений
+// в этом чате. Используется командами модерации, когда есть только @username
+// (например, /unban @user). 0 — не найден.
+func (s *ChatActivityService) LookupUserIDByUsername(chatID int64, username string) (int64, error) {
+	return s.repo.LookupUserIDByUsername(chatID, username)
 }
 
 // CleanupOldMessages удаляет сообщения старше retentionDays дней

--- a/backend/internal/service/moderation.go
+++ b/backend/internal/service/moderation.go
@@ -1,0 +1,234 @@
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"ithozyeva/internal/models"
+	"ithozyeva/internal/repository"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ModerationService struct {
+	repo *repository.ModerationRepository
+}
+
+func NewModerationService() *ModerationService {
+	return &ModerationService{repo: repository.NewModerationRepository()}
+}
+
+// ParseHumanDuration принимает "30m", "1h", "1d", "7d", "12h30m" и пр.
+// Поддерживает суффиксы s/m/h/d (день = 24h). Пустая строка → (0, nil).
+func ParseHumanDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0, nil
+	}
+
+	// Расширяем "d" в "24h" и доверяем стандартному парсеру для остального.
+	// Пример: "1d12h" → "36h0m".
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		j := i
+		for j < len(s) && (s[j] == '.' || (s[j] >= '0' && s[j] <= '9')) {
+			j++
+		}
+		if j == i || j >= len(s) {
+			return 0, fmt.Errorf("неверный формат длительности: %q", s)
+		}
+		num := s[i:j]
+		unit := s[j]
+		i = j + 1
+		switch unit {
+		case 'd':
+			n, err := strconv.ParseFloat(num, 64)
+			if err != nil {
+				return 0, fmt.Errorf("неверное число: %q", num)
+			}
+			sb.WriteString(strconv.FormatFloat(n*24, 'f', -1, 64))
+			sb.WriteByte('h')
+		case 's', 'm', 'h':
+			sb.WriteString(num)
+			sb.WriteByte(unit)
+		default:
+			return 0, fmt.Errorf("неизвестная единица %q", string(unit))
+		}
+	}
+
+	return time.ParseDuration(sb.String())
+}
+
+// FormatDurationHuman — короткая русская форма ("1ч", "30м", "2д").
+func FormatDurationHuman(d time.Duration) string {
+	if d <= 0 {
+		return "навсегда"
+	}
+	if d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dд", int(d/(24*time.Hour)))
+	}
+	if d%time.Hour == 0 {
+		return fmt.Sprintf("%dч", int(d/time.Hour))
+	}
+	if d%time.Minute == 0 {
+		return fmt.Sprintf("%dм", int(d/time.Minute))
+	}
+	return d.String()
+}
+
+// LogAction сохраняет запись в журнал модерации.
+func (s *ModerationService) LogAction(action *models.ModerationAction) error {
+	return s.repo.LogAction(action)
+}
+
+// LogActionWithMeta — то же, но с произвольной meta-payload.
+func (s *ModerationService) LogActionWithMeta(action *models.ModerationAction, meta map[string]interface{}) error {
+	if meta != nil {
+		raw, err := json.Marshal(meta)
+		if err == nil {
+			action.Meta = string(raw)
+		}
+	}
+	return s.repo.LogAction(action)
+}
+
+// MessagesForCleanup — id телеграм-сообщений юзера в чате за период.
+func (s *ModerationService) MessagesForCleanup(chatID, userID int64, since time.Time) ([]int, error) {
+	return s.repo.MessagesForCleanup(chatID, userID, since)
+}
+
+// DeleteCleanedMessages удаляет записи из chat_messages после успешного удаления в Telegram.
+func (s *ModerationService) DeleteCleanedMessages(chatID int64, messageIDs []int) (int64, error) {
+	return s.repo.DeleteCleanedMessages(chatID, messageIDs)
+}
+
+// VotebanStartParams описывает входные данные старта голосования.
+type VotebanStartParams struct {
+	ChatID           int64
+	ChatTitle        string
+	TargetUserID     int64
+	TargetUsername   string
+	TargetFirstName  string
+	InitiatorUserID  int64
+	TriggerMessageID *int
+	PollMessageID    int
+	RequiredVotes    int
+	MuteSeconds      int
+	WindowSeconds    int
+}
+
+// StartVoteban создаёт запись об открытом голосовании. Возвращает
+// ErrVotebanAlreadyOpen, если на (chat, target) уже есть открытое.
+func (s *ModerationService) StartVoteban(p VotebanStartParams) (*models.Voteban, error) {
+	existing, err := s.repo.FindOpenVoteban(p.ChatID, p.TargetUserID)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, ErrVotebanAlreadyOpen
+	}
+	v := &models.Voteban{
+		ChatID:           p.ChatID,
+		ChatTitle:        p.ChatTitle,
+		TargetUserID:     p.TargetUserID,
+		TargetUsername:   p.TargetUsername,
+		TargetFirstName:  p.TargetFirstName,
+		InitiatorUserID:  p.InitiatorUserID,
+		TriggerMessageID: p.TriggerMessageID,
+		PollMessageID:    p.PollMessageID,
+		RequiredVotes:    p.RequiredVotes,
+		MuteSeconds:      p.MuteSeconds,
+		ExpiresAt:        time.Now().Add(time.Duration(p.WindowSeconds) * time.Second),
+		Status:           models.VotebanStatusOpen,
+	}
+	if err := s.repo.CreateVoteban(v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// GetVoteban возвращает запись по id.
+func (s *ModerationService) GetVoteban(id int64) (*models.Voteban, error) {
+	return s.repo.GetVoteban(id)
+}
+
+// CastVoteResult — результат голосования.
+type CastVoteResult struct {
+	Tally    models.VotebanTally
+	Voteban  *models.Voteban
+	Threshold bool // достигнут ли порог "за"
+	Changed   bool // изменился ли голос (false — повторный тот же)
+}
+
+// CastVote ставит/обновляет голос. Если порог достигнут, возвращает Threshold=true
+// (финализация — на стороне вызывающего, чтобы он мог сделать Telegram-действие).
+func (s *ModerationService) CastVote(votebanID, voterID int64, vote int16) (*CastVoteResult, error) {
+	if vote != models.VotebanVoteFor && vote != models.VotebanVoteAgainst {
+		return nil, fmt.Errorf("неверное значение голоса")
+	}
+	v, err := s.repo.GetVoteban(votebanID)
+	if err != nil {
+		return nil, err
+	}
+	if v.Status != models.VotebanStatusOpen {
+		return &CastVoteResult{Voteban: v}, ErrVotebanClosed
+	}
+	if voterID == v.TargetUserID {
+		return &CastVoteResult{Voteban: v}, ErrVoteSelfTarget
+	}
+
+	prev, err := s.repo.GetVote(votebanID, voterID)
+	if err != nil {
+		return nil, err
+	}
+	changed := prev == nil || *prev != vote
+
+	if err := s.repo.UpsertVote(votebanID, voterID, vote); err != nil {
+		return nil, err
+	}
+	tally, err := s.repo.CountVotes(votebanID)
+	if err != nil {
+		return nil, err
+	}
+	return &CastVoteResult{
+		Tally:     tally,
+		Voteban:   v,
+		Threshold: tally.For >= v.RequiredVotes,
+		Changed:   changed,
+	}, nil
+}
+
+// FinalizeVoteban переводит запись в финальный статус. Идемпотентно:
+// повторный вызов после успешной финализации ничего не делает (запись
+// уже не "open"). Возвращает true, если перевод произошёл.
+func (s *ModerationService) FinalizeVoteban(id int64, status string) (bool, error) {
+	v, err := s.repo.GetVoteban(id)
+	if err != nil {
+		return false, err
+	}
+	if v.Status != models.VotebanStatusOpen {
+		return false, nil
+	}
+	if err := s.repo.FinalizeVoteban(id, status); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ListExpiredOpenVotebans возвращает голосования, у которых истекло окно.
+func (s *ModerationService) ListExpiredOpenVotebans(now time.Time) ([]models.Voteban, error) {
+	return s.repo.ListExpiredOpenVotebans(now)
+}
+
+// CountVotes — текущая раскладка голосов.
+func (s *ModerationService) CountVotes(votebanID int64) (models.VotebanTally, error) {
+	return s.repo.CountVotes(votebanID)
+}
+
+var (
+	ErrVotebanAlreadyOpen = errors.New("voteban: на этого пользователя уже идёт голосование")
+	ErrVotebanClosed      = errors.New("voteban: голосование закрыто")
+	ErrVoteSelfTarget     = errors.New("voteban: цель голосования не может голосовать")
+)

--- a/backend/internal/service/moderation_test.go
+++ b/backend/internal/service/moderation_test.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseHumanDuration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		bad  bool
+	}{
+		{"", 0, false},
+		{"30s", 30 * time.Second, false},
+		{"30m", 30 * time.Minute, false},
+		{"1h", time.Hour, false},
+		{"2h", 2 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"1d12h", 36 * time.Hour, false},
+		{"2h30m", 2*time.Hour + 30*time.Minute, false},
+		{" 1H ", time.Hour, false},
+		{"30", 0, true},
+		{"abc", 0, true},
+		{"10x", 0, true},
+		{"d", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseHumanDuration(c.in)
+		if c.bad {
+			if err == nil {
+				t.Errorf("ParseHumanDuration(%q): want error, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseHumanDuration(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseHumanDuration(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatDurationHuman(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "навсегда"},
+		{-time.Second, "навсегда"},
+		{30 * time.Minute, "30м"},
+		{time.Hour, "1ч"},
+		{2 * time.Hour, "2ч"},
+		{24 * time.Hour, "1д"},
+		{7 * 24 * time.Hour, "7д"},
+	}
+	for _, c := range cases {
+		if got := FormatDurationHuman(c.in); got != c.want {
+			t.Errorf("FormatDurationHuman(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Что добавляем

Полный набор инструментов модерации в бот для групповых чатов.

### Команды в групповых чатах

**Админам** (super-admin / роль `ADMIN` в БД / реальные админы Telegram-чата):
- \`/ban [duration]\` — бан в этом чате (reply на сообщение). Без аргумента — навсегда. Примеры: \`/ban 1h\`, \`/ban 1d\`, \`/ban 7d\`.
- \`/unban\` — разбан в этом чате (reply, или \`/unban @user\`, или \`/unban <id>\`).
- \`/mute [duration]\` — restrict без права писать/слать медиа (reply).
- \`/cleanup [period]\` — удалить все сообщения юзера в этом чате за период (reply, период по умолчанию \`24h\`, максимум \`7d\`).

**Любым участникам чата:**
- \`/voteban\` (reply) — запускает голосование. 5 голосов «✅ За» в течение 30 минут → мут на 1 час + удаление триггер-сообщения. Цель не голосует. Голос инициатора засчитывается автоматически. На админов и ботов запустить нельзя.

### Под капотом

- Миграция \`20260426160000_create_moderation_tables.sql\`:
  - \`chat_messages.telegram_message_id\` (nullable) — без этого id Telegram API не позволяет удалять сообщения, поэтому /cleanup работает только на сообщения, **отправленные после деплоя миграции**. В выводе команды это явно указано.
  - \`bot_moderation_actions\` — аудит всех действий (ban/unban/mute/cleanup/voteban_mute) с reason/duration/expires/meta JSONB.
  - \`bot_votebans\` + \`bot_voteban_votes\` — голосования с уникальным открытым на (chat_id, target).
- \`service.ParseHumanDuration\` поддерживает \`s/m/h/d\` (сутки = 24h), есть unit-тесты.
- Watcher (тик в минуту) финализирует протёкшие голосования: \`passed\` если набралось «за», иначе \`failed\`.
- Все служебные сообщения подсказок auto-delete через 15 сек, чтобы не засорять чат.
- Voteban-голосования живут в БД, переживают рестарт бота.

### Затронутые файлы
- backend/database/migrations/20260426160000_create_moderation_tables.sql (new)
- backend/internal/models/moderation.go (new), models/chat_message.go (+telegram_message_id)
- backend/internal/repository/moderation.go (new), repository/chat_activity.go (+LookupUserIDByUsername)
- backend/internal/service/moderation.go (new) + tests, service/chat_activity.go (TrackMessage сохраняет message_id, +LookupUserIDByUsername)
- backend/internal/bot/moderation.go (new), bot/telegram_bot.go (роутинг команд, callback voteban, watcher, /help)

## План тестирования
- [ ] После деплоя проверить применение миграции (\`telegram_message_id\` появилась в \`chat_messages\`, новые таблицы созданы).
- [ ] В тестовом чате: \`/ban\` (reply, навсегда), \`/unban\` — пользователь возвращается.
- [ ] \`/ban 1h\` (reply) — забанен с истечением через час.
- [ ] \`/mute 30m\` (reply) — теряет право писать на 30 минут.
- [ ] \`/cleanup 24h\` (reply) — удаляются только новые (после миграции) сообщения юзера.
- [ ] \`/voteban\` — стартует голосование, инициатор автоматически голосует «за», 4 других участника жмут «за» → автомут + удаление триггера + редактирование сообщения с итогом.
- [ ] \`/voteban\` второй раз на того же юзера — отвечает «уже идёт».
- [ ] \`/voteban\` без 5 голосов за 30 минут → автозакрытие watcher'ом со статусом «голосов недостаточно».
- [ ] Проверить, что \`/ban\`, \`/cleanup\` и т.п. от не-админа игнорируются молча.