### PR TITLE
feat(bot): /globalban /globalunban /globalbans (super-admin)

### DIFF
--- a/backend/database/migrations/20260426170000_create_bot_global_bans.sql
+++ b/backend/database/migrations/20260426170000_create_bot_global_bans.sql
@@ -1,0 +1,13 @@
+-- Глобальные баны: блокировка пользователя во всех чатах сразу + отказ
+-- в выдаче доступа по подписке. Снимается через /globalunban.
+CREATE TABLE IF NOT EXISTS bot_global_bans (
+    user_id BIGINT PRIMARY KEY,
+    banned_by BIGINT NOT NULL,
+    reason TEXT,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bot_global_bans_expires
+    ON bot_global_bans (expires_at);

--- a/backend/internal/bot/moderation.go
+++ b/backend/internal/bot/moderation.go
@@ -721,6 +721,283 @@ func (b *TelegramBot) finalizeVotebanFailed(vb *models.Voteban) {
 	}
 }
 
+// --- /globalban /globalunban /globalbans ---
+
+// handleGlobalBanCommand: super-admin блокирует юзера во всех известных боту
+// чатах разом. Формат:
+//
+//	/globalban (reply) [duration] [reason...]
+//	/globalban @user [duration] [reason...]
+//	/globalban <user_id> [duration] [reason...]
+//
+// reason — всё, что после duration (если есть). Без duration → permanent.
+func (b *TelegramBot) handleGlobalBanCommand(message *tgbotapi.Message) {
+	if !b.isSubscriptionAdmin(message.From.ID) {
+		return
+	}
+
+	var (
+		targetID    int64
+		display     string
+		argsAfter   []string
+	)
+
+	args := commandArgs(message)
+	if message.ReplyToMessage != nil && message.ReplyToMessage.From != nil {
+		targetID = message.ReplyToMessage.From.ID
+		display = targetDisplay(message.ReplyToMessage.From)
+		argsAfter = args
+	} else {
+		if len(args) == 0 {
+			b.replyAndAutoDelete(message,
+				"Использование: /globalban в reply | /globalban @user [duration] [reason] | /globalban &lt;id&gt; [duration] [reason]")
+			return
+		}
+		// Без привязки к чату ищем глобально (NULL chatID).
+		id, d, ok := b.resolveTargetGlobally(args[0])
+		if !ok {
+			b.replyAndAutoDelete(message,
+				"Не нашёл пользователя. Передай user_id или @username, который писал хотя бы в одном из наших чатов.")
+			return
+		}
+		targetID = id
+		display = html.EscapeString(d)
+		argsAfter = args[1:]
+	}
+
+	if targetID == b.bot.Self.ID {
+		b.replyAndAutoDelete(message, "Нельзя забанить бота.")
+		return
+	}
+	if b.isSubscriptionAdmin(targetID) || b.isAdmin(targetID) {
+		b.replyAndAutoDelete(message, "Нельзя глобально забанить администратора.")
+		return
+	}
+
+	var duration time.Duration
+	if len(argsAfter) > 0 {
+		if d, err := service.ParseHumanDuration(argsAfter[0]); err == nil && d > 0 {
+			duration = d
+			argsAfter = argsAfter[1:]
+		}
+	}
+	var reasonPtr *string
+	if len(argsAfter) > 0 {
+		r := strings.TrimSpace(strings.Join(argsAfter, " "))
+		if r != "" {
+			reasonPtr = &r
+		}
+	}
+
+	chats, err := b.moderationService.KnownChatIDs()
+	if err != nil {
+		log.Printf("globalban: KnownChatIDs failed: %v", err)
+		b.replyAndAutoDelete(message, "Не смог получить список чатов.")
+		return
+	}
+
+	if _, err := b.moderationService.UpsertGlobalBan(targetID, message.From.ID, reasonPtr, duration); err != nil {
+		log.Printf("globalban: upsert failed for user %d: %v", targetID, err)
+		b.replyAndAutoDelete(message, "Не смог сохранить запись о бане.")
+		return
+	}
+
+	// Команду в чате убираем сразу — отчёт прилетит в DM админу.
+	b.tryDelete(message.Chat.ID, message.MessageID)
+
+	go b.runGlobalBan(targetID, message.From.ID, display, duration, reasonPtr, chats)
+}
+
+func (b *TelegramBot) runGlobalBan(targetID, actorID int64, display string, duration time.Duration, reason *string, chats []int64) {
+	until := int64(0)
+	var expiresAt *time.Time
+	if duration > 0 {
+		t := time.Now().Add(duration)
+		until = t.Unix()
+		expiresAt = &t
+	}
+
+	banned, failed := 0, 0
+	for _, chatID := range chats {
+		_, err := b.bot.Request(tgbotapi.BanChatMemberConfig{
+			ChatMemberConfig: tgbotapi.ChatMemberConfig{
+				ChatID: chatID,
+				UserID: targetID,
+			},
+			UntilDate: until,
+		})
+		if err != nil {
+			failed++
+			log.Printf("globalban: ban in chat %d for user %d failed: %v", chatID, targetID, err)
+			continue
+		}
+		banned++
+		// Telegram лимиты по «административным» вызовам мягче, чем по send,
+		// но для 50+ чатов всё равно ставим небольшую паузу.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	durSec := int(duration.Seconds())
+	durPtr := &durSec
+	if duration == 0 {
+		durPtr = nil
+	}
+	meta := map[string]interface{}{
+		"chats_total":  len(chats),
+		"chats_banned": banned,
+		"chats_failed": failed,
+	}
+	if reason != nil {
+		meta["reason"] = *reason
+	}
+	_ = b.moderationService.LogActionWithMeta(&models.ModerationAction{
+		ChatID:          0,
+		TargetUserID:    targetID,
+		ActorUserID:     actorID,
+		Action:          models.ModerationActionGlobalBan,
+		DurationSeconds: durPtr,
+		ExpiresAt:       expiresAt,
+		Reason:          reason,
+	}, meta)
+
+	durStr := service.FormatDurationHuman(duration)
+	reasonStr := ""
+	if reason != nil {
+		reasonStr = "\nПричина: " + html.EscapeString(*reason)
+	}
+	b.SendDirectMessage(actorID, fmt.Sprintf(
+		"⛔ Глобальный бан применён.\nЦель: %s\nЧатов: %d (успех %d, ошибок %d)\nСрок: %s%s",
+		display, len(chats), banned, failed, durStr, reasonStr))
+}
+
+// handleGlobalUnbanCommand снимает запись и пытается разбанить во всех чатах.
+func (b *TelegramBot) handleGlobalUnbanCommand(message *tgbotapi.Message) {
+	if !b.isSubscriptionAdmin(message.From.ID) {
+		return
+	}
+
+	var (
+		targetID int64
+		display  string
+	)
+	if message.ReplyToMessage != nil && message.ReplyToMessage.From != nil {
+		targetID = message.ReplyToMessage.From.ID
+		display = targetDisplay(message.ReplyToMessage.From)
+	} else {
+		args := commandArgs(message)
+		if len(args) == 0 {
+			b.replyAndAutoDelete(message, "Использование: /globalunban в reply | /globalunban @user | /globalunban <id>")
+			return
+		}
+		id, d, ok := b.resolveTargetGlobally(args[0])
+		if !ok {
+			b.replyAndAutoDelete(message, "Не нашёл пользователя.")
+			return
+		}
+		targetID = id
+		display = html.EscapeString(d)
+	}
+
+	chats, err := b.moderationService.KnownChatIDs()
+	if err != nil {
+		log.Printf("globalunban: KnownChatIDs failed: %v", err)
+		b.replyAndAutoDelete(message, "Не смог получить список чатов.")
+		return
+	}
+	if err := b.moderationService.DeleteGlobalBan(targetID); err != nil {
+		log.Printf("globalunban: delete record failed for user %d: %v", targetID, err)
+	}
+	b.tryDelete(message.Chat.ID, message.MessageID)
+
+	go b.runGlobalUnban(targetID, message.From.ID, display, chats)
+}
+
+func (b *TelegramBot) runGlobalUnban(targetID, actorID int64, display string, chats []int64) {
+	unbanned, failed := 0, 0
+	for _, chatID := range chats {
+		_, err := b.bot.Request(tgbotapi.UnbanChatMemberConfig{
+			ChatMemberConfig: tgbotapi.ChatMemberConfig{
+				ChatID: chatID,
+				UserID: targetID,
+			},
+			OnlyIfBanned: true,
+		})
+		if err != nil {
+			failed++
+			log.Printf("globalunban: unban in chat %d for user %d failed: %v", chatID, targetID, err)
+			continue
+		}
+		unbanned++
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	_ = b.moderationService.LogActionWithMeta(&models.ModerationAction{
+		ChatID:       0,
+		TargetUserID: targetID,
+		ActorUserID:  actorID,
+		Action:       models.ModerationActionGlobalUnban,
+	}, map[string]interface{}{
+		"chats_total":    len(chats),
+		"chats_unbanned": unbanned,
+		"chats_failed":   failed,
+	})
+
+	b.SendDirectMessage(actorID, fmt.Sprintf(
+		"✅ Глобальный бан снят.\nЦель: %s\nЧатов: %d (успех %d, ошибок %d)",
+		display, len(chats), unbanned, failed))
+}
+
+// handleGlobalBansListCommand — короткая сводка по активным записям.
+func (b *TelegramBot) handleGlobalBansListCommand(message *tgbotapi.Message) {
+	if !b.isSubscriptionAdmin(message.From.ID) {
+		return
+	}
+	bans, err := b.moderationService.ListActiveGlobalBans()
+	if err != nil {
+		log.Printf("globalbans: list failed: %v", err)
+		return
+	}
+	if len(bans) == 0 {
+		b.SendDirectMessage(message.Chat.ID, "Активных глобальных банов нет.")
+		return
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("<b>Глобальные баны (%d):</b>\n\n", len(bans)))
+	for _, gb := range bans {
+		expires := "permanent"
+		if gb.ExpiresAt != nil {
+			expires = "до " + gb.ExpiresAt.Format("2006-01-02 15:04")
+		}
+		reason := ""
+		if gb.Reason != nil && *gb.Reason != "" {
+			reason = " · " + html.EscapeString(*gb.Reason)
+		}
+		sb.WriteString(fmt.Sprintf("• <code>%d</code> — %s%s\n", gb.UserID, expires, reason))
+	}
+	b.SendDirectMessage(message.Chat.ID, sb.String())
+}
+
+// resolveTargetGlobally ищет user_id по числу или @username (в любом
+// chat_messages — без привязки к конкретному чату). Возвращает displayName.
+func (b *TelegramBot) resolveTargetGlobally(arg string) (int64, string, bool) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return 0, "", false
+	}
+	if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
+		return id, fmt.Sprintf("id=%d", id), true
+	}
+	username := strings.TrimPrefix(arg, "@")
+	if username == "" {
+		return 0, "", false
+	}
+	id, err := b.chatActivityService.LookupUserIDByUsernameAny(username)
+	if err != nil || id == 0 {
+		return 0, "", false
+	}
+	return id, "@" + username, true
+}
+
 // startVotebanWatcher финализирует протёкшие открытые голосования.
 func (b *TelegramBot) startVotebanWatcher() {
 	ticker := time.NewTicker(moderationWatcherTick)

--- a/backend/internal/bot/subscription.go
+++ b/backend/internal/bot/subscription.go
@@ -161,6 +161,22 @@ func (b *TelegramBot) kickUserFunc() func(int64, int64) {
 // handleSubCommand checks subscription and grants access.
 func (b *TelegramBot) handleSubCommand(message *tgbotapi.Message) {
 	user := message.From
+
+	// Глобально заблокированных не пускаем дальше — иначе /sub попытается
+	// раздать им invite-ссылки, а через минуту их снова кикнут наши же
+	// модерационные хуки. Лучше один внятный отказ.
+	if active, gb, _ := b.moderationService.IsGloballyBanned(user.ID); active && gb != nil {
+		text := "Доступ ограничен."
+		if gb.Reason != nil && *gb.Reason != "" {
+			text += "\nПричина: " + *gb.Reason
+		}
+		if gb.ExpiresAt != nil {
+			text += "\nДо: " + gb.ExpiresAt.Format("2006-01-02 15:04")
+		}
+		b.sendMessage(message.Chat.ID, text)
+		return
+	}
+
 	result, err := b.subscriptionService.OnboardUser(
 		user.ID, strPtr(user.UserName), user.FirstName+" "+user.LastName,
 		b.botCheckFunc(), b.createInviteLinkFunc(), b.kickUserFunc(),

--- a/backend/internal/bot/telegram_bot.go
+++ b/backend/internal/bot/telegram_bot.go
@@ -285,6 +285,15 @@ func (b *TelegramBot) Start() {
 			case "voteban":
 				b.handleVotebanCommand(update.Message)
 				continue
+			case "globalban":
+				b.handleGlobalBanCommand(update.Message)
+				continue
+			case "globalunban":
+				b.handleGlobalUnbanCommand(update.Message)
+				continue
+			case "globalbans":
+				b.handleGlobalBansListCommand(update.Message)
+				continue
 			}
 		}
 
@@ -438,6 +447,13 @@ func (b *TelegramBot) handleHelpCommand(message *tgbotapi.Message) {
 			"/subcheckall - Проверить всех\n" +
 			"/substats - Статистика\n" +
 			"/subpin <anchor_chat_id> - Запостить и закрепить приветствие в anchor-чате"
+	}
+
+	if b.isSubscriptionAdmin(message.From.ID) {
+		text += "\n\nGlobal-бан (только super-admin):\n" +
+			"/globalban (reply | @user | <id>) [duration] [reason] — забанить во всех чатах сразу\n" +
+			"/globalunban (reply | @user | <id>) — снять глобальный бан\n" +
+			"/globalbans — список активных глобальных банов"
 	}
 
 	b.sendMessage(message.Chat.ID, text)

--- a/backend/internal/models/moderation.go
+++ b/backend/internal/models/moderation.go
@@ -9,6 +9,8 @@ const (
 	ModerationActionUnmute      = "unmute"
 	ModerationActionCleanup     = "cleanup"
 	ModerationActionVotebanMute = "voteban_mute"
+	ModerationActionGlobalBan   = "globalban"
+	ModerationActionGlobalUnban = "globalunban"
 )
 
 // ModerationAction — журнал модерационных действий бота.
@@ -81,4 +83,27 @@ func (VotebanVote) TableName() string {
 type VotebanTally struct {
 	For     int `json:"for"`
 	Against int `json:"against"`
+}
+
+// GlobalBan — запись о глобальной блокировке пользователя. ExpiresAt=nil
+// означает permanent. Снимается через /globalunban.
+type GlobalBan struct {
+	UserID    int64      `json:"userId" gorm:"column:user_id;primaryKey"`
+	BannedBy  int64      `json:"bannedBy" gorm:"column:banned_by"`
+	Reason    *string    `json:"reason" gorm:"column:reason"`
+	ExpiresAt *time.Time `json:"expiresAt" gorm:"column:expires_at"`
+	CreatedAt time.Time  `json:"createdAt" gorm:"column:created_at"`
+	UpdatedAt time.Time  `json:"updatedAt" gorm:"column:updated_at"`
+}
+
+func (GlobalBan) TableName() string {
+	return "bot_global_bans"
+}
+
+// IsActive возвращает true, если бан ещё действует.
+func (g GlobalBan) IsActive(now time.Time) bool {
+	if g.ExpiresAt == nil {
+		return true
+	}
+	return g.ExpiresAt.After(now)
 }

--- a/backend/internal/repository/chat_activity.go
+++ b/backend/internal/repository/chat_activity.go
@@ -290,3 +290,15 @@ func (r *ChatActivityRepository) LookupUserIDByUsername(chatID int64, username s
 		Pluck("telegram_user_id", &userID).Error
 	return userID, err
 }
+
+// LookupUserIDByUsernameAny — то же, но без привязки к чату. Используется
+// глобальными командами модерации, когда чат отправителя — личка.
+func (r *ChatActivityRepository) LookupUserIDByUsernameAny(username string) (int64, error) {
+	var userID int64
+	err := database.DB.Model(&models.ChatMessage{}).
+		Where("LOWER(telegram_username) = LOWER(?)", username).
+		Order("sent_at DESC").
+		Limit(1).
+		Pluck("telegram_user_id", &userID).Error
+	return userID, err
+}

--- a/backend/internal/repository/moderation.go
+++ b/backend/internal/repository/moderation.go
@@ -156,3 +156,61 @@ func (r *ModerationRepository) ListExpiredOpenVotebans(now time.Time) ([]models.
 		Find(&list).Error
 	return list, err
 }
+
+// --- Global bans ---
+
+// UpsertGlobalBan создаёт/обновляет запись (по PK user_id).
+func (r *ModerationRepository) UpsertGlobalBan(b *models.GlobalBan) error {
+	now := time.Now()
+	b.UpdatedAt = now
+	if b.CreatedAt.IsZero() {
+		b.CreatedAt = now
+	}
+	return database.DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"banned_by", "reason", "expires_at", "updated_at",
+		}),
+	}).Create(b).Error
+}
+
+// GetGlobalBan возвращает запись или (nil, nil) если её нет.
+func (r *ModerationRepository) GetGlobalBan(userID int64) (*models.GlobalBan, error) {
+	var b models.GlobalBan
+	err := database.DB.Where("user_id = ?", userID).First(&b).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &b, nil
+}
+
+// DeleteGlobalBan удаляет запись (используется при /globalunban).
+func (r *ModerationRepository) DeleteGlobalBan(userID int64) error {
+	return database.DB.Where("user_id = ?", userID).Delete(&models.GlobalBan{}).Error
+}
+
+// ListActiveGlobalBans возвращает все активные баны (не истёкшие).
+func (r *ModerationRepository) ListActiveGlobalBans(now time.Time) ([]models.GlobalBan, error) {
+	var list []models.GlobalBan
+	err := database.DB.Where("expires_at IS NULL OR expires_at > ?", now).
+		Order("created_at DESC").
+		Find(&list).Error
+	return list, err
+}
+
+// KnownChatIDs возвращает уникальные chat_id из subscription_chats и активных
+// tracked_chats — тот набор, по которому проходим при глобальном бане/анбане.
+func (r *ModerationRepository) KnownChatIDs() ([]int64, error) {
+	var ids []int64
+	err := database.DB.Raw(`
+		SELECT DISTINCT chat_id FROM (
+			SELECT id AS chat_id FROM subscription_chats
+			UNION
+			SELECT chat_id FROM tracked_chats WHERE is_active = TRUE
+		) c
+	`).Pluck("chat_id", &ids).Error
+	return ids, err
+}

--- a/backend/internal/service/chat_activity.go
+++ b/backend/internal/service/chat_activity.go
@@ -237,6 +237,11 @@ func (s *ChatActivityService) LookupUserIDByUsername(chatID int64, username stri
 	return s.repo.LookupUserIDByUsername(chatID, username)
 }
 
+// LookupUserIDByUsernameAny — без привязки к чату; для глобальных команд.
+func (s *ChatActivityService) LookupUserIDByUsernameAny(username string) (int64, error) {
+	return s.repo.LookupUserIDByUsernameAny(username)
+}
+
 // CleanupOldMessages удаляет сообщения старше retentionDays дней
 func (s *ChatActivityService) CleanupOldMessages(retentionDays int) {
 	beforeDate := time.Now().AddDate(0, 0, -retentionDays)

--- a/backend/internal/service/moderation.go
+++ b/backend/internal/service/moderation.go
@@ -232,3 +232,52 @@ var (
 	ErrVotebanClosed      = errors.New("voteban: голосование закрыто")
 	ErrVoteSelfTarget     = errors.New("voteban: цель голосования не может голосовать")
 )
+
+// --- Global bans ---
+
+// UpsertGlobalBan создаёт/обновляет запись глобального бана.
+func (s *ModerationService) UpsertGlobalBan(userID, bannedBy int64, reason *string, duration time.Duration) (*models.GlobalBan, error) {
+	b := &models.GlobalBan{
+		UserID:   userID,
+		BannedBy: bannedBy,
+		Reason:   reason,
+	}
+	if duration > 0 {
+		t := time.Now().Add(duration)
+		b.ExpiresAt = &t
+	}
+	if err := s.repo.UpsertGlobalBan(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// GetGlobalBan возвращает запись или nil. Запись с истёкшим expires_at
+// возвращается, чтобы вызывающий мог сам решить (например, считать неактивной).
+func (s *ModerationService) GetGlobalBan(userID int64) (*models.GlobalBan, error) {
+	return s.repo.GetGlobalBan(userID)
+}
+
+// IsGloballyBanned — true, если запись существует и активна на now.
+func (s *ModerationService) IsGloballyBanned(userID int64) (bool, *models.GlobalBan, error) {
+	b, err := s.repo.GetGlobalBan(userID)
+	if err != nil || b == nil {
+		return false, nil, err
+	}
+	return b.IsActive(time.Now()), b, nil
+}
+
+// DeleteGlobalBan снимает глобальный бан.
+func (s *ModerationService) DeleteGlobalBan(userID int64) error {
+	return s.repo.DeleteGlobalBan(userID)
+}
+
+// ListActiveGlobalBans — список действующих банов для /globalbans.
+func (s *ModerationService) ListActiveGlobalBans() ([]models.GlobalBan, error) {
+	return s.repo.ListActiveGlobalBans(time.Now())
+}
+
+// KnownChatIDs возвращает все известные боту чаты (subscription + tracked).
+func (s *ModerationService) KnownChatIDs() ([]int64, error) {
+	return s.repo.KnownChatIDs()
+}


### PR DESCRIPTION
## Что добавляем

Глобальный бан: super-admin одной командой блокирует юзера во всех известных боту чатах.

### Команды (доступны только super-admin'у)
- \`/globalban (reply | @user | <id>) [duration] [reason]\`
  - reply на сообщение — банит автора
  - \`@user\` — ищем user_id по последнему сообщению этого username в любом нашем чате
  - \`<id>\` — прямой Telegram user id
  - \`duration\` (опц.) — \`30m\`, \`1h\`, \`1d\`, \`7d\`. Без неё — permanent
  - \`reason\` (опц.) — всё, что после duration; сохраняется в записи
- \`/globalunban (reply | @user | <id>)\` — снимает запись и проходит \`UnbanChatMember\` по всем чатам
- \`/globalbans\` — список активных глобальных банов (id, expires, reason)

### Затрагиваемые чаты
\`subscription_chats\` ∪ \`tracked_chats (is_active)\`. По каждому делаем \`BanChatMemberConfig\` с \`UntilDate\` — Telegram сам снимет бан, когда срок истечёт.

### Защита /sub
Если у юзера активный globalban, \`/sub\` отвечает «Доступ ограничен» с reason/срок и не запускает onboarding — иначе мы бы выдавали ему инвайт-ссылки, которые наш же модерационный код тут же отзывал.

### Под капотом
- Миграция \`20260426170000_create_bot_global_bans.sql\` — таблица \`bot_global_bans (user_id PK, banned_by, reason, expires_at, …)\`.
- Аудит каждого global-действия в \`bot_moderation_actions\` с meta \`{chats_total, chats_banned/unbanned, chats_failed, reason}\`.
- Защита: нельзя забанить super-admin'а, ADMIN'а в БД и самого бота.

## План тестирования
- [ ] Применилась миграция, таблица \`bot_global_bans\` существует.
- [ ] \`/globalban <id> 1h тест\` от super-admin → DM-сводка «успех N / ошибок M», запись в БД с expires_at.
- [ ] Тестовый аккаунт получает kick во всех чатах.
- [ ] \`/globalbans\` показывает текущий бан с reason и сроком.
- [ ] \`/sub\` от забаненного → «Доступ ограничен … До: …».
- [ ] \`/globalunban <id>\` → запись удалена, аккаунт может снова вступать (после истечения уже снятых banов это и так работает, но проверим явно).
- [ ] Не-super-admin вызывает любую \`/global*\` — игнор без ответа.

## Зависимости
Базируется на mерджнутой ветке #293 (миграции и сервис модерации).