### PR TITLE
feat(bot): voteban — адаптивный порог 15% активных + симметрия за/против

### DIFF
--- a/backend/internal/bot/moderation.go
+++ b/backend/internal/bot/moderation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -16,7 +17,15 @@ import (
 
 // Параметры голосования по умолчанию.
 const (
-	votebanRequiredVotes = 5
+	// Адаптивный порог: required = clamp(round(active_authors_7d * 0.15), MIN, MAX).
+	// Симметричный — те же N голосов нужно для kick'a и для отмены.
+	votebanRequiredVotesPercent = 0.15
+	votebanRequiredVotesMin     = 3
+	votebanRequiredVotesMax     = 10
+	// Минимум активных за 7 дней, чтобы /voteban имел смысл — иначе порог 3
+	// упирается в самих участников (инициатор + цель уже двое).
+	votebanMinActiveAuthors = 4
+
 	votebanWindowSeconds = 15 * 60 // 15 минут — окно сбора голосов
 	// votebanKickSeconds — длительность санкции (BanChatMember с UntilDate).
 	// В БД хранится в колонке voteban.mute_seconds (имя оставлено по
@@ -37,6 +46,18 @@ const (
 
 	moderationWatcherTick = time.Minute
 )
+
+// computeVotebanThreshold возвращает required = clamp(round(active*15%), 3, 10).
+func computeVotebanThreshold(activeAuthors int64) int {
+	threshold := int(math.Round(float64(activeAuthors) * votebanRequiredVotesPercent))
+	if threshold < votebanRequiredVotesMin {
+		return votebanRequiredVotesMin
+	}
+	if threshold > votebanRequiredVotesMax {
+		return votebanRequiredVotesMax
+	}
+	return threshold
+}
 
 // --- Permissions ---
 
@@ -512,12 +533,27 @@ func (b *TelegramBot) handleVotebanCommand(message *tgbotapi.Message) {
 		}
 	}
 
+	// Адаптивный порог: 15% от уникальных авторов в этом чате за 7 дней,
+	// clamp [3..10]. Защищает большие чаты от того, что 5 друзей кикнут
+	// кого угодно, а маленькие — от случайного veto'а единичной группой.
+	activeAuthors, err := b.chatActivityService.CountActiveAuthorsInChatSince(
+		message.Chat.ID, time.Now().Add(-voterMinActivityWindow))
+	if err != nil {
+		log.Printf("voteban: count active authors failed: %v", err)
+	}
+	if activeAuthors < votebanMinActiveAuthors {
+		b.replyAndAutoDelete(message,
+			"В чате слишком мало активных участников за последние 7 дней — voteban здесь не имеет смысла.")
+		return
+	}
+	requiredVotes := computeVotebanThreshold(activeAuthors)
+
 	triggerID := message.ReplyToMessage.MessageID
 	triggerPtr := &triggerID
 	chatTitle := message.Chat.Title
 
 	// Сначала отправляем poll-сообщение — нам нужен его MessageID для записи.
-	pollText := b.formatVotebanPoll(target, message.From, models.VotebanTally{}, votebanRequiredVotes, time.Duration(votebanWindowSeconds)*time.Second)
+	pollText := b.formatVotebanPoll(target, message.From, models.VotebanTally{}, requiredVotes, time.Duration(votebanWindowSeconds)*time.Second)
 	pollMsg := tgbotapi.NewMessage(message.Chat.ID, pollText)
 	pollMsg.ParseMode = "HTML"
 	pollMsg.DisableWebPagePreview = true
@@ -538,7 +574,7 @@ func (b *TelegramBot) handleVotebanCommand(message *tgbotapi.Message) {
 		InitiatorUserID:  message.From.ID,
 		TriggerMessageID: triggerPtr,
 		PollMessageID:    sent.MessageID,
-		RequiredVotes:    votebanRequiredVotes,
+		RequiredVotes:    requiredVotes,
 		MuteSeconds:      votebanKickSeconds, // длительность kick-санкции (БД-колонка из T1)
 		WindowSeconds:    votebanWindowSeconds,
 	})
@@ -563,8 +599,12 @@ func (b *TelegramBot) handleVotebanCommand(message *tgbotapi.Message) {
 	// Инициатор автоматически голосует «за» — один клик меньше.
 	if res, err := b.moderationService.CastVote(vb.Id, message.From.ID, models.VotebanVoteFor); err == nil {
 		b.refreshVotebanMessage(vb, res.Tally)
+		// Авто-голос инициатора может закрыть голосование сразу, если порог = 1
+		// (теоретически невозможно при MIN=3, но оставим симметрично).
 		if res.Threshold {
 			b.finalizeVotebanPassed(vb)
+		} else if res.ThresholdAgainst {
+			b.finalizeVotebanCancelledByVotes(vb)
 		}
 	}
 
@@ -576,13 +616,15 @@ func (b *TelegramBot) formatVotebanPoll(target, initiator *tgbotapi.User, tally 
 		"⚖️ <b>Голосование за кик</b>\n\n"+
 			"Кого: %s\n"+
 			"Кто запустил: %s\n"+
-			"Окно: %s · нужно «за»: %d · санкция: кик на %s\n\n"+
+			"Окно: %s · санкция: кик на %s\n"+
+			"Нужно %d «за» — кик; или %d «против» — отмена\n\n"+
 			"Голосуют участники чата (с активностью за последние 7 дней). Цель не голосует.",
 		targetDisplay(target),
 		targetDisplay(initiator),
 		service.FormatDurationHuman(window),
-		required,
 		service.FormatDurationHuman(time.Duration(votebanKickSeconds)*time.Second),
+		required,
+		required,
 	) + b.formatVotebanTally(tally, required)
 }
 
@@ -687,8 +729,11 @@ func (b *TelegramBot) handleVotebanCallback(callback *tgbotapi.CallbackQuery) {
 	}
 	b.refreshVotebanMessage(vb, res.Tally)
 
-	if res.Threshold {
+	switch {
+	case res.Threshold:
 		b.finalizeVotebanPassed(vb)
+	case res.ThresholdAgainst:
+		b.finalizeVotebanCancelledByVotes(vb)
 	}
 }
 
@@ -767,6 +812,30 @@ func (b *TelegramBot) finalizeVotebanFailed(vb *models.Voteban) {
 	edit.ParseMode = "HTML"
 	if _, err := b.bot.Send(edit); err != nil {
 		log.Printf("voteban: edit final failed: %v", err)
+	}
+}
+
+// finalizeVotebanCancelledByVotes — голосование отменено достижением порога
+// «против». Цель остаётся в чате, статус cancelled (тот же, что у админ-отмены
+// из UI — отличается только по контексту в логах через CountVotes/Against).
+func (b *TelegramBot) finalizeVotebanCancelledByVotes(vb *models.Voteban) {
+	ok, err := b.moderationService.FinalizeVoteban(vb.Id, models.VotebanStatusCancelled)
+	if err != nil {
+		log.Printf("voteban: finalize-cancelled failed: %v", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	tally, _ := b.moderationService.CountVotes(vb.Id)
+	target := &tgbotapi.User{ID: vb.TargetUserID, UserName: vb.TargetUsername, FirstName: vb.TargetFirstName}
+	text := fmt.Sprintf("⚖️ Голосование отменено по голосам «против» (✅ %d / ❌ %d). %s остаётся в чате.",
+		tally.For, tally.Against, targetDisplay(target))
+	edit := tgbotapi.NewEditMessageText(vb.ChatID, vb.PollMessageID, text)
+	edit.ParseMode = "HTML"
+	if _, err := b.bot.Send(edit); err != nil {
+		log.Printf("voteban: edit final cancelled failed: %v", err)
 	}
 }
 

--- a/backend/internal/bot/moderation_test.go
+++ b/backend/internal/bot/moderation_test.go
@@ -1,0 +1,25 @@
+package bot
+
+import "testing"
+
+func TestComputeVotebanThreshold(t *testing.T) {
+	cases := []struct {
+		active int64
+		want   int
+	}{
+		{0, votebanRequiredVotesMin},
+		{1, votebanRequiredVotesMin},
+		{10, votebanRequiredVotesMin},  // 1.5 → 2 → clamp 3
+		{20, votebanRequiredVotesMin},  // 3
+		{30, 5},                        // 4.5 → 5
+		{50, 8},                        // 7.5 → 8
+		{67, votebanRequiredVotesMax},  // 10.05 → 10
+		{100, votebanRequiredVotesMax}, // 15 → clamp 10
+		{500, votebanRequiredVotesMax}, // clamp 10
+	}
+	for _, c := range cases {
+		if got := computeVotebanThreshold(c.active); got != c.want {
+			t.Errorf("computeVotebanThreshold(%d) = %d, want %d", c.active, got, c.want)
+		}
+	}
+}

--- a/backend/internal/repository/chat_activity.go
+++ b/backend/internal/repository/chat_activity.go
@@ -289,6 +289,18 @@ func (r *ChatActivityRepository) CountUserMessagesInChatSince(chatID, userID int
 	return count, err
 }
 
+// CountActiveAuthorsInChatSince — сколько уникальных авторов написало в чате
+// с момента since. Используется voteban'ом для адаптивного порога: чем
+// активнее чат, тем больше голосов нужно набрать.
+func (r *ChatActivityRepository) CountActiveAuthorsInChatSince(chatID int64, since time.Time) (int64, error) {
+	var count int64
+	err := database.DB.Model(&models.ChatMessage{}).
+		Where("chat_id = ? AND sent_at >= ?", chatID, since).
+		Distinct("telegram_user_id").
+		Count(&count).Error
+	return count, err
+}
+
 // LookupUserIDByUsername ищет telegram_user_id по последнему совпадению
 // telegram_username в указанном чате. Регистронезависимо. 0 = не найдено.
 func (r *ChatActivityRepository) LookupUserIDByUsername(chatID int64, username string) (int64, error) {

--- a/backend/internal/service/chat_activity.go
+++ b/backend/internal/service/chat_activity.go
@@ -235,6 +235,12 @@ func (s *ChatActivityService) CountUserMessagesInChatSince(chatID, userID int64,
 	return s.repo.CountUserMessagesInChatSince(chatID, userID, since)
 }
 
+// CountActiveAuthorsInChatSince — сколько уникальных авторов в чате за период.
+// Voteban использует это для адаптивного порога голосов.
+func (s *ChatActivityService) CountActiveAuthorsInChatSince(chatID int64, since time.Time) (int64, error) {
+	return s.repo.CountActiveAuthorsInChatSince(chatID, since)
+}
+
 // LookupUserIDByUsername ищет telegram_user_id по @username среди сообщений
 // в этом чате. Используется командами модерации, когда есть только @username
 // (например, /unban @user). 0 — не найден.

--- a/backend/internal/service/moderation.go
+++ b/backend/internal/service/moderation.go
@@ -226,10 +226,11 @@ func (s *ModerationService) GetVoteban(id int64) (*models.Voteban, error) {
 
 // CastVoteResult — результат голосования.
 type CastVoteResult struct {
-	Tally    models.VotebanTally
-	Voteban  *models.Voteban
-	Threshold bool // достигнут ли порог "за"
-	Changed   bool // изменился ли голос (false — повторный тот же)
+	Tally            models.VotebanTally
+	Voteban          *models.Voteban
+	Threshold        bool // достигнут ли порог "за" — пора финализировать как passed
+	ThresholdAgainst bool // достигнут ли порог "против" — пора финализировать как cancelled
+	Changed          bool // изменился ли голос (false — повторный тот же)
 }
 
 // CastVote ставит/обновляет голос. Если порог достигнут, возвращает Threshold=true
@@ -263,10 +264,11 @@ func (s *ModerationService) CastVote(votebanID, voterID int64, vote int16) (*Cas
 		return nil, err
 	}
 	return &CastVoteResult{
-		Tally:     tally,
-		Voteban:   v,
-		Threshold: tally.For >= v.RequiredVotes,
-		Changed:   changed,
+		Tally:            tally,
+		Voteban:          v,
+		Threshold:        tally.For >= v.RequiredVotes,
+		ThresholdAgainst: tally.Against >= v.RequiredVotes,
+		Changed:          changed,
 	}, nil
 }
 


### PR DESCRIPTION
## Что меняется

**Адаптивный порог.** Раньше всегда нужно было 5 «за» — это плохо масштабируется: в крупных платных чатах 5 друзей могли кикнуть кого угодно, а в тихих 5 голосов недостижимо. Теперь:

\`\`\`
required = clamp(round(active_authors_7d * 0.15), 3, 10)
\`\`\`

где \`active_authors_7d\` — число уникальных авторов в этом чате за последние 7 дней (тот же window, что у voter-фильтра).

| активных | required |
|---|---|
| ≤20 | 3 |
| 30 | 5 |
| 50 | 8 |
| ≥67 | 10 (clamp) |

Зафиксирован в \`bot_votebans.required_votes\` при старте, не меняется в процессе.

**Симметрия за/против.** То же N нужно набрать «за» (→ kick на час) или «против» (→ голосование отменено, цель остаётся в чате). Кто первый дойдёт — побеждает. Через 15 мин окно закрывается как и раньше (\`failed\`, если ни один порог не достигнут).

**Edge case** — если активных в чате <4 за 7 дней, \`/voteban\` отказывает с понятным текстом. Иначе порог 3 был бы недостижим (инициатор + цель уже занимают 2).

## UX
Сообщение голосования теперь выглядит так:
\`\`\`
⚖️ Голосование за кик

Кого: @user
Кто запустил: @initiator
Окно: 15м · санкция: кик на 1ч
Нужно 5 «за» — кик; или 5 «против» — отмена

Голосуют участники чата (с активностью за последние 7 дней). Цель не голосует.

✅ За: 3/5   ❌ Против: 1
[✅ За (3)]  [❌ Против (1)]
\`\`\`

При финализации:
- 5 «за» → \`⚖️ Голосование завершено: @user кикнут из чата на 1ч (✅ 5 / ❌ 1).\`
- 5 «против» → \`⚖️ Голосование отменено по голосам «против» (✅ 3 / ❌ 5). @user остаётся в чате.\`
- 15 мин истекло → \`⚖️ Голосование закрыто: голосов недостаточно...\`

## Файлы
- backend/internal/bot/moderation.go — новые константы, computeVotebanThreshold, проверка \`votebanMinActiveAuthors\`, ветка \`finalizeVotebanCancelledByVotes\`, обновлённый текст poll'а
- backend/internal/bot/moderation_test.go (new) — unit-тест порога
- backend/internal/repository/chat_activity.go — \`CountActiveAuthorsInChatSince\`
- backend/internal/service/chat_activity.go — обёртка
- backend/internal/service/moderation.go — \`CastVoteResult.ThresholdAgainst\`

## Без миграций
Поле \`required_votes\` уже есть в \`bot_votebans\` (значение раньше всегда было 5). Существующие открытые голосования (если найдутся в момент деплоя) продолжат работать со своим зафиксированным required, симметрия применится для них тоже автоматически.

## План тестирования
- [ ] Тестовый чат с <4 активными за 7 дней: \`/voteban\` → отказ
- [ ] Чат с 20-30 активными: \`/voteban\` → текст «Нужно 3 за; или 3 против»
- [ ] Набрать 3 «за» → kick
- [ ] Набрать 3 «против» (после старта) → отмена с финальным сообщением
- [ ] В админке /moderation → активное голосование показывает корректный required (3/5/8/10)