### PR TITLE
feat(bot): voteban — pin/unpin poll, 8% порог, фикс display и форматирования окна

### DIFF
--- a/backend/internal/bot/moderation.go
+++ b/backend/internal/bot/moderation.go
@@ -17,11 +17,12 @@ import (
 
 // Параметры голосования по умолчанию.
 const (
-	// Адаптивный порог: required = clamp(round(active_authors_7d * 0.15), MIN, MAX).
+	// Адаптивный порог: required = clamp(round(active_authors_7d * 0.08), MIN, MAX).
 	// Симметричный — те же N голосов нужно для kick'a и для отмены.
-	votebanRequiredVotesPercent = 0.15
+	// В чате на 50 активных = 4, 80 → 6, 100+ → 8 (clamp).
+	votebanRequiredVotesPercent = 0.08
 	votebanRequiredVotesMin     = 3
-	votebanRequiredVotesMax     = 10
+	votebanRequiredVotesMax     = 8
 	// Минимум активных за 7 дней, чтобы /voteban имел смысл — иначе порог 3
 	// упирается в самих участников (инициатор + цель уже двое).
 	votebanMinActiveAuthors = 4
@@ -619,6 +620,17 @@ func (b *TelegramBot) handleVotebanCommand(message *tgbotapi.Message) {
 		log.Printf("voteban: edit markup failed: %v", err)
 	}
 
+	// Закрепляем сообщение голосования. DisableNotification=true — чтобы не
+	// спамить уведомлением каждому участнику. Если бот не админ или нет
+	// прав — просто логируем и продолжаем (голосование работает и без пина).
+	if _, err := b.bot.Request(tgbotapi.PinChatMessageConfig{
+		ChatID:              message.Chat.ID,
+		MessageID:           sent.MessageID,
+		DisableNotification: true,
+	}); err != nil {
+		log.Printf("voteban: pin failed chat=%d msg=%d: %v", message.Chat.ID, sent.MessageID, err)
+	}
+
 	// Инициатор автоматически голосует «за» — один клик меньше.
 	if res, err := b.moderationService.CastVote(vb.Id, message.From.ID, models.VotebanVoteFor); err == nil {
 		b.refreshVotebanMessage(vb, res.Tally)
@@ -634,6 +646,34 @@ func (b *TelegramBot) handleVotebanCommand(message *tgbotapi.Message) {
 	b.tryDelete(message.Chat.ID, message.MessageID)
 }
 
+// formatRemainingHuman — «осталось N мин M сек» / «N сек» / «N ч M мин» для
+// произвольной длительности (с округлением до секунды). Отличается от
+// service.FormatDurationHuman, который для «не круглых» значений падает
+// в d.String() (например «13m18.012604577s» в poll-сообщении).
+func formatRemainingHuman(d time.Duration) string {
+	if d <= 0 {
+		return "0с"
+	}
+	d = d.Round(time.Second)
+	h := int(d / time.Hour)
+	m := int((d % time.Hour) / time.Minute)
+	s := int((d % time.Minute) / time.Second)
+	switch {
+	case h > 0:
+		if m == 0 {
+			return fmt.Sprintf("%dч", h)
+		}
+		return fmt.Sprintf("%dч %dм", h, m)
+	case m > 0:
+		if s == 0 {
+			return fmt.Sprintf("%dм", m)
+		}
+		return fmt.Sprintf("%dм %dс", m, s)
+	default:
+		return fmt.Sprintf("%dс", s)
+	}
+}
+
 func (b *TelegramBot) formatVotebanPoll(target, initiator *tgbotapi.User, tally models.VotebanTally, required int, window time.Duration) string {
 	return fmt.Sprintf(
 		"⚖️ <b>Голосование за кик</b>\n\n"+
@@ -644,7 +684,7 @@ func (b *TelegramBot) formatVotebanPoll(target, initiator *tgbotapi.User, tally 
 			"Голосуют участники чата (с активностью за последние 7 дней). Цель не голосует.",
 		targetDisplay(target),
 		targetDisplay(initiator),
-		service.FormatDurationHuman(window),
+		formatRemainingHuman(window),
 		service.FormatDurationHuman(time.Duration(votebanKickSeconds)*time.Second),
 		required,
 		required,
@@ -664,6 +704,34 @@ func (b *TelegramBot) votebanKeyboard(votebanID int64, tally models.VotebanTally
 	)
 }
 
+// unpinVotebanPoll снимает закреп с poll-сообщения голосования. Само
+// сообщение оставляем — оно становится «логом результата» в ленте.
+func (b *TelegramBot) unpinVotebanPoll(vb *models.Voteban) {
+	if _, err := b.bot.Request(tgbotapi.UnpinChatMessageConfig{
+		ChatID:    vb.ChatID,
+		MessageID: vb.PollMessageID,
+	}); err != nil {
+		// «message to unpin not found» — нормально, если уже сняли.
+		if !strings.Contains(err.Error(), "not found") {
+			log.Printf("voteban: unpin chat=%d msg=%d: %v", vb.ChatID, vb.PollMessageID, err)
+		}
+	}
+}
+
+// fetchUserDisplay реконструирует *tgbotapi.User по chat_messages-истории,
+// чтобы targetDisplay() показывал @username/имя, а не «id=...». Имя инициатора
+// в bot_votebans отдельной колонкой не хранится, поэтому ищем по последнему
+// сообщению в этом чате; если ничего не нашли — оставляем только ID.
+func (b *TelegramBot) fetchUserDisplay(chatID, userID int64) *tgbotapi.User {
+	user := &tgbotapi.User{ID: userID}
+	username, firstName, err := b.chatActivityService.LookupDisplayByUserID(chatID, userID)
+	if err == nil {
+		user.UserName = username
+		user.FirstName = firstName
+	}
+	return user
+}
+
 // refreshVotebanMessage обновляет текст и кнопки poll-сообщения с актуальной раскладкой.
 func (b *TelegramBot) refreshVotebanMessage(vb *models.Voteban, tally models.VotebanTally) {
 	target := &tgbotapi.User{
@@ -671,7 +739,7 @@ func (b *TelegramBot) refreshVotebanMessage(vb *models.Voteban, tally models.Vot
 		UserName:  vb.TargetUsername,
 		FirstName: vb.TargetFirstName,
 	}
-	initiator := &tgbotapi.User{ID: vb.InitiatorUserID}
+	initiator := b.fetchUserDisplay(vb.ChatID, vb.InitiatorUserID)
 	window := time.Until(vb.ExpiresAt)
 	if window < 0 {
 		window = 0
@@ -775,6 +843,7 @@ func (b *TelegramBot) finalizeVotebanPassed(vb *models.Voteban) {
 	if !ok {
 		return
 	}
+	b.unpinVotebanPoll(vb)
 
 	until := time.Now().Add(time.Duration(vb.MuteSeconds) * time.Second)
 	if _, err := b.bot.Request(tgbotapi.BanChatMemberConfig{
@@ -826,6 +895,7 @@ func (b *TelegramBot) finalizeVotebanFailed(vb *models.Voteban) {
 	if !ok {
 		return
 	}
+	b.unpinVotebanPoll(vb)
 
 	tally, _ := b.moderationService.CountVotes(vb.Id)
 	target := &tgbotapi.User{ID: vb.TargetUserID, UserName: vb.TargetUsername, FirstName: vb.TargetFirstName}
@@ -850,6 +920,7 @@ func (b *TelegramBot) finalizeVotebanCancelledByVotes(vb *models.Voteban) {
 	if !ok {
 		return
 	}
+	b.unpinVotebanPoll(vb)
 
 	tally, _ := b.moderationService.CountVotes(vb.Id)
 	target := &tgbotapi.User{ID: vb.TargetUserID, UserName: vb.TargetUsername, FirstName: vb.TargetFirstName}
@@ -1318,6 +1389,7 @@ func (b *TelegramBot) revokeVoteban(ev service.ModerationRevokeEvent) {
 		log.Printf("revoke voteban: not found id=%d: %v", ev.VotebanID, err)
 		return
 	}
+	b.unpinVotebanPoll(vb)
 	target := &tgbotapi.User{ID: vb.TargetUserID, UserName: vb.TargetUsername, FirstName: vb.TargetFirstName}
 	text := fmt.Sprintf("⚖️ Голосование отменено админом. %s остаётся в чате.", targetDisplay(target))
 	edit := tgbotapi.NewEditMessageText(vb.ChatID, vb.PollMessageID, text)

--- a/backend/internal/bot/moderation_test.go
+++ b/backend/internal/bot/moderation_test.go
@@ -1,21 +1,45 @@
 package bot
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatRemainingHuman(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0с"},
+		{-time.Second, "0с"},
+		{30 * time.Second, "30с"},
+		{15 * time.Minute, "15м"},
+		{13*time.Minute + 18*time.Second + 12*time.Millisecond, "13м 18с"},
+		{time.Hour, "1ч"},
+		{time.Hour + 5*time.Minute, "1ч 5м"},
+	}
+	for _, c := range cases {
+		if got := formatRemainingHuman(c.in); got != c.want {
+			t.Errorf("formatRemainingHuman(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
 
 func TestComputeVotebanThreshold(t *testing.T) {
 	cases := []struct {
 		active int64
 		want   int
 	}{
-		{0, votebanRequiredVotesMin},
-		{1, votebanRequiredVotesMin},
-		{10, votebanRequiredVotesMin},  // 1.5 → 2 → clamp 3
-		{20, votebanRequiredVotesMin},  // 3
-		{30, 5},                        // 4.5 → 5
-		{50, 8},                        // 7.5 → 8
-		{67, votebanRequiredVotesMax},  // 10.05 → 10
-		{100, votebanRequiredVotesMax}, // 15 → clamp 10
-		{500, votebanRequiredVotesMax}, // clamp 10
+		{0, votebanRequiredVotesMin},   // clamp 3
+		{20, votebanRequiredVotesMin},  // 1.6 → 2 → clamp 3
+		{30, votebanRequiredVotesMin},  // 2.4 → 2 → clamp 3
+		{38, votebanRequiredVotesMin},  // 3.04 → 3
+		{50, 4},                        // 4.0
+		{63, 5},                        // 5.04
+		{80, 6},                        // 6.4 → 6
+		{94, 8},                        // 7.52 → 8
+		{100, votebanRequiredVotesMax}, // 8.0
+		{500, votebanRequiredVotesMax}, // clamp 8
 	}
 	for _, c := range cases {
 		if got := computeVotebanThreshold(c.active); got != c.want {

--- a/backend/internal/repository/chat_activity.go
+++ b/backend/internal/repository/chat_activity.go
@@ -301,6 +301,23 @@ func (r *ChatActivityRepository) CountActiveAuthorsInChatSince(chatID int64, sin
 	return count, err
 }
 
+// LookupDisplayByUserID — последний username/first_name юзера в этом чате.
+// Используется voteban'ом для восстановления display-имени по telegram_user_id
+// (не сохраняем в bot_votebans отдельной колонкой — берём из истории сообщений).
+func (r *ChatActivityRepository) LookupDisplayByUserID(chatID, userID int64) (username, firstName string, err error) {
+	var row struct {
+		TelegramUsername  string
+		TelegramFirstName string
+	}
+	err = database.DB.Model(&models.ChatMessage{}).
+		Select("telegram_username, telegram_first_name").
+		Where("chat_id = ? AND telegram_user_id = ?", chatID, userID).
+		Order("sent_at DESC").
+		Limit(1).
+		Scan(&row).Error
+	return row.TelegramUsername, row.TelegramFirstName, err
+}
+
 // LookupUserIDByUsername ищет telegram_user_id по последнему совпадению
 // telegram_username в указанном чате. Регистронезависимо. 0 = не найдено.
 func (r *ChatActivityRepository) LookupUserIDByUsername(chatID int64, username string) (int64, error) {

--- a/backend/internal/service/chat_activity.go
+++ b/backend/internal/service/chat_activity.go
@@ -241,6 +241,11 @@ func (s *ChatActivityService) CountActiveAuthorsInChatSince(chatID int64, since 
 	return s.repo.CountActiveAuthorsInChatSince(chatID, since)
 }
 
+// LookupDisplayByUserID — последние username/first_name юзера в этом чате.
+func (s *ChatActivityService) LookupDisplayByUserID(chatID, userID int64) (string, string, error) {
+	return s.repo.LookupDisplayByUserID(chatID, userID)
+}
+
 // LookupUserIDByUsername ищет telegram_user_id по @username среди сообщений
 // в этом чате. Используется командами модерации, когда есть только @username
 // (например, /unban @user). 0 — не найден.


### PR DESCRIPTION
## Что меняется (фидбэк из живого голосования в /b/-чате)

Скриншот показал три проблемы и одно пожелание:

### 1. Poll закрепляется при старте, открепляется при финализации
- Pin (\`PinChatMessage\` с \`DisableNotification=true\`) сразу после старта голосования — не теряется в флуде
- Unpin при любом завершении: passed / failed / cancelled-by-votes / admin-revoke
- Само сообщение остаётся в ленте как лог результата («кикнут / не набрали»)

### 2. «Кто запустил: id=931916742» → @username
Имя инициатора теперь подтягивается из \`chat_messages\` этого чата (helper \`fetchUserDisplay\`). Без миграции — данные уже есть в истории.

### 3. «Окно: 13m18.012604577s» → «13м 18с»
Новая функция \`formatRemainingHuman\` для произвольных длительностей:
- «1ч 5м» / «13м 18с» / «30с»
- \`service.FormatDurationHuman\` для нек-круглых значений падал в \`d.String()\` (Go-формат) — теперь только для «целых» длительностей санкции (1ч, 1д, …)

### 4. Порог 15% → 8%, MAX 10 → 8
В живом чате на 50 активных за 7 дней получалось 8 «за» — слишком много. Теперь:

| активных | было (15% / 10) | стало (8% / 8) |
|---|---|---|
| 30 | 5 | **3** (clamp) |
| 50 | 8 | **4** |
| 80 | 10 (clamp) | **6** |
| 100 | 10 | **8** (clamp) |

Симметрия за/против сохраняется.

## Файлы
- \`backend/internal/bot/moderation.go\` — pin/unpin/fetchUserDisplay/formatRemainingHuman, обновлённая формула
- \`backend/internal/bot/moderation_test.go\` — обновлены тесты порога, добавлен тест форматтера
- \`backend/internal/repository/chat_activity.go\` — \`LookupDisplayByUserID\`
- \`backend/internal/service/chat_activity.go\` — обёртка

## Без миграций. Существующее не ломается.

## План тестирования
- [ ] \`/voteban @user\` в чате на 50 активных → текст «Нужно 4 «за»»
- [ ] Сообщение закрепилось (значок 📌 в шапке чата, без push'а)
- [ ] «Кто запустил: @username» (или имя), а не «id=…»
- [ ] «Окно: 14м 30с» (без Go-стиля длительности)
- [ ] Голосование завершилось (любым из 4 способов) → закреп снят, сообщение осталось как итог